### PR TITLE
Issue #45: Document @key attribute requirement for update() more prominently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to TypeBridge will be documented in this file.
 
+## [0.9.3] - 2025-12-12
+
+### Documentation
+
+#### @key Attribute Requirement for update() (Issue #45)
+- **Added prominent documentation explaining that `update()` requires @key attributes**
+  - New section "Important: @key Attributes Required for update()" in CRUD docs
+  - Clear examples showing proper `@key` attribute definition
+  - Error scenarios documented: no `@key` defined, `@key` value is `None`
+  - Guidance for UUID/ID fields as `@key` attributes
+  - Cross-reference to Exception Handling section
+  - Location: `docs/api/crud.md` (lines 369-413)
+
+### Key Files Modified
+
+- `docs/api/crud.md` - Added @key requirement documentation in Update Operations section
+
 ## [0.9.2] - 2025-12-12
 
 ### New Features

--- a/docs/api/crud.md
+++ b/docs/api/crud.md
@@ -366,6 +366,52 @@ alice.status = Status("active")
 person_manager.update(alice)
 ```
 
+### Important: @key Attributes Required for update()
+
+The `update()` method uses `@key` attributes to identify which entity to update in the database. Your entity class must have at least one `@key` attribute defined:
+
+```python
+class Person(Entity):
+    flags = TypeFlags(name="person")
+    name: Name = Flag(Key)  # @key attribute - required for update()
+    age: Age | None = None
+
+# This works because Person has @key attribute "name"
+alice = person_manager.get(name="Alice")[0]
+alice.age = Age(31)
+person_manager.update(alice)  # Uses "name" to match entity in database
+```
+
+**Without a @key attribute**, `update()` will raise `KeyAttributeError`:
+
+```python
+class Counter(Entity):
+    flags = TypeFlags(name="counter")
+    value: Value  # No @key attribute!
+
+counter = counter_manager.get(value=42)[0]
+counter.value = Value(100)
+counter_manager.update(counter)  # Raises KeyAttributeError
+```
+
+**If a @key attribute value is None**, `update()` will also raise `KeyAttributeError`:
+
+```python
+alice = Person(name=None, age=Age(30))  # Invalid: @key is None
+person_manager.update(alice)  # Raises KeyAttributeError
+```
+
+If your entity uses a UUID or ID field, make sure it's marked as `@key`:
+
+```python
+class Document(Entity):
+    flags = TypeFlags(name="document")
+    id: Id = Flag(Key)  # Mark as @key for update() to work
+    title: Title
+```
+
+See [Exception Handling](#exception-handling-v072) for details on handling `KeyAttributeError`.
+
 ### Update Single-Value Attributes
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "type-bridge"
-version = "0.9.2"
+version = "0.9.3"
 description = "A modern, Pythonic ORM for TypeDB with an Attribute-based API"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/type_bridge/__init__.py
+++ b/type_bridge/__init__.py
@@ -33,7 +33,7 @@ from type_bridge.schema import MigrationManager, SchemaManager
 from type_bridge.session import Connection, Database, TransactionContext
 from type_bridge.typedb_driver import Credentials, TransactionType, TypeDB
 
-__version__ = "0.9.2"
+__version__ = "0.9.3"
 
 __all__ = [
     # Database and session

--- a/uv.lock
+++ b/uv.lock
@@ -324,7 +324,7 @@ wheels = [
 
 [[package]]
 name = "type-bridge"
-version = "0.9.2"
+version = "0.9.3"
 source = { editable = "." }
 dependencies = [
     { name = "isodate" },


### PR DESCRIPTION
## Summary

Added prominent documentation explaining that `update()` requires `@key` attributes to identify which entity to update in the database.

## Changes

### `docs/api/crud.md`

Added new section **"Important: @key Attributes Required for update()"** after the "Basic Update" section (lines 369-413) that includes:

1. **Clear explanation** - The `update()` method uses `@key` attributes to identify which entity to update
2. **Working example** - Shows `Person` entity with `name: Name = Flag(Key)` and how update works
3. **Error scenarios**:
   - When no `@key` attribute is defined → raises `KeyAttributeError`
   - When `@key` attribute value is `None` → raises `KeyAttributeError`
4. **UUID/ID guidance** - Shows how to mark an `id` field as `@key`
5. **Cross-reference** - Links to the existing Exception Handling section

## Before

The documentation showed the fetch-modify-update pattern but didn't explain:
- `update()` requires `@key` attributes
- What error is raised without `@key` attributes
- How to fix the issue

## After

Users now see a prominent note immediately after the "Basic Update" section that explains the `@key` requirement with clear examples and error scenarios.

Closes #45