### PR TITLE
RelationManager: IID-preferring role player matching

### DIFF
--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -455,7 +455,24 @@ class Person(Entity):
 
 5. **Schema sync before data**: Always sync schema before inserting data
 
-6. **Transaction types**:
+6. **Role player matching**: Relation CRUD operations identify role players using:
+   - **IID (preferred)**: If the entity has `_iid` set (from being fetched from DB), uses fast IID matching
+   - **Key attributes (fallback)**: If no IID, uses `Flag(Key)` attributes to identify the entity
+   - **Error**: If neither is available, raises `ValueError` with clear guidance
+
+   ```python
+   # Pattern 1: Fetch entities first (uses IID matching - faster)
+   alice = person_manager.filter(name=Name("Alice")).first()  # alice._iid is set
+   emp = Employment(employee=alice, employer=company)
+   emp_manager.insert(emp)  # Uses alice._iid for matching
+
+   # Pattern 2: Create stub entities (uses key attribute matching)
+   alice = Person(name=Name("Alice"))  # No _iid
+   emp = Employment(employee=alice, employer=company)
+   emp_manager.insert(emp)  # Uses name (key attr) for matching
+   ```
+
+7. **Transaction types**:
    - `"read"`: For queries (no commit needed)
    - `"write"`: For insert/update/delete (auto-commits)
    - `"schema"`: For schema changes (auto-commits)

--- a/docs/api/crud.md
+++ b/docs/api/crud.md
@@ -95,6 +95,7 @@ with db.transaction(TransactionType.WRITE) as tx:
 ```
 
 Notes:
+
 - `Database.transaction` returns a context manager; pass the returned context or its `transaction` to managers/queries.
 - Entity/Relation managers and queries automatically reuse the provided transaction instead of opening new ones.
 - READ transactions are never rolled back (no writes); WRITE/SCHEMA auto-commit on success and rollback on exception.
@@ -144,10 +145,10 @@ Both `insert()` and `insert_many()` run in a single write transaction when a tra
 
 PUT operations are idempotent - they insert only if the pattern doesn't exist, making them safe to run multiple times.
 
-| Operation | Behavior |
-|-----------|----------|
-| **INSERT** | Always creates new instances |
-| **PUT** | Idempotent - inserts only if doesn't exist |
+| Operation  | Behavior                                   |
+| ---------- | ------------------------------------------ |
+| **INSERT** | Always creates new instances               |
+| **PUT**    | Idempotent - inserts only if doesn't exist |
 
 ```python
 # Single PUT
@@ -211,6 +212,13 @@ first_person = person_manager.filter(name="Alice").first()
 
 if first_person:
     print(f"Found: {first_person.name}")
+else:
+    print("Not found")
+
+# Count matching entities
+count = person_manager.filter(age=30).count()
+print(f"Found {count} persons aged 30")
+```
 
 ### Django-style lookup suffixes
 
@@ -262,17 +270,11 @@ present_age = person_manager.filter(age__isnull=False)
 ```
 
 Rules and validation:
+
 - Attribute names cannot contain `__` when using lookups.
 - `__in` requires a non-empty iterable; mixed raw values and Attribute instances are allowed.
 - String lookups (`contains`, `startswith`, `endswith`, `regex`) require `String` attributes.
 - `__isnull` requires a boolean.
-else:
-    print("Not found")
-
-# Count matching entities
-count = person_manager.filter(age=30).count()
-print(f"Found {count} persons aged 30")
-```
 
 ### EntityQuery Methods
 
@@ -350,6 +352,7 @@ results = employment_manager.filter().order_by('employee__age', '-salary').execu
 ## Update Operations
 
 The update API supports two patterns:
+
 1. **Instance-based**: fetch → modify → update (traditional ORM pattern)
 2. **Bulk functional**: filter → update_with function (efficient bulk updates)
 
@@ -411,7 +414,7 @@ class Document(Entity):
     title: Title
 ```
 
-See [Exception Handling](#exception-handling-v072) for details on handling `KeyAttributeError`.
+See [Exception Handling](#exception-handling) for details on handling `KeyAttributeError`.
 
 ### Update Single-Value Attributes
 
@@ -463,7 +466,7 @@ person_manager.update(charlie)
 
 ### Bulk Update with Function
 
-**New in v0.6.0**: Update multiple entities efficiently using `update_with()`:
+Update multiple entities efficiently using `update_with()`:
 
 ```python
 # Increment age for all persons over 30
@@ -512,6 +515,7 @@ person_manager.update_many(people)
 `update_many()` reuses a provided transaction/context; otherwise it opens exactly one write transaction for the batch.
 
 **How `update_with()` works**:
+
 1. Fetches all entities matching the filter
 2. Applies the function to each entity in-place
 3. Updates all entities in a single atomic transaction
@@ -526,9 +530,11 @@ person_manager.update_many(people)
 The update method generates different TypeQL based on cardinality:
 
 **Single-value attributes** (`@card(0..1)` or `@card(1..1)`):
+
 - Uses TypeQL `update` clause for efficient in-place updates
 
 **Multi-value attributes** (e.g., `@card(1..)`, `@card(2..5)`):
+
 - Deletes all old values
 - Inserts new values
 
@@ -550,11 +556,8 @@ $e has status "active";
 
 ## Delete Operations
 
-**Changed in v0.7.1**: Delete API refactored to instance-based pattern for consistency with `insert()` and `update()`.
-
-**Changed in v0.7.2**: New exceptions for delete operations - `EntityNotFoundError`, `RelationNotFoundError`, `NotUniqueError`.
-
 TypeBridge supports two delete patterns:
+
 1. **Instance delete**: `manager.delete(entity)` - delete by entity instance (recommended)
 2. **Filter delete**: `manager.filter(...).delete()` - delete matching entities by filter
 
@@ -575,10 +578,11 @@ alice.delete(db)  # Returns alice for chaining
 ```
 
 **How instance delete works**:
+
 - Uses `@key` attributes to identify the entity (same as `update()`)
 - Returns the deleted entity instance (not a count)
 - Raises `ValueError` if key attribute is None
-- Raises `EntityNotFoundError` if entity doesn't exist in database (v0.7.2+)
+- Raises `EntityNotFoundError` if entity doesn't exist in database
 
 ### Delete Entities Without @key
 
@@ -600,10 +604,11 @@ manager.delete(counter)  # Error: found 2 matches
 ```
 
 **Behavior**:
+
 - Matches by ALL non-None attributes
 - Only deletes if exactly 1 match found
-- Raises `EntityNotFoundError` if 0 matches (v0.7.2+)
-- Raises `NotUniqueError` if >1 matches (v0.7.2+)
+- Raises `EntityNotFoundError` if 0 matches
+- Raises `NotUniqueError` if >1 matches
 
 ### Batch Delete with `delete_many`
 
@@ -623,7 +628,7 @@ deleted = person_manager.delete_many([])
 assert deleted == []
 ```
 
-**Idempotent by default** (v1.2.0+): Missing entities are silently ignored:
+**Idempotent by default**: Missing entities are silently ignored:
 
 ```python
 # Create entity that doesn't exist in DB
@@ -675,13 +680,14 @@ assert count == 0
 ```
 
 **How filter delete works**:
+
 - Builds TypeQL delete query from all filters
 - Executes in single atomic transaction
 - Returns count of deleted entities (int)
 
 ### Instance Delete Method
 
-**New in v0.7.1**: Entities can delete themselves:
+Entities can delete themselves:
 
 ```python
 # Create and insert entity
@@ -697,7 +703,7 @@ Person(name=Name("Temp")).insert(db).delete(db)
 
 **Warning**: Delete operations are permanent and cannot be undone!
 
-### Exception Handling (v0.7.2+)
+### Exception Handling
 
 Delete and update operations raise specific exceptions for better error handling:
 
@@ -717,7 +723,7 @@ except NotUniqueError:
     # Use filter().delete() for bulk deletion instead
     count = manager.filter(value=keyless_entity.value).delete()
 
-# Handle @key validation failures (v0.9.2+)
+# Handle @key validation failures
 try:
     manager.update(entity_with_none_key)
 except KeyAttributeError as e:
@@ -729,15 +735,16 @@ except KeyAttributeError as e:
 ```
 
 **Exception hierarchy**:
+
 - `EntityNotFoundError(LookupError)` - Entity not found in database
 - `NotUniqueError(ValueError)` - Multiple matches for keyless entity
-- `KeyAttributeError(ValueError)` - @key attribute is None or no @key defined (v0.9.2+)
+- `KeyAttributeError(ValueError)` - @key attribute is None or no @key defined
 
 ## RelationManager
 
 Type-safe manager for relation CRUD operations.
 
-### Creating a Manager
+### Creating a Relation Manager
 
 ```python
 from type_bridge import Relation, TypeFlags, Role
@@ -794,12 +801,12 @@ class RelationManager[R: Relation]:
 class Relation:
     @classmethod
     def get_roles(cls) -> dict[str, Role]:
-        """Get all roles defined on this relation. New in v0.9.0."""
+        """Get all roles defined on this relation."""
 ```
 
 ### Accessing Relation Roles
 
-**New in v0.9.0**: Use `get_roles()` to introspect relation roles:
+Use `get_roles()` to introspect relation roles:
 
 ```python
 # Get all roles for a relation
@@ -811,6 +818,38 @@ employee_role = Employment.get_roles()['employee']
 print(employee_role.role_name)  # 'employee'
 print(employee_role.player_entity_types)  # (Person,)
 ```
+
+### Role Player Matching
+
+When performing relation CRUD operations (`insert`, `put`, `update`, `delete`), TypeBridge needs to identify the role player entities in the database. It uses an **IID-preferring** matching strategy:
+
+1. **IID (preferred)**: If the entity has `_iid` set (from being fetched from the database), uses fast IID-based matching
+2. **Key attributes (fallback)**: If no IID, uses the entity's `@key` attributes to identify it
+3. **Error**: If neither is available, raises `ValueError` with clear guidance
+
+```python
+# Pattern 1: Fetch entities first (uses IID matching - faster, more precise)
+alice = person_manager.filter(name=Name("Alice")).first()  # alice._iid is set
+company = company_manager.filter(name=Name("TechCorp")).first()  # company._iid is set
+emp = Employment(employee=alice, employer=company, position=Position("Engineer"))
+emp_manager.insert(emp)  # Uses IIDs for matching
+
+# Pattern 2: Create stub entities (uses key attribute matching)
+alice = Person(name=Name("Alice"))  # No _iid - just the key attribute
+company = Company(name=Name("TechCorp"))
+emp = Employment(employee=alice, employer=company, position=Position("Engineer"))
+emp_manager.insert(emp)  # Uses name (@key) for matching
+
+# Pattern 3: Entity without IID or @key - raises error
+# class NoKeyEntity(Entity):
+#     flags = TypeFlags(name="no_key")
+#     value: Value  # No @key attribute
+# no_key = NoKeyEntity(value=Value(42))
+# emp = SomeRelation(player=no_key)
+# relation_manager.insert(emp)  # ValueError: cannot identify role player
+```
+
+**Best practice**: Fetch entities from the database when you need to use them as role players. This populates `_iid` and enables faster, more precise matching.
 
 ### Insert Relations
 
@@ -861,7 +900,7 @@ for employment in all_employments:
     print(f"{employment.employee.name}: {employment.position}")
 ```
 
-#### Get with Filters
+#### Get Relations with Filters
 
 Filter by both attributes and role players:
 
@@ -886,9 +925,9 @@ specific_employment = employment_manager.get(
 )
 ```
 
-#### Chainable Queries
+#### Chainable Relation Queries
 
-**New in v0.6.0**: RelationManager now supports the same chainable query API as EntityManager:
+RelationManager now supports the same chainable query API as EntityManager:
 
 ```python
 # Basic query
@@ -913,9 +952,9 @@ print(f"Found {count} engineers")
 
 #### RelationQuery Methods
 
-**New in v0.6.0**: Complete API parity with EntityQuery.
+Complete API parity with EntityQuery.
 
-**New in v0.9.0**: Type-safe role player expressions and `**kwargs` support in chained `filter()`.
+Type-safe role player expressions and `**kwargs` support in chained `filter()`.
 
 ```python
 class RelationQuery[R: Relation]:
@@ -955,7 +994,7 @@ class RelationQuery[R: Relation]:
 
 #### Type-Safe Role Player Expressions
 
-**New in v0.9.0**: Filter relations using type-safe role player field access:
+Filter relations using type-safe role player field access:
 
 ```python
 # Type-safe role player expressions
@@ -988,10 +1027,11 @@ See [Queries - Type-Safe Role Player Expressions](queries.md#type-safe-role-play
 ### Update Relations
 
 The update API supports two patterns (same as EntityManager):
+
 1. **Instance-based**: fetch → modify → update (traditional ORM pattern)
 2. **Bulk functional**: filter → update_with function (efficient bulk updates)
 
-#### Basic Update
+#### Basic Relation Update
 
 ```python
 # Step 1: Fetch relation
@@ -1005,7 +1045,7 @@ employment.salary = Salary(150000)
 employment_manager.update(employment)
 ```
 
-#### Update Single-Value Attributes
+#### Update Relation Single-Value Attributes
 
 ```python
 # Fetch relation
@@ -1020,7 +1060,7 @@ employment.start_date = StartDate("2024-01-01")
 employment_manager.update(employment)
 ```
 
-#### Update Multi-Value Attributes
+#### Update Relation Multi-Value Attributes
 
 ```python
 # Fetch relation
@@ -1041,9 +1081,9 @@ employment.responsibilities = []
 employment_manager.update(employment)
 ```
 
-#### Bulk Update with Function
+#### Bulk Relation Update with Function
 
-**New in v0.6.0**: Update multiple relations efficiently using `update_with()`:
+Update multiple relations efficiently using `update_with()`:
 
 ```python
 # Give all engineers a 10% raise
@@ -1072,6 +1112,7 @@ print(f"Promoted {len(promoted)} employments")
 ```
 
 **How `update_with()` works for relations**:
+
 1. Fetches all relations matching the filter
 2. Stores original attribute values (needed to uniquely identify relations)
 3. Applies the function to each relation in-place
@@ -1086,15 +1127,16 @@ print(f"Promoted {len(promoted)} employments")
 
 ### Delete Relations
 
-**Changed in v0.7.1**: Delete API refactored to instance-based pattern.
+Delete API refactored to instance-based pattern.
 
-**Changed in v0.7.2**: Raises `RelationNotFoundError` when relation doesn't exist.
+Raises `RelationNotFoundError` when relation doesn't exist.
 
 TypeBridge supports two delete patterns for relations:
+
 1. **Instance delete**: `manager.delete(relation)` - delete by relation instance (recommended)
 2. **Filter delete**: `manager.filter(...).delete()` - delete matching relations by filter
 
-#### Instance Delete (Recommended)
+#### Relation Instance Delete (Recommended)
 
 Delete relations by instance, using role players' `@key` attributes:
 
@@ -1111,12 +1153,13 @@ employment.delete(db)  # Returns employment for chaining
 ```
 
 **How instance delete works**:
+
 - Uses role players' `@key` attributes to identify the relation
 - Returns the deleted relation instance (not a count)
 - Raises `ValueError` if role player is missing or has None key
-- Raises `RelationNotFoundError` if relation doesn't exist (v0.7.2+)
+- Raises `RelationNotFoundError` if relation doesn't exist
 
-#### Batch Delete with `delete_many`
+#### Relation Batch Delete with `delete_many`
 
 Delete multiple relation instances in a single transaction:
 
@@ -1134,7 +1177,7 @@ deleted = employment_manager.delete_many([])
 assert deleted == []
 ```
 
-#### Filter-Based Delete
+#### Relation Filter-Based Delete
 
 For bulk deletion by criteria, use `filter().delete()`:
 
@@ -1160,13 +1203,14 @@ assert count == 0
 ```
 
 **How filter delete works**:
+
 - Builds TypeQL delete query from all filters
 - Executes in single atomic transaction
 - Returns count of deleted relations (int)
 
-#### Instance Delete Method
+#### Relation Instance Delete Method
 
-**New in v0.7.1**: Relations can delete themselves:
+Relations can delete themselves:
 
 ```python
 # Create and insert relation
@@ -1179,7 +1223,7 @@ emp.delete(db)  # Returns emp for chaining
 
 **Warning**: Delete operations are permanent and cannot be undone!
 
-#### Exception Handling (v0.7.2+)
+#### Relation Exception Handling
 
 Relation delete operations raise `RelationNotFoundError` when the relation doesn't exist:
 
@@ -1366,7 +1410,7 @@ alice = user_manager.get(age=30)[0]  # May return multiple results
 Delete entities by instance, not by filter:
 
 ```python
-# ✅ GOOD: Instance-based delete (v0.7.1+)
+# ✅ GOOD: Instance-based delete
 alice = user_manager.get(user_id="u1")[0]
 deleted = user_manager.delete(alice)  # Returns alice
 print(f"Deleted {deleted.username.value}")
@@ -1377,7 +1421,7 @@ alice.delete(db)
 # ✅ GOOD: Filter-based for bulk operations
 count = user_manager.filter(Age.gt(Age(65))).delete()  # Returns count
 
-# ⚠️ NOTE: Old filter-based manager.delete(**filters) removed in v0.7.1
+# Use filter().delete() for filter-based deletion
 # Use filter().delete() instead for filter-based deletion
 ```
 
@@ -1444,6 +1488,7 @@ driver.close()
 ```
 
 **Ownership semantics:**
+
 - `driver=None` (default): `Database` creates and owns the driver, `close()` closes it
 - `driver=<Driver>`: `Database` uses but doesn't own it, `close()` only clears the reference
 

--- a/type_bridge/crud/relation/manager.py
+++ b/type_bridge/crud/relation/manager.py
@@ -37,6 +37,106 @@ class RelationManager[R: Relation]:
         self._executor = ConnectionExecutor(connection)
         self.model_class = model_class
 
+    def _build_role_player_match(self, role_name: str, entity: Any, entity_type_name: str) -> str:
+        """Build a match clause for a role player entity.
+
+        Prefers IID-based matching when available (more precise and faster),
+        falls back to key attribute matching, and raises a clear error if
+        neither is available.
+
+        Args:
+            role_name: The role name (used as variable name)
+            entity: The entity instance
+            entity_type_name: The TypeDB type name for the entity
+
+        Returns:
+            A TypeQL match clause string like "$role_name isa type, iid 0x..."
+            or "$role_name isa type, has key_attr value"
+
+        Raises:
+            ValueError: If entity has neither _iid nor key attributes
+        """
+        # Prefer IID-based matching when available (more precise and faster)
+        entity_iid = getattr(entity, "_iid", None)
+        if entity_iid:
+            return f"${role_name} isa {entity_type_name}, iid {entity_iid}"
+
+        # Fall back to key attribute matching
+        key_attrs = {
+            field_name: attr_info
+            for field_name, attr_info in entity.__class__.get_all_attributes().items()
+            if attr_info.flags.is_key
+        }
+
+        for field_name, attr_info in key_attrs.items():
+            value = getattr(entity, field_name)
+            if value is not None:
+                attr_class = attr_info.typ
+                attr_name = attr_class.get_attribute_name()
+                formatted_value = format_value(value)
+                return f"${role_name} isa {entity_type_name}, has {attr_name} {formatted_value}"
+
+        # Neither IID nor key attributes available
+        raise ValueError(
+            f"Role player '{role_name}' ({entity.__class__.__name__}) cannot be identified: "
+            f"no _iid set and no @key attributes defined. Either fetch the entity from the "
+            f"database first (to populate _iid) or add Flag(Key) to an attribute."
+        )
+
+    def _build_player_key_and_match(
+        self, player_entity: Any
+    ) -> tuple[tuple[str, Any], str, list[str]]:
+        """Build a unique key and match clause parts for a role player entity.
+
+        Used by insert_many/put_many to deduplicate role players across relations.
+        Prefers IID-based matching when available.
+
+        Args:
+            player_entity: The entity instance
+
+        Returns:
+            Tuple of (player_key, player_type, match_parts) where:
+            - player_key: Tuple for deduplication (either ("iid", iid) or key attr values)
+            - player_type: The TypeDB type name
+            - match_parts: List of match clause parts like ["isa type", "iid 0x..."]
+
+        Raises:
+            ValueError: If entity has neither _iid nor key attributes
+        """
+        player_type = player_entity.get_type_name()
+
+        # Prefer IID-based matching when available
+        entity_iid = getattr(player_entity, "_iid", None)
+        if entity_iid:
+            player_key: tuple[str, Any] = ("iid", entity_iid)
+            match_parts = [f"isa {player_type}", f"iid {entity_iid}"]
+            return (player_key, player_type, match_parts)
+
+        # Fall back to key attribute matching
+        owned_attrs = player_entity.get_all_attributes()
+        key_values: list[tuple[str, Any]] = []
+        for field_name, attr_info in owned_attrs.items():
+            if attr_info.flags.is_key:
+                value = getattr(player_entity, field_name, None)
+                if value is not None:
+                    attr_name = attr_info.typ.get_attribute_name()
+                    key_values.append((attr_name, value))
+
+        if key_values:
+            player_key = ("keys", tuple(sorted(key_values)))
+            match_parts = [f"isa {player_type}"]
+            for attr_name, value in key_values:
+                formatted_value = format_value(value)
+                match_parts.append(f"has {attr_name} {formatted_value}")
+            return (player_key, player_type, match_parts)
+
+        # Neither IID nor key attributes available
+        raise ValueError(
+            f"Role player ({player_entity.__class__.__name__}) cannot be identified: "
+            f"no _iid set and no @key attributes defined. Either fetch the entity from the "
+            f"database first (to populate _iid) or add Flag(Key) to an attribute."
+        )
+
     def insert(self, relation: R) -> R:
         """Insert a typed relation instance into the database.
 
@@ -65,27 +165,11 @@ class RelationManager[R: Relation]:
             if entity is not None:
                 role_players[role_name] = entity
 
-        # Build match clause for role players
+        # Build match clause for role players (IID-preferring)
         match_parts = []
         for role_name, entity in role_players.items():
-            # Get key attributes from the entity (including inherited attributes)
             entity_type_name = entity.__class__.get_type_name()
-            key_attrs = {
-                field_name: attr_info
-                for field_name, attr_info in entity.__class__.get_all_attributes().items()
-                if attr_info.flags.is_key
-            }
-
-            # Match entity by its key attribute
-            for field_name, attr_info in key_attrs.items():
-                value = getattr(entity, field_name)
-                attr_class = attr_info.typ
-                attr_name = attr_class.get_attribute_name()
-                formatted_value = format_value(value)
-                match_parts.append(
-                    f"${role_name} isa {entity_type_name}, has {attr_name} {formatted_value}"
-                )
-                break  # Only use first key attribute
+            match_parts.append(self._build_role_player_match(role_name, entity, entity_type_name))
 
         # Build insert clause
         relation_type_name = self.model_class.get_type_name()
@@ -170,27 +254,11 @@ class RelationManager[R: Relation]:
             if entity is not None:
                 role_players[role_name] = entity
 
-        # Build match clause for role players
+        # Build match clause for role players (IID-preferring)
         match_parts = []
         for role_name, entity in role_players.items():
-            # Get key attributes from the entity (including inherited attributes)
             entity_type_name = entity.__class__.get_type_name()
-            key_attrs = {
-                field_name: attr_info
-                for field_name, attr_info in entity.__class__.get_all_attributes().items()
-                if attr_info.flags.is_key
-            }
-
-            # Match entity by its key attribute
-            for field_name, attr_info in key_attrs.items():
-                value = getattr(entity, field_name)
-                attr_class = attr_info.typ
-                attr_name = attr_class.get_attribute_name()
-                formatted_value = format_value(value)
-                match_parts.append(
-                    f"${role_name} isa {entity_type_name}, has {attr_name} {formatted_value}"
-                )
-                break  # Only use first key attribute
+            match_parts.append(self._build_role_player_match(role_name, entity, entity_type_name))
 
         # Build put clause (same as insert clause but with "put" keyword)
         relation_type_name = self.model_class.get_type_name()
@@ -280,30 +348,22 @@ class RelationManager[R: Relation]:
         # Build query
         query = Query()
 
-        # Collect all unique role players to match
-        all_players = {}  # key: (entity_type, key_attr_values) -> player_var
+        # Collect all unique role players to match (IID-preferring)
+        all_players: dict[tuple[str, tuple[str, Any]], str] = {}  # player_key -> player_var
         player_counter = 0
 
         # First pass: collect all unique players from all relation instances
         for relation in relations:
             # Extract role players from instance
-            for role_name, role in self.model_class._roles.items():
+            for role_name in self.model_class._roles:
                 player_entity = relation.__dict__.get(role_name)
                 if player_entity is None:
                     continue
-                # Create unique key for this player based on key attributes (including inherited)
-                player_type = player_entity.get_type_name()
-                owned_attrs = player_entity.get_all_attributes()
 
-                key_values = []
-                for field_name, attr_info in owned_attrs.items():
-                    if attr_info.flags.is_key:
-                        value = getattr(player_entity, field_name, None)
-                        if value is not None:
-                            attr_name = attr_info.typ.get_attribute_name()
-                            key_values.append((attr_name, value))
-
-                player_key = (player_type, tuple(sorted(key_values)))
+                # Build player key and match clause (IID-preferring)
+                player_key, player_type, match_parts = self._build_player_key_and_match(
+                    player_entity
+                )
 
                 if player_key not in all_players:
                     player_var = f"$player{player_counter}"
@@ -311,17 +371,12 @@ class RelationManager[R: Relation]:
                     all_players[player_key] = player_var
 
                     # Build match clause for this player
-                    match_parts = [f"{player_var} isa {player_type}"]
-                    for attr_name, value in key_values:
-                        formatted_value = format_value(value)
-                        match_parts.append(f"has {attr_name} {formatted_value}")
-
-                    query.match(", ".join(match_parts))
+                    query.match(f"{player_var} " + ", ".join(match_parts))
 
         # Second pass: build put patterns for relations (same as insert_many but with "put")
         put_patterns = []
 
-        for i, relation in enumerate(relations):
+        for relation in relations:
             # Map role players to their variables
             role_var_map = {}
             for role_name, role in self.model_class._roles.items():
@@ -329,19 +384,8 @@ class RelationManager[R: Relation]:
                 if player_entity is None:
                     raise ValueError(f"Missing role player for role: {role_name}")
 
-                # Find the player variable (including inherited attributes)
-                player_type = player_entity.get_type_name()
-                owned_attrs = player_entity.get_all_attributes()
-
-                key_values = []
-                for field_name, attr_info in owned_attrs.items():
-                    if attr_info.flags.is_key:
-                        value = getattr(player_entity, field_name, None)
-                        if value is not None:
-                            attr_name = attr_info.typ.get_attribute_name()
-                            key_values.append((attr_name, value))
-
-                player_key = (player_type, tuple(sorted(key_values)))
+                # Find the player variable using the same key logic
+                player_key, _, _ = self._build_player_key_and_match(player_entity)
                 player_var = all_players[player_key]
                 role_var_map[role_name] = (player_var, role.role_name)
 
@@ -439,30 +483,22 @@ class RelationManager[R: Relation]:
         # Build query
         query = Query()
 
-        # Collect all unique role players to match
-        all_players = {}  # key: (entity_type, key_attr_values) -> player_var
+        # Collect all unique role players to match (IID-preferring)
+        all_players: dict[tuple[str, tuple[str, Any]], str] = {}  # player_key -> player_var
         player_counter = 0
 
         # First pass: collect all unique players from all relation instances
         for relation in relations:
             # Extract role players from instance
-            for role_name, role in self.model_class._roles.items():
+            for role_name in self.model_class._roles:
                 player_entity = relation.__dict__.get(role_name)
                 if player_entity is None:
                     continue
-                # Create unique key for this player based on key attributes (including inherited)
-                player_type = player_entity.get_type_name()
-                owned_attrs = player_entity.get_all_attributes()
 
-                key_values = []
-                for field_name, attr_info in owned_attrs.items():
-                    if attr_info.flags.is_key:
-                        value = getattr(player_entity, field_name, None)
-                        if value is not None:
-                            attr_name = attr_info.typ.get_attribute_name()
-                            key_values.append((attr_name, value))
-
-                player_key = (player_type, tuple(sorted(key_values)))
+                # Build player key and match clause (IID-preferring)
+                player_key, player_type, match_parts = self._build_player_key_and_match(
+                    player_entity
+                )
 
                 if player_key not in all_players:
                     player_var = f"$player{player_counter}"
@@ -470,17 +506,12 @@ class RelationManager[R: Relation]:
                     all_players[player_key] = player_var
 
                     # Build match clause for this player
-                    match_parts = [f"{player_var} isa {player_type}"]
-                    for attr_name, value in key_values:
-                        formatted_value = format_value(value)
-                        match_parts.append(f"has {attr_name} {formatted_value}")
-
-                    query.match(", ".join(match_parts))
+                    query.match(f"{player_var} " + ", ".join(match_parts))
 
         # Second pass: build insert patterns for relations
         insert_patterns = []
 
-        for i, relation in enumerate(relations):
+        for relation in relations:
             # Map role players to their variables
             role_var_map = {}
             for role_name, role in self.model_class._roles.items():
@@ -488,19 +519,8 @@ class RelationManager[R: Relation]:
                 if player_entity is None:
                     raise ValueError(f"Missing role player for role: {role_name}")
 
-                # Find the player variable (including inherited attributes)
-                player_type = player_entity.get_type_name()
-                owned_attrs = player_entity.get_all_attributes()
-
-                key_values = []
-                for field_name, attr_info in owned_attrs.items():
-                    if attr_info.flags.is_key:
-                        value = getattr(player_entity, field_name, None)
-                        if value is not None:
-                            attr_name = attr_info.typ.get_attribute_name()
-                            key_values.append((attr_name, value))
-
-                player_key = (player_type, tuple(sorted(key_values)))
+                # Find the player variable using the same key logic
+                player_key, _, _ = self._build_player_key_and_match(player_entity)
                 player_var = all_players[player_key]
                 role_var_map[role_name] = (player_var, role.role_name)
 
@@ -1013,7 +1033,7 @@ class RelationManager[R: Relation]:
                         # Optional attribute set to None - needs to be deleted
                         single_value_deletes.add(attr_name)
 
-        # Build match clause with role players
+        # Build match clause with role players (IID-preferring)
         role_parts = []
         match_statements = []
 
@@ -1022,20 +1042,10 @@ class RelationManager[R: Relation]:
             role = roles[role_name]
             role_parts.append(f"{role.role_name}: {role_var}")
 
-            # Match the role player by their key attributes (including inherited)
-            entity_class = entity.__class__
-            player_owned_attrs = entity_class.get_all_attributes()
-            for field_name, attr_info in player_owned_attrs.items():
-                if attr_info.flags.is_key:
-                    key_value = getattr(entity, field_name, None)
-                    if key_value is not None:
-                        attr_name = attr_info.typ.get_attribute_name()
-                        # Extract value from Attribute instance if needed
-                        if hasattr(key_value, "value"):
-                            key_value = key_value.value
-                        formatted_value = format_value(key_value)
-                        match_statements.append(f"{role_var} has {attr_name} {formatted_value};")
-                        break
+            # Match the role player using IID-preferring logic
+            entity_type_name = entity.__class__.get_type_name()
+            match_clause = self._build_role_player_match(role_name, entity, entity_type_name)
+            match_statements.append(f"{match_clause};")
 
         roles_str = ", ".join(role_parts)
         relation_match = f"$r isa {self.model_class.get_type_name()} ({roles_str});"
@@ -1142,7 +1152,7 @@ class RelationManager[R: Relation]:
                 raise ValueError(f"Role player '{role_name}' is required for delete")
             role_players[role_name] = entity
 
-        # Build match clause with role players
+        # Build match clause with role players (IID-preferring)
         role_parts = []
         match_statements = []
 
@@ -1151,18 +1161,10 @@ class RelationManager[R: Relation]:
             role = roles[role_name]
             role_parts.append(f"{role.role_name}: {role_var}")
 
-            # Match role player by their @key attribute (including inherited)
-            player_attrs = entity.__class__.get_all_attributes()
-            for field_name, attr_info in player_attrs.items():
-                if attr_info.flags.is_key:
-                    key_value = getattr(entity, field_name, None)
-                    if key_value is not None:
-                        attr_name = attr_info.typ.get_attribute_name()
-                        if hasattr(key_value, "value"):
-                            key_value = key_value.value
-                        formatted_value = format_value(key_value)
-                        match_statements.append(f"{role_var} has {attr_name} {formatted_value}")
-                        break
+            # Match the role player using IID-preferring logic
+            entity_type_name = entity.__class__.get_type_name()
+            match_clause = self._build_role_player_match(role_name, entity, entity_type_name)
+            match_statements.append(match_clause)
 
         roles_str = ", ".join(role_parts)
         relation_match = f"$r isa {self.model_class.get_type_name()} ({roles_str})"
@@ -1223,7 +1225,7 @@ class RelationManager[R: Relation]:
         roles = self.model_class._roles
         role_names = list(roles.keys())
 
-        # Build disjunctive check query to see which relations exist
+        # Build disjunctive check query to see which relations exist (IID-preferring)
         # Use shared variable names across all branches for TypeQL compatibility
         check_clauses = []
         relation_keys: list[tuple[tuple[str, Any], ...]] = []
@@ -1242,19 +1244,26 @@ class RelationManager[R: Relation]:
                 role = roles[role_name]
                 role_parts.append(f"{role.role_name}: {role_var}")
 
-                # Match role player by their @key attribute
-                player_attrs = entity.__class__.get_all_attributes()
-                for field_name, attr_info in player_attrs.items():
-                    if attr_info.flags.is_key:
-                        key_value = getattr(entity, field_name, None)
-                        if key_value is not None:
-                            attr_name = attr_info.typ.get_attribute_name()
-                            if hasattr(key_value, "value"):
-                                key_value = key_value.value
-                            formatted_value = format_value(key_value)
-                            match_statements.append(f"{role_var} has {attr_name} {formatted_value}")
-                            key_parts.append((f"{role_name}:{attr_name}", key_value))
-                            break
+                # Match role player using IID-preferring logic
+                entity_type_name = entity.__class__.get_type_name()
+                match_clause = self._build_role_player_match(role_name, entity, entity_type_name)
+                match_statements.append(match_clause)
+
+                # Build key for deduplication (use IID if available, else key attrs)
+                entity_iid = getattr(entity, "_iid", None)
+                if entity_iid:
+                    key_parts.append((f"{role_name}:iid", entity_iid))
+                else:
+                    player_attrs = entity.__class__.get_all_attributes()
+                    for field_name, attr_info in player_attrs.items():
+                        if attr_info.flags.is_key:
+                            key_value = getattr(entity, field_name, None)
+                            if key_value is not None:
+                                attr_name = attr_info.typ.get_attribute_name()
+                                if hasattr(key_value, "value"):
+                                    key_value = key_value.value
+                                key_parts.append((f"{role_name}:{attr_name}", key_value))
+                                break
 
             if not role_parts:
                 continue
@@ -1313,7 +1322,7 @@ class RelationManager[R: Relation]:
             logger.info("No relations to delete (none exist)")
             return []
 
-        # Build batched delete query for existing relations
+        # Build batched delete query for existing relations (IID-preferring)
         # Reuse the same clause-building logic with shared variable names
         delete_clauses = []
         for relation in existing_relations:
@@ -1328,18 +1337,10 @@ class RelationManager[R: Relation]:
                 role = roles[role_name]
                 role_parts.append(f"{role.role_name}: {role_var}")
 
-                # Match role player by their @key attribute
-                player_attrs = entity.__class__.get_all_attributes()
-                for field_name, attr_info in player_attrs.items():
-                    if attr_info.flags.is_key:
-                        key_value = getattr(entity, field_name, None)
-                        if key_value is not None:
-                            attr_name = attr_info.typ.get_attribute_name()
-                            if hasattr(key_value, "value"):
-                                key_value = key_value.value
-                            formatted_value = format_value(key_value)
-                            match_statements.append(f"{role_var} has {attr_name} {formatted_value}")
-                            break
+                # Match role player using IID-preferring logic
+                entity_type_name = entity.__class__.get_type_name()
+                match_clause = self._build_role_player_match(role_name, entity, entity_type_name)
+                match_statements.append(match_clause)
 
             roles_str = ", ".join(role_parts)
             relation_match = f"$r isa {self.model_class.get_type_name()} ({roles_str})"


### PR DESCRIPTION
## Summary

- Add `_build_role_player_match()` helper that prefers IID when available for faster, more precise matching
- Fall back to key attribute matching when IID not set
- Raise clear `ValueError` when neither IID nor key attributes available
- Update `insert()`, `put()`, `update()`, `delete()` and their `*_many` variants

## Role Player Matching Strategy

When performing relation CRUD operations, TypeBridge now uses an IID-preferring matching strategy:

1. **IID (preferred)**: If the entity has `_iid` set (from being fetched from the database), uses fast IID-based matching
2. **Key attributes (fallback)**: If no IID, uses the entity's `@key` attributes to identify it
3. **Error**: If neither is available, raises `ValueError` with clear guidance

## Test plan

- [x] Unit tests pass (`uv run pytest tests/unit/`)
- [x] Integration tests pass (`USE_DOCKER=false TYPEDB_ADDRESS=localhost:1729 uv run pytest -m integration`)
- [x] Lint checks pass (`uv run ruff check .`)
- [x] Type checks pass (`uvx ty check .`)