### PR TITLE
feat: Populate role player IIDs and add --schema-path CLI option

### DIFF
--- a/packages/python/type_bridge/crud/relation/query.py
+++ b/packages/python/type_bridge/crud/relation/query.py
@@ -555,10 +555,10 @@ class RelationQuery[R: Relation]:
         return relations
 
     def _populate_iids(self, relations: list[R]) -> None:
-        """Populate _iid field on relations by querying TypeDB.
+        """Populate _iid field on relations and their role players by querying TypeDB.
 
         Since fetch queries cannot return IIDs, this method makes a second
-        query to get IIDs for each relation based on their role players.
+        query to get IIDs for each relation and its role players based on their key attributes.
 
         Args:
             relations: List of relations to populate IIDs for
@@ -568,11 +568,12 @@ class RelationQuery[R: Relation]:
 
         roles = self.model_class._roles
 
-        # For each relation, query its IID using role players
+        # For each relation, query its IID and role player IIDs
         for relation in relations:
             # Build match clause with role players
             role_parts = []
             match_statements = []
+            role_var_to_entity: dict[str, Any] = {}  # Map role var to entity for IID assignment
 
             for role_name, role in roles.items():
                 entity = getattr(relation, role_name, None)
@@ -585,6 +586,7 @@ class RelationQuery[R: Relation]:
 
                 role_var = f"${role_name}"
                 role_parts.append(f"{role.role_name}: {role_var}")
+                role_var_to_entity[role_name] = entity
 
                 # Match the role player by their key attributes
                 entity_class = entity.__class__
@@ -606,9 +608,11 @@ class RelationQuery[R: Relation]:
             roles_str = ", ".join(role_parts)
             relation_match = f"$r isa {self.model_class.get_type_name()} ({roles_str})"
 
-            # Build query to get relation with IID
+            # Build query to get relation and role player IIDs
             query_parts = [relation_match] + match_statements
-            query_str = f"match\n{'; '.join(query_parts)};\nselect $r;"
+            # Select relation and all role player variables
+            select_vars = ["$r"] + [f"${role_name}" for role_name in role_var_to_entity.keys()]
+            query_str = f"match\n{'; '.join(query_parts)};\nselect {', '.join(select_vars)};"
             logger.debug(f"IID lookup query: {query_str}")
 
             results = self._execute(query_str, TransactionType.READ)
@@ -616,19 +620,30 @@ class RelationQuery[R: Relation]:
             if not results:
                 continue
 
-            # Extract IID from result
+            # Extract IIDs from result
             result = results[0]
-            iid = None
 
-            # Try different result formats
+            # Extract relation IID
+            relation_iid = None
             if "r" in result and isinstance(result["r"], dict):
-                iid = result["r"].get("_iid")
+                relation_iid = result["r"].get("_iid")
             elif "_iid" in result:
-                iid = result["_iid"]
+                relation_iid = result["_iid"]
 
-            if iid:
-                object.__setattr__(relation, "_iid", iid)
-                logger.debug(f"Set IID {iid} for relation {self.model_class.__name__}")
+            if relation_iid:
+                object.__setattr__(relation, "_iid", relation_iid)
+                logger.debug(f"Set IID {relation_iid} for relation {self.model_class.__name__}")
+
+            # Extract role player IIDs
+            for role_name, entity in role_var_to_entity.items():
+                if role_name in result and isinstance(result[role_name], dict):
+                    player_iid = result[role_name].get("_iid")
+                    if player_iid:
+                        object.__setattr__(entity, "_iid", player_iid)
+                        logger.debug(
+                            f"Set IID {player_iid} for role player {role_name} "
+                            f"({entity.__class__.__name__})"
+                        )
 
     def first(self) -> R | None:
         """Get first matching relation.

--- a/packages/python/type_bridge/generator/__main__.py
+++ b/packages/python/type_bridge/generator/__main__.py
@@ -47,6 +47,16 @@ def main(
         bool,
         typer.Option("--no-copy-schema", help="Don't copy the schema file to the output directory"),
     ] = False,
+    schema_path: Annotated[
+        str | None,
+        typer.Option(
+            "--schema-path",
+            help=(
+                "Custom path for the schema file. Relative paths are resolved "
+                "against the output directory. Absolute paths write to that location."
+            ),
+        ),
+    ] = None,
     implicit_keys: Annotated[
         list[str] | None,
         typer.Option("--implicit-keys", help="Attribute names to treat as @key even if not marked"),
@@ -73,6 +83,7 @@ def main(
             implicit_key_attributes=implicit_keys or None,
             schema_version=version,
             copy_schema=not no_copy_schema,
+            schema_path=schema_path,
         )
     except Exception as e:
         logger.error(f"Generation failed: {e}", exc_info=True)

--- a/packages/python/type_bridge/generator/render/package.py
+++ b/packages/python/type_bridge/generator/render/package.py
@@ -12,6 +12,7 @@ def render_package_init(
     *,
     schema_version: str = "1.0.0",
     include_schema_loader: bool = True,
+    schema_filename: str | None = "schema.tql",
     functions_present: bool = False,
 ) -> str:
     """Render the package __init__.py source.
@@ -22,11 +23,16 @@ def render_package_init(
         relation_class_names: Mapping from TypeDB relation names to Python class names
         schema_version: Version string for SCHEMA_VERSION constant
         include_schema_loader: Whether to include schema_text() helper
+        schema_filename: Filename for the schema file (used in schema_text() loader)
         functions_present: Whether to export functions module
 
     Returns:
         Complete Python source code for __init__.py
     """
+    # Don't include loader if no filename provided
+    if schema_filename is None:
+        include_schema_loader = False
+
     module_imports = ["attributes", "entities", "registry", "relations"]
     if functions_present:
         module_imports.append("functions")
@@ -53,6 +59,7 @@ def render_package_init(
         module_imports=module_imports,
         schema_version=schema_version,
         include_schema_loader=include_schema_loader,
+        schema_filename=schema_filename or "schema.tql",
         attributes=sorted(attr_class_names[name] for name in attr_class_names),
         entities=sorted(entity_class_names[name] for name in entity_class_names),
         relations=sorted(relation_class_names[name] for name in relation_class_names),

--- a/packages/python/type_bridge/generator/templates/package_init.py.jinja
+++ b/packages/python/type_bridge/generator/templates/package_init.py.jinja
@@ -16,7 +16,7 @@ def schema_text() -> str:
     """Return the canonical TypeDB schema text bundled with the package."""
     return (
         resources.files(__package__)
-        .joinpath("schema.tql")
+        .joinpath("{{ schema_filename }}")
         .read_text(encoding="utf-8")
     )
 


### PR DESCRIPTION
## Summary

- **Issue #68**: Populate `_iid` on role player entities when fetching relations
- **Generator**: Add `--schema-path` CLI option for custom schema file location

## Changes

### Role Player IID Population (Issue #68)

When fetching relations via `get()`, `all()`, or `filter().execute()`, the role player entities now have their `_iid` populated alongside the relation's `_iid`.

**Before:**
```python
relation = Employment.manager(db).get()[0]
relation._iid           # "0x..." ✓
relation.employee._iid  # None ✗
relation.employer._iid  # None ✗
```

**After:**
```python
relation = Employment.manager(db).get()[0]
relation._iid           # "0x..." ✓
relation.employee._iid  # "0x..." ✓
relation.employer._iid  # "0x..." ✓
```

### Generator `--schema-path` Option

New CLI option to customize where the schema file is written:

```bash
# Default: schema.tql in output directory
python -m type_bridge.generator schema.tql -o ./models/

# Custom filename in output directory
python -m type_bridge.generator schema.tql -o ./models/ --schema-path definition.tql

# Absolute path (outside package, no schema_text() loader)
python -m type_bridge.generator schema.tql -o ./models/ --schema-path /docs/schema.tql
```

## Test plan

- [x] Unit tests pass (936 passed)
- [x] Integration tests pass (407 passed)
- [x] Added 3 new integration tests for role player IID population
- [x] Linting and type checking pass

Closes #68

🤖 Generated with [Claude Code](https://claude.ai/code)