### PR TITLE
fix: Correct IID correlation in RelationManager._populate_iids

### DIFF
--- a/packages/python/type_bridge/session.py
+++ b/packages/python/type_bridge/session.py
@@ -103,6 +103,15 @@ def _extract_concept_row(item: Any) -> dict[str, Any]:
                 except Exception:
                     pass
 
+            # Try to get value (for attribute concepts used in correlation queries)
+            if hasattr(concept, "get_value"):
+                try:
+                    value = concept.get_value()
+                    if value is not None:
+                        concept_data["value"] = value
+                except Exception:
+                    pass
+
             # If we couldn't get IID directly, try parsing from string
             if "_iid" not in concept_data:
                 concept_str = str(concept)


### PR DESCRIPTION
## Summary

Fixes #78

The `_populate_iids` method was incorrectly assigning the same IIDs to all relations' role players instead of correlating each result to its correct relation.

### Changes

- **session.py**: Add value extraction for attribute concepts in `_extract_concept_row` to enable proper result correlation
- **relation/manager.py**: Fix `_populate_iids` to capture key attribute values as variables in the query and use them to build a lookup map for correlating results back to the correct relations
- **test_iid_feature.py**: Add regression tests for issue #78 verifying that multiple relations each get their own unique IIDs

### The Fix

The key insight is that instead of just checking if a result has an IID (which all results do), we now:
1. Include the key attribute values in the query results using variables (e.g., `$role_name_key`)
2. Build a lookup map from key values → result
3. Match each relation to its result by looking up its key values

## Test plan

- [x] All existing IID tests pass
- [x] New regression tests specifically verify that multiple relations get unique, correct IIDs
- [x] Unit tests pass (964 tests)
- [x] Ruff linting passes
- [x] Pyright type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)