### PR TITLE
docs(rust): full documentation and metadata polish for Rust core

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,24 @@ uv run pytest -m "" -v                    # Run all tests
 ./check.sh                                # Run linting and type checking
 ```
 
+## Rust Core
+
+The project includes a Rust core (`type-bridge-core/`) that provides high-performance implementations of the query compiler, validation engine, and value coercer. When the native extension is installed, Python automatically delegates to Rust for:
+
+- **Validation** — ~8.6x faster schema-aware query validation
+- **Compilation** — ~1.3x faster AST-to-TypeQL compilation via serde bridge
+- **Value coercion** — Type-safe value coercion and TypeQL literal formatting
+
+The Rust core is a Cargo workspace with three crates:
+
+| Crate | Description |
+|-------|-------------|
+| `type-bridge-core-lib` | Pure-Rust AST, schema parser, query compiler, and validation engine |
+| `type-bridge-core` | PyO3 bindings exposing the Rust core to Python |
+| `type-bridge-server` | Transport-agnostic query pipeline with HTTP API |
+
+See [`type-bridge-core/README.md`](type-bridge-core/README.md) for build instructions and architecture details.
+
 ## Requirements
 
 - Python 3.13+

--- a/type-bridge-core/Cargo.toml
+++ b/type-bridge-core/Cargo.toml
@@ -2,5 +2,10 @@
 resolver = "3"
 members = ["crates/core", "crates/python", "crates/server"]
 
+[workspace.package]
+license = "MIT"
+repository = "https://github.com/ds1sqe/type-bridge"
+authors = ["ds1sqe"]
+
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)', 'cfg(coverage)'] }

--- a/type-bridge-core/README.md
+++ b/type-bridge-core/README.md
@@ -1,30 +1,53 @@
 # type-bridge-core
 
-Rust core for the `type-bridge` TypeDB ORM.
+Rust core for the **type-bridge** TypeDB ORM — high-performance AST, schema parser, query compiler, validation engine, and value coercer.
 
-## Overview
+## Workspace structure
 
-This crate provides a high-performance, shared type system and query engine for `type-bridge`. It enables:
+```
+type-bridge-core/
+├── Cargo.toml          # Workspace root
+└── crates/
+    ├── core/           # type-bridge-core-lib  (pure Rust, no runtime deps)
+    ├── python/         # type-bridge-core      (PyO3 bindings → Python)
+    └── server/         # type-bridge-server    (query pipeline + HTTP API)
+```
 
-- **Bidirectional Validation**: Define validation rules once in Rust and enforce them on both client (Python) and server (Rust/WASM).
-- **Query Object Portability**: First-class AST objects that can be serialized and moved between runtimes.
-- **Performance**: High-speed query compilation and schema parsing.
+## Crates
 
-## Structure
-
-- `src/core`: Pure Rust implementation of the AST, schema, and validation engine. This is runtime-agnostic.
-- `src/ast`: PyO3 wrappers for the core AST nodes, providing an idiomatic Python API.
-- `src/lib.rs`: PyO3 module definition.
+| Crate | Description |
+|-------|-------------|
+| [`type-bridge-core-lib`](crates/core/) | Pure-Rust TypeQL AST, schema parser, query compiler, validation engine, and value coercer |
+| [`type-bridge-core`](crates/python/) | PyO3 bindings exposing the Rust core to Python via serde-tagged-enum dicts |
+| [`type-bridge-server`](crates/server/) | Transport-agnostic query pipeline with validation, interceptors, and HTTP API |
 
 ## Building
 
-To build the Python extension:
-
 ```bash
+# Check all crates (requires PYO3 compat flag on Python ≥ 3.14)
+PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo check --all-targets
+
+# Build the Python extension
 cd type-bridge-core
-maturin develop
+PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 maturin develop
+
+# Run tests
+cargo test -p type-bridge-core-lib -p type-bridge-server
+
+# Generate docs
+PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo doc --no-deps --open
 ```
 
-## Status
+## Local CI mirror
 
-This is an initial implementation following the RFC in issue #95. Key structures are in place, with logic being ported from Python.
+Use the project-level check script to mirror CI locally:
+
+```bash
+./scripts/check.sh rust      # Rust checks only
+./scripts/check.sh python    # Python checks only
+./scripts/check.sh           # Both
+```
+
+## License
+
+MIT

--- a/type-bridge-core/crates/core/Cargo.toml
+++ b/type-bridge-core/crates/core/Cargo.toml
@@ -2,6 +2,10 @@
 name = "type-bridge-core-lib"
 version = "0.1.0-dev.0"
 edition = "2024"
+description = "TypeQL AST, schema parser, query compiler, and validation engine for type-bridge"
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
 
 [features]
 default = []

--- a/type-bridge-core/crates/core/README.md
+++ b/type-bridge-core/crates/core/README.md
@@ -1,0 +1,55 @@
+# type-bridge-core-lib
+
+Pure-Rust TypeQL AST, schema parser, query compiler, validation engine, and value coercer for **type-bridge**.
+
+## Modules
+
+| Module | Purpose |
+|--------|---------|
+| `ast` | TypeQL Abstract Syntax Tree — patterns, statements, clauses, and values |
+| `schema` | Schema representation with entity / relation / attribute types and inheritance resolution |
+| `validation` | Schema-aware query validation plus a portable JSON validation-rule DSL |
+| `compiler` | Compiles an AST back into a TypeQL query string |
+| `query_parser` | Parses a TypeQL query string into the AST (bidirectional round-trip) |
+| `value_coercion` | Coerces raw values into TypeDB value-types and formats TypeQL literals |
+| `reserved_words` | TypeQL reserved-word detection |
+| `parser` | Low-level Winnow grammar consumed by `query_parser` and `schema` |
+
+## Usage
+
+```rust
+use type_bridge_core_lib::query_parser::parse_typeql_query;
+use type_bridge_core_lib::compiler::QueryCompiler;
+use type_bridge_core_lib::schema::TypeSchema;
+use type_bridge_core_lib::validation::ValidationEngine;
+
+// Parse a TypeQL query into AST clauses
+let clauses = parse_typeql_query("match $p isa person, has name 'Alice';").unwrap();
+
+// Compile back to TypeQL
+let compiler = QueryCompiler::new();
+let typeql = compiler.compile(&clauses);
+assert_eq!(typeql, "match $p isa person, has name 'Alice';");
+
+// Validate against a schema
+let schema = TypeSchema::from_typeql("define entity person, owns name; attribute name, value string;").unwrap();
+let engine = ValidationEngine::new();
+let result = engine.validate_query(&clauses, &schema);
+assert!(result.is_valid);
+```
+
+## Feature flags
+
+| Feature | Default | Effect |
+|---------|---------|--------|
+| `pyo3` | no | Enables `#[derive(FromPyObject)]` on AST types for PyO3 interop |
+
+## Testing
+
+```bash
+cargo test -p type-bridge-core-lib
+```
+
+## License
+
+MIT

--- a/type-bridge-core/crates/core/src/ast.rs
+++ b/type-bridge-core/crates/core/src/ast.rs
@@ -1,152 +1,333 @@
 use serde::{Deserialize, Serialize};
 
+/// A value expression in TypeQL.
+///
+/// Represents any expression that evaluates to a value, including literals,
+/// function calls, arithmetic operations, and variable references.
+/// Uses tagged JSON serialization (`"type"` + `"data"`) for portable interchange.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data")]
 pub enum Value {
+    /// A typed literal value (e.g. `"Alice"`, `30`, `true`).
     Literal(LiteralValue),
+    /// A function invocation (e.g. `count($x)`, `max($salary)`).
     FunctionCall(FunctionCallValue),
+    /// A binary arithmetic expression (e.g. `$base + $bonus`).
     Arithmetic(ArithmeticValue),
+    /// A reference to a query variable (e.g. `$x`).
     Variable(String),
 }
 
+/// A typed literal value in TypeQL.
+///
+/// Stores the raw JSON representation of a value together with its TypeQL
+/// value type name (e.g. `"string"`, `"long"`, `"double"`, `"boolean"`,
+/// `"datetime"`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LiteralValue {
+    /// The literal value as a JSON-compatible representation.
     pub value: serde_json::Value,
+    /// The TypeQL value type name (e.g. `"string"`, `"long"`, `"double"`).
     pub value_type: String,
 }
 
+/// A function invocation value in TypeQL.
+///
+/// Represents calling a built-in or user-defined function with a list of
+/// argument expressions, such as `count($x)` or `max($salary)`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FunctionCallValue {
+    /// The name of the function being called (e.g. `"count"`, `"max"`, `"min"`).
     pub function: String,
+    /// The argument expressions passed to the function.
     pub args: Vec<Value>,
 }
 
+/// A binary arithmetic expression in TypeQL.
+///
+/// Represents an infix arithmetic operation such as `$base + $bonus` or
+/// `$price * $quantity`. The operands are boxed `Value` nodes to allow
+/// arbitrary nesting.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ArithmeticValue {
+    /// The left-hand operand of the arithmetic expression.
     pub left: Box<Value>,
+    /// The arithmetic operator (e.g. `"+"`, `"-"`, `"*"`, `"/"`).
     pub operator: String,
+    /// The right-hand operand of the arithmetic expression.
     pub right: Box<Value>,
 }
 
+/// A participant in a TypeQL relation.
+///
+/// Binds a role name to a player variable, representing one side of a
+/// relation pattern such as `friendship:friend($alice)`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RolePlayer {
+    /// The role name within the relation (e.g. `"friend"`, `"employee"`).
     pub role: String,
+    /// The variable name of the entity playing this role (e.g. `"$alice"`).
     pub player_var: String,
 }
 
+/// A constraint applied to a pattern variable.
+///
+/// Constraints narrow the results of a match clause by requiring an IID,
+/// an attribute ownership, or a type assertion on a variable.
+/// Uses tagged JSON serialization (`"type"` + `"data"`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data")]
 pub enum Constraint {
+    /// An internal identifier (IID) lookup constraint.
     Iid(String),
+    /// A has-attribute constraint requiring the variable to own an attribute
+    /// with the given name and value.
     Has {
+        /// The attribute type name (e.g. `"name"`, `"age"`).
         attr_name: String,
+        /// The expected value of the attribute.
         value: Value,
     },
+    /// A type assertion constraint (`isa` or `isa!`).
     Isa {
+        /// The type name to assert (e.g. `"person"`, `"company"`).
         type_name: String,
+        /// Whether to use strict type matching (`isa!`) rather than inclusive (`isa`).
         strict: bool,
     },
 }
 
+/// A match-clause pattern in TypeQL.
+///
+/// Patterns describe the shape of data to match in the database. They can
+/// represent entities, relations, subtypes, attributes, has-bindings,
+/// comparisons, negations, disjunctions, IID lookups, or raw TypeQL strings.
+/// Uses tagged JSON serialization (`"type"` + `"data"`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data")]
 pub enum Pattern {
+    /// An entity pattern matching a typed entity with optional constraints.
     Entity {
+        /// The query variable bound to this entity (e.g. `"$p"`).
         variable: String,
+        /// The entity type name (e.g. `"person"`).
         type_name: String,
+        /// Additional constraints on the entity (has-attribute, IID, etc.).
         constraints: Vec<Constraint>,
+        /// Whether to use strict type matching (`isa!`) instead of inclusive (`isa`).
         is_strict: bool,
     },
+    /// A relation pattern matching a typed relation with role players.
     Relation {
+        /// The query variable bound to this relation (e.g. `"$r"`).
         variable: String,
+        /// The relation type name (e.g. `"friendship"`).
         type_name: String,
+        /// The role players participating in this relation.
         role_players: Vec<RolePlayer>,
+        /// Additional constraints on the relation.
         constraints: Vec<Constraint>,
     },
+    /// A subtype pattern matching variables whose type is a subtype of a parent.
     SubType {
+        /// The query variable bound to the subtype.
         variable: String,
+        /// The parent type name to match subtypes of.
         parent_type: String,
     },
+    /// An attribute pattern matching a typed attribute with an optional value.
     Attribute {
+        /// The query variable bound to this attribute.
         variable: String,
+        /// The attribute type name (e.g. `"name"`, `"age"`).
         type_name: String,
+        /// An optional value to constrain the attribute to.
         value: Option<Value>,
     },
+    /// A has-binding pattern linking a thing variable to an attribute variable.
     Has {
+        /// The variable of the thing that owns the attribute.
         thing_var: String,
+        /// The attribute type name.
         attr_type: String,
+        /// The variable bound to the attribute instance.
         attr_var: String,
     },
+    /// A value comparison pattern (e.g. `$age > 18`).
     ValueComparison {
+        /// The variable being compared.
         var: String,
+        /// The comparison operator (e.g. `">"`, `"<"`, `"=="`, `"!="`, `">="`, `"<="`).
         operator: String,
+        /// The value to compare against.
         value: Value,
     },
+    /// A negation pattern — none of the inner patterns may match.
     Not(Vec<Pattern>),
+    /// A disjunction pattern — at least one branch of patterns must match.
+    /// Each inner `Vec<Pattern>` represents one branch of the `or`.
     Or(Vec<Vec<Pattern>>),
+    /// An IID lookup pattern matching a specific internal identifier.
     Iid {
+        /// The query variable bound to the thing with this IID.
         variable: String,
+        /// The internal identifier value.
         iid: String,
     },
+    /// A raw TypeQL string pattern, passed through without further processing.
     Raw(String),
 }
 
+/// A write-clause statement in TypeQL.
+///
+/// Statements describe mutations to perform in insert, delete, or update
+/// clauses. They can assign attributes, assert types, create relations,
+/// delete things, or pass through raw TypeQL strings.
+/// Uses tagged JSON serialization (`"type"` + `"data"`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data")]
 pub enum Statement {
+    /// A has-attribute statement assigning an attribute value to a subject.
     Has {
+        /// The variable of the subject that will own the attribute.
         subject_var: String,
+        /// The attribute type name (e.g. `"name"`, `"email"`).
         attr_name: String,
+        /// The value to assign to the attribute.
         value: Value,
     },
+    /// A type assertion statement (`isa`) declaring a variable's type.
     Isa {
+        /// The query variable being typed.
         variable: String,
+        /// The type name to assert (e.g. `"person"`, `"company"`).
         type_name: String,
     },
+    /// A relation creation statement with role players and optional inline attributes.
     Relation {
+        /// The query variable bound to the new relation.
         variable: String,
+        /// The relation type name (e.g. `"employment"`).
         type_name: String,
+        /// The role players participating in this relation.
         role_players: Vec<RolePlayer>,
+        /// Whether to include the variable assignment in the generated TypeQL.
         include_variable: bool,
-        attributes: Vec<Statement>, // Should be HasStatement but recursive enum needs care
+        /// Inline has-attribute statements on the relation (recursive `Statement::Has`).
+        attributes: Vec<Statement>,
     },
+    /// A delete statement removing a thing by its variable name.
     DeleteThing(String),
+    /// A raw TypeQL string statement, passed through without further processing.
     Raw(String),
 }
 
+/// A top-level query clause in TypeQL.
+///
+/// Clauses are the building blocks of a complete TypeQL query. A query is
+/// composed of one or more clauses chained together (e.g. match then fetch,
+/// match then insert, match then delete).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Clause {
+    /// A match clause containing patterns to match against the database.
     Match(Vec<Pattern>),
+    /// A match-let clause with variable bindings evaluated during matching.
     MatchLet(Vec<LetAssignment>),
+    /// An insert clause containing statements that create new data.
     Insert(Vec<Statement>),
+    /// A delete clause containing statements that remove existing data.
     Delete(Vec<Statement>),
+    /// An update clause containing statements that modify existing data.
     Update(Vec<Statement>),
+    /// A fetch clause specifying which attributes and values to return.
     Fetch(Vec<FetchItem>),
+    /// A reduce clause performing aggregations over matched results.
     Reduce {
+        /// The aggregation assignments (e.g. `$total = count($x)`).
         assignments: Vec<ReduceAssignment>,
+        /// An optional variable to group results by before aggregating.
         group_by: Option<String>,
     },
 }
 
+/// A variable binding in a match-let clause.
+///
+/// Assigns the result of an expression to one or more variables during
+/// the match phase, optionally as a stream of values.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LetAssignment {
+    /// The variable names to bind the expression result to.
     pub variables: Vec<String>,
+    /// The expression whose result is assigned to the variables.
     pub expression: Value,
+    /// Whether this assignment produces a stream of values rather than a single value.
     pub is_stream: bool,
 }
 
+/// An item in a fetch clause specifying what data to return.
+///
+/// Fetch items describe the shape of the query response, selecting specific
+/// attributes, variables, attribute lists, function results, or wildcards.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum FetchItem {
-    Attribute { key: String, var: String, attr_name: String },
-    Variable { key: String, var: String },
-    AttributeList { key: String, var: String, attr_name: String },
-    Function { key: String, func_name: String, var: String },
-    Wildcard { key: String, var: String },
-    NestedWildcard { key: String, var: String },
+    /// Fetch a single attribute value from a variable, keyed in the response.
+    Attribute {
+        /// The key name in the response object.
+        key: String,
+        /// The variable that owns the attribute.
+        var: String,
+        /// The attribute type name to fetch.
+        attr_name: String,
+    },
+    /// Fetch a variable's value directly, keyed in the response.
+    Variable {
+        /// The key name in the response object.
+        key: String,
+        /// The variable to fetch.
+        var: String,
+    },
+    /// Fetch all values of a multi-valued attribute as a list.
+    AttributeList {
+        /// The key name in the response object.
+        key: String,
+        /// The variable that owns the attribute.
+        var: String,
+        /// The attribute type name to fetch as a list.
+        attr_name: String,
+    },
+    /// Fetch the result of applying a function to a variable.
+    Function {
+        /// The key name in the response object.
+        key: String,
+        /// The function name to apply (e.g. `"count"`, `"sum"`).
+        func_name: String,
+        /// The variable to pass as the function argument.
+        var: String,
+    },
+    /// Fetch all attributes of a variable (wildcard expansion).
+    Wildcard {
+        /// The key name in the response object.
+        key: String,
+        /// The variable whose attributes are fetched.
+        var: String,
+    },
+    /// Fetch all attributes of a variable and its nested owned things.
+    NestedWildcard {
+        /// The key name in the response object.
+        key: String,
+        /// The variable whose attributes and nested things are fetched.
+        var: String,
+    },
 }
 
+/// An aggregation assignment in a reduce clause.
+///
+/// Binds the result of an aggregation expression to a variable name,
+/// such as `$total = count($x)` or `$avg_salary = mean($s)`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ReduceAssignment {
+    /// The variable name to bind the aggregation result to.
     pub variable: String,
+    /// The aggregation expression (typically a `Value::FunctionCall`).
     pub expression: Value,
 }

--- a/type-bridge-core/crates/core/src/compiler.rs
+++ b/type-bridge-core/crates/core/src/compiler.rs
@@ -1,5 +1,8 @@
+//! TypeQL query compiler — converts AST [`Clause`](crate::ast::Clause)s into TypeQL query strings.
+
 use crate::ast::{Clause, Pattern, Statement, Constraint, Value, LiteralValue, LetAssignment, FetchItem, ReduceAssignment};
 
+/// Compiles a sequence of [`Clause`] AST nodes into a TypeQL query string.
 pub struct QueryCompiler {
 }
 
@@ -10,10 +13,12 @@ impl Default for QueryCompiler {
 }
 
 impl QueryCompiler {
+    /// Create a new compiler instance.
     pub fn new() -> Self {
         QueryCompiler {}
     }
 
+    /// Compile a slice of clauses into a complete TypeQL query string.
     pub fn compile(&self, clauses: &[Clause]) -> String {
         clauses.iter()
             .map(|c| self.compile_clause(c))
@@ -21,6 +26,7 @@ impl QueryCompiler {
             .join("\n")
     }
 
+    /// Compile a single clause into its TypeQL string representation.
     pub fn compile_clause(&self, clause: &Clause) -> String {
         match clause {
             Clause::Match(patterns) => {

--- a/type-bridge-core/crates/core/src/lib.rs
+++ b/type-bridge-core/crates/core/src/lib.rs
@@ -1,8 +1,36 @@
+//! # type-bridge-core-lib
+//!
+//! Pure-Rust core library for **type-bridge**, providing a TypeQL AST,
+//! schema parser, query compiler, value coercer, and validation engine.
+//!
+//! ## Modules
+//!
+//! | Module | Purpose |
+//! |--------|---------|
+//! | [`ast`] | TypeQL Abstract Syntax Tree — patterns, statements, clauses, and values |
+//! | [`schema`] | Schema representation with entity / relation / attribute types and inheritance |
+//! | [`validation`] | Schema-aware query validation plus a custom validation-rule DSL |
+//! | [`compiler`] | Compiles an AST back into a TypeQL query string |
+//! | [`query_parser`] | Parses a TypeQL query string into the AST |
+//! | [`value_coercion`] | Coerces raw values into TypeDB value-types and formats TypeQL literals |
+//! | [`reserved_words`] | TypeQL reserved-word detection |
+//! | [`parser`] | Low-level PEG grammar consumed by [`query_parser`] |
+
+#![warn(missing_docs)]
+
+/// TypeQL Abstract Syntax Tree — patterns, statements, clauses, and values.
 pub mod ast;
+/// Compiles an AST back into a TypeQL query string.
 pub mod compiler;
+/// Low-level PEG grammar for TypeQL, consumed by [`query_parser`].
 pub mod parser;
+/// Parses a TypeQL query string into the AST.
 pub mod query_parser;
+/// TypeQL reserved-word detection.
 pub mod reserved_words;
+/// Schema representation with entity / relation / attribute types and inheritance.
 pub mod schema;
+/// Schema-aware query validation plus a custom validation-rule DSL.
 pub mod validation;
+/// Coerces raw values into TypeDB value-types and formats TypeQL literals.
 pub mod value_coercion;

--- a/type-bridge-core/crates/core/src/parser.rs
+++ b/type-bridge-core/crates/core/src/parser.rs
@@ -1,6 +1,6 @@
 //! Winnow-based parser for TypeQL `define` blocks.
 //!
-//! Converts TypeQL schema text into [`TypeSchema`] structs.
+//! Converts TypeQL schema text into [`TypeSchema`](crate::schema::TypeSchema) structs.
 //! Reference grammar: `type_bridge/generator/typeql.lark`
 
 use winnow::combinator::{alt, delimited, opt, repeat, separated, terminated};

--- a/type-bridge-core/crates/core/src/query_parser.rs
+++ b/type-bridge-core/crates/core/src/query_parser.rs
@@ -1,7 +1,7 @@
 //! Winnow-based parser for TypeQL data-manipulation queries.
 //!
 //! Converts TypeQL query strings (match, insert, delete, update, fetch, reduce)
-//! back into [`Clause`] AST nodes — the reverse of [`QueryCompiler`].
+//! back into [`Clause`](crate::ast::Clause) AST nodes — the reverse of [`QueryCompiler`](crate::compiler::QueryCompiler).
 
 use std::fmt;
 
@@ -25,9 +25,13 @@ type PResult<T> = winnow::error::Result<T>;
 /// Error returned by [`parse_typeql_query`].
 #[derive(Debug, Clone)]
 pub enum QueryParseError {
+    /// The TypeQL query string could not be parsed.
     ParseError {
+        /// Human-readable description of the parse failure.
         message: String,
+        /// 1-based line number where the error occurred.
         line: usize,
+        /// 1-based column number where the error occurred.
         column: usize,
     },
 }

--- a/type-bridge-core/crates/core/src/reserved_words.rs
+++ b/type-bridge-core/crates/core/src/reserved_words.rs
@@ -1,6 +1,9 @@
+//! TypeQL reserved words — keywords that cannot be used as type or variable names.
+
 use std::collections::HashSet;
 use once_cell::sync::Lazy;
 
+/// The set of all TypeQL reserved words (keywords, value types, built-in functions, etc.).
 pub static TYPEQL_RESERVED_WORDS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
     let mut m = HashSet::new();
     // Schema queries
@@ -105,6 +108,7 @@ pub static TYPEQL_RESERVED_WORDS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
     m
 });
 
+/// Check whether `name` is a TypeQL reserved word (case-insensitive).
 pub fn is_reserved_word(name: &str) -> bool {
     TYPEQL_RESERVED_WORDS.contains(name.to_lowercase().as_str())
 }

--- a/type-bridge-core/crates/core/src/schema.rs
+++ b/type-bridge-core/crates/core/src/schema.rs
@@ -6,29 +6,49 @@ use std::fmt;
 // Error types
 // ---------------------------------------------------------------------------
 
+/// Errors that can occur during schema parsing, validation, or inheritance resolution.
+///
+/// Each variant captures the specific context needed to produce a helpful error
+/// message (e.g. source location for parse errors, the cycle participant for
+/// inheritance cycles).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SchemaError {
+    /// A syntax error encountered while parsing a TypeQL `define` block.
     ParseError {
+        /// Human-readable description of what went wrong.
         message: String,
+        /// 1-based line number where the error was detected.
         line: usize,
+        /// 1-based column number where the error was detected.
         column: usize,
     },
+    /// A cycle was detected in the `sub` (inheritance) chain of a type.
     InheritanceCycle {
+        /// The name of the type involved in the cycle.
         type_name: String,
     },
+    /// A type declares a parent (`sub`) that does not exist in the schema.
     UnknownParent {
+        /// The child type that references a missing parent.
         child: String,
+        /// The parent type name that could not be found.
         parent: String,
     },
+    /// Two definitions with the same name and kind were found in the schema.
     DuplicateDefinition {
+        /// The duplicated type name.
         name: String,
+        /// The kind of type that was duplicated (e.g. `"entity"`, `"relation"`, `"attribute"`).
         kind: String,
     },
+    /// A semantic validation error (e.g. invalid cardinality bounds, bad regex pattern).
     ValidationError {
+        /// Human-readable description of the validation failure.
         message: String,
     },
 }
 
+/// Formats a [`SchemaError`] into a human-readable error message.
 impl fmt::Display for SchemaError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -57,29 +77,49 @@ impl fmt::Display for SchemaError {
     }
 }
 
+/// Enables [`SchemaError`] to be used as a standard Rust error type.
 impl std::error::Error for SchemaError {}
 
 // ---------------------------------------------------------------------------
 // Cardinality
 // ---------------------------------------------------------------------------
 
+/// Ownership or role-play cardinality constraint, corresponding to the
+/// TypeQL `@card(min..max)` annotation.
+///
+/// Examples:
+/// - `@card(1..1)` -- exactly one (default for most ownership)
+/// - `@card(0..5)` -- zero to five
+/// - `@card(1..)` -- one or more (unbounded upper bound)
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Cardinality {
+    /// Minimum number of values or role-players required.
     pub min: u32,
-    pub max: Option<u32>, // None = unbounded
+    /// Maximum number of values or role-players allowed, or `None` for unbounded.
+    pub max: Option<u32>,
 }
 
 // ---------------------------------------------------------------------------
 // OwnedAttribute
 // ---------------------------------------------------------------------------
 
+/// An attribute ownership declaration on an entity or relation type.
+///
+/// Corresponds to a TypeQL `owns <attribute>` clause, optionally annotated
+/// with `@key`, `@unique`, `@cascade`, `@subkey`, or `@card`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OwnedAttribute {
+    /// The name of the owned attribute type (must exist in the schema's attributes map).
     pub name: String,
+    /// Whether this attribute is annotated with `@key`, making it a unique identifier.
     pub is_key: bool,
+    /// Whether this attribute is annotated with `@unique`.
     pub is_unique: bool,
+    /// Whether deleting this owner should cascade-delete the attribute instance.
     pub is_cascade: bool,
+    /// Optional `@subkey(<label>)` group identifier for composite key membership.
     pub subkey_group: Option<String>,
+    /// Optional `@card(min..max)` cardinality constraint on the ownership.
     pub cardinality: Option<Cardinality>,
 }
 
@@ -87,9 +127,13 @@ pub struct OwnedAttribute {
 // PlayedRole
 // ---------------------------------------------------------------------------
 
+/// A role that an entity or relation type can play, corresponding to a
+/// TypeQL `plays <relation>:<role>` clause.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlayedRole {
-    pub role_ref: String, // e.g. "friendship:friend"
+    /// Fully-qualified role reference in `"<relation>:<role>"` format (e.g. `"friendship:friend"`).
+    pub role_ref: String,
+    /// Optional `@card(min..max)` cardinality constraint on playing this role.
     pub cardinality: Option<Cardinality>,
 }
 
@@ -97,11 +141,21 @@ pub struct PlayedRole {
 // RoleSpec
 // ---------------------------------------------------------------------------
 
+/// A role defined within a relation type, corresponding to a TypeQL
+/// `relates <role>` clause.
+///
+/// Roles may override a parent relation's role via the `as` keyword
+/// (e.g. `relates author as contributor`), carry a cardinality constraint,
+/// or be marked `@distinct`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RoleSpec {
+    /// The local name of the role (e.g. `"friend"`, `"author"`).
     pub name: String,
-    pub overrides: Option<String>, // For "relates author as contributor"
+    /// If this role overrides a parent relation's role, the parent role name (e.g. `"contributor"`).
+    pub overrides: Option<String>,
+    /// Optional `@card(min..max)` cardinality constraint on the role.
     pub cardinality: Option<Cardinality>,
+    /// Whether the role is annotated with `@distinct`, requiring unique role-players.
     pub distinct: bool,
 }
 
@@ -109,16 +163,30 @@ pub struct RoleSpec {
 // AttributeType
 // ---------------------------------------------------------------------------
 
+/// A TypeDB attribute type definition.
+///
+/// Attribute types hold the value-type information (e.g. `string`, `long`,
+/// `double`) and optional constraints such as `@regex`, `@values`, and
+/// `@range`. They may also form an inheritance hierarchy via `sub`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AttributeType {
+    /// The attribute type name (e.g. `"name"`, `"email"`, `"age"`).
     pub name: String,
+    /// The TypeDB value type (e.g. `"string"`, `"long"`, `"double"`, `"boolean"`, `"datetime"`).
     pub value_type: String,
+    /// Optional parent attribute type name for inheritance (`sub` clause).
     pub parent: Option<String>,
+    /// Whether the attribute type is declared `@abstract`.
     pub is_abstract: bool,
+    /// Whether the attribute type is declared `@independent` (can exist without an owner).
     pub is_independent: bool,
+    /// Optional `@regex` pattern constraining string attribute values.
     pub regex: Option<String>,
+    /// Optional `@values` enumeration constraining allowed attribute values.
     pub allowed_values: Option<Vec<String>>,
+    /// Optional lower bound of a `@range` constraint (inclusive), as a string literal.
     pub range_min: Option<String>,
+    /// Optional upper bound of a `@range` constraint (inclusive), as a string literal.
     pub range_max: Option<String>,
 }
 
@@ -126,13 +194,24 @@ pub struct AttributeType {
 // EntityType
 // ---------------------------------------------------------------------------
 
+/// A TypeDB entity type definition.
+///
+/// Entities are independent objects in the TypeDB type system. They can own
+/// attributes, play roles in relations, and form an inheritance hierarchy
+/// via the `sub` keyword.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EntityType {
+    /// The entity type name (e.g. `"person"`, `"company"`).
     pub name: String,
+    /// Optional parent entity type name for inheritance (`sub` clause).
     pub parent: Option<String>,
+    /// Whether the entity type is declared `@abstract`.
     pub is_abstract: bool,
+    /// Attributes owned by this entity type (includes inherited attributes after resolution).
     pub owns: Vec<OwnedAttribute>,
+    /// Attribute names in declaration order (parent attributes first after inheritance resolution).
     pub owns_order: Vec<String>,
+    /// Roles this entity type can play (includes inherited roles after resolution).
     pub plays: Vec<PlayedRole>,
 }
 
@@ -140,14 +219,27 @@ pub struct EntityType {
 // RelationType
 // ---------------------------------------------------------------------------
 
+/// A TypeDB relation type definition.
+///
+/// Relations connect entities (and other relations) via named roles. Like
+/// entities, they can own attributes, play roles, and participate in an
+/// inheritance hierarchy. Child relations may override parent roles using
+/// the `as` keyword.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RelationType {
+    /// The relation type name (e.g. `"friendship"`, `"employment"`).
     pub name: String,
+    /// Optional parent relation type name for inheritance (`sub` clause).
     pub parent: Option<String>,
+    /// Whether the relation type is declared `@abstract`.
     pub is_abstract: bool,
+    /// Roles defined by this relation (includes inherited roles after resolution).
     pub roles: Vec<RoleSpec>,
+    /// Attributes owned by this relation type (includes inherited attributes after resolution).
     pub owns: Vec<OwnedAttribute>,
+    /// Attribute names in declaration order (parent attributes first after inheritance resolution).
     pub owns_order: Vec<String>,
+    /// Roles this relation type can play (includes inherited roles after resolution).
     pub plays: Vec<PlayedRole>,
 }
 
@@ -155,20 +247,39 @@ pub struct RelationType {
 // TypeSchema
 // ---------------------------------------------------------------------------
 
+/// The complete parsed TypeDB schema containing all attribute, entity, and
+/// relation type definitions.
+///
+/// This is the main entry point for working with a TypeDB schema in Rust.
+/// Create one via [`TypeSchema::from_typeql()`] to parse a TypeQL `define`
+/// block, which performs parsing, validation, and inheritance resolution in
+/// one step. Alternatively, build one programmatically and call
+/// `resolve_inheritance()` yourself.
+///
+/// After construction, use the lookup methods (`get_entity`, `get_relation`,
+/// `get_attribute`) and the inheritance-aware accessors
+/// (`get_all_owned_attributes`, `get_all_plays_roles`, `get_all_relates`)
+/// to inspect the resolved type system.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TypeSchema {
+    /// All entity type definitions, keyed by type name. Sorted alphabetically (BTreeMap).
     pub entities: BTreeMap<String, EntityType>,
+    /// All relation type definitions, keyed by type name. Sorted alphabetically (BTreeMap).
     pub relations: BTreeMap<String, RelationType>,
+    /// All attribute type definitions, keyed by type name. Sorted alphabetically (BTreeMap).
     pub attributes: BTreeMap<String, AttributeType>,
 }
 
+/// Provides a default empty [`TypeSchema`] by delegating to [`TypeSchema::new()`].
 impl Default for TypeSchema {
     fn default() -> Self {
         Self::new()
     }
 }
 
+/// Core methods for constructing, querying, validating, and resolving a [`TypeSchema`].
 impl TypeSchema {
+    /// Creates an empty `TypeSchema` with no types defined.
     pub fn new() -> Self {
         TypeSchema {
             entities: BTreeMap::new(),

--- a/type-bridge-core/crates/core/src/validation.rs
+++ b/type-bridge-core/crates/core/src/validation.rs
@@ -9,23 +9,52 @@ use unicode_ident::{is_xid_start, is_xid_continue};
 // Result types
 // ---------------------------------------------------------------------------
 
+/// The severity level of a validation diagnostic.
+///
+/// `Error` indicates a hard failure that makes the result invalid.
+/// `Warning` indicates a potential issue that does not invalidate the result.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ValidationSeverity {
+    /// A hard validation error. Any result containing at least one `Error`
+    /// is considered invalid (`is_valid == false`).
     Error,
+    /// A soft warning. Warnings are reported but do not cause the overall
+    /// validation result to be invalid.
     Warning,
 }
 
+/// The outcome of a validation pass.
+///
+/// Contains a boolean `is_valid` flag (true when no `Error`-severity
+/// diagnostics are present) and the full list of diagnostics (errors and
+/// warnings).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ValidationResult {
+    /// Whether the validated input is considered valid.
+    ///
+    /// This is `true` when there are no diagnostics with
+    /// [`ValidationSeverity::Error`]; warnings alone do not invalidate.
     pub is_valid: bool,
+    /// The list of validation diagnostics (errors and warnings).
     pub errors: Vec<ValidationError>,
 }
 
+/// A single validation diagnostic produced by the engine.
+///
+/// Each error carries a machine-readable `code`, a human-readable `message`,
+/// a `path` indicating where in the query/data the issue was found, and a
+/// `severity` level.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ValidationError {
+    /// A machine-readable error code (e.g. `"UNKNOWN_TYPE"`,
+    /// `"RULE_REQUIRED"`).
     pub code: String,
+    /// A human-readable description of the issue.
     pub message: String,
+    /// A dot-separated path indicating the location of the issue within the
+    /// validated structure (e.g. `"clauses[0].patterns[1].constraints[0]"`).
     pub path: String,
+    /// The severity of this diagnostic (`Error` or `Warning`).
     pub severity: ValidationSeverity,
 }
 
@@ -106,43 +135,98 @@ fn value_types_compatible(literal_type: &str, schema_type: &str) -> bool {
 // Custom validation rules (JSON DSL)
 // ---------------------------------------------------------------------------
 
+/// The target that a custom validation rule applies to.
+///
+/// Rules can target either any instance of a particular attribute type, or
+/// a specific entity-attribute combination.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data")]
 pub enum RuleTarget {
-    /// Applies to any instance of this attribute type.
-    Attribute { attribute: String },
-    /// Applies only when a specific entity/relation owns the attribute.
-    EntityAttribute { entity: String, attribute: String },
+    /// Applies to any instance of this attribute type, regardless of which
+    /// entity or relation owns it.
+    Attribute {
+        /// The name of the attribute type this rule targets.
+        attribute: String,
+    },
+    /// Applies only when a specific entity type owns the attribute.
+    EntityAttribute {
+        /// The name of the entity type that must own the attribute for the
+        /// rule to apply.
+        entity: String,
+        /// The name of the attribute type this rule targets.
+        attribute: String,
+    },
 }
 
+/// The kind of constraint that a custom validation rule enforces.
+///
+/// Each variant corresponds to a different check (presence, pattern matching,
+/// numeric range, allowed values, cardinality, or string length).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data")]
 pub enum RuleType {
     /// Attribute must be present (non-null, non-missing).
     Required,
     /// String must match the given regex pattern.
-    Regex { pattern: String },
+    Regex {
+        /// The regular expression pattern that the string value must match.
+        pattern: String,
+    },
     /// Numeric value must be within [min, max]. Either bound can be None.
-    Range { min: Option<f64>, max: Option<f64> },
+    Range {
+        /// The minimum allowed value (inclusive), or `None` for no lower bound.
+        min: Option<f64>,
+        /// The maximum allowed value (inclusive), or `None` for no upper bound.
+        max: Option<f64>,
+    },
     /// Value must be one of the allowed values.
-    Values { allowed: Vec<serde_json::Value> },
+    Values {
+        /// The set of allowed values. Any value not in this list is rejected.
+        allowed: Vec<serde_json::Value>,
+    },
     /// Multi-value attribute count must be within [min, max].
-    Cardinality { min: u32, max: Option<u32> },
+    Cardinality {
+        /// The minimum number of values required.
+        min: u32,
+        /// The maximum number of values allowed, or `None` for no upper bound.
+        max: Option<u32>,
+    },
     /// String length must be within [min, max].
-    Length { min: Option<u32>, max: Option<u32> },
+    Length {
+        /// The minimum string length (inclusive), or `None` for no lower bound.
+        min: Option<u32>,
+        /// The maximum string length (inclusive), or `None` for no upper bound.
+        max: Option<u32>,
+    },
 }
 
+/// A single custom validation rule.
+///
+/// Each rule has a unique `id`, a [`RuleTarget`] that determines which
+/// attributes it applies to, a [`RuleType`] that specifies the constraint,
+/// and an optional custom error message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ValidationRule {
+    /// A unique identifier for this rule (e.g. `"email-regex"`).
     pub id: String,
+    /// The target that this rule applies to (attribute or entity-attribute).
     pub target: RuleTarget,
+    /// The type of constraint this rule enforces.
     pub rule_type: RuleType,
+    /// An optional custom error message. When set, this message is used
+    /// instead of the auto-generated default.
     #[serde(default)]
     pub error_message: Option<String>,
 }
 
+/// A named collection of custom validation rules.
+///
+/// This is the top-level structure used for JSON serialization/deserialization
+/// of rule sets via [`ValidationEngine::load_rules`] and
+/// [`ValidationEngine::export_rules`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ValidationRuleSet {
+    /// The list of validation rules in this set.
     pub rules: Vec<ValidationRule>,
 }
 
@@ -162,6 +246,23 @@ fn extract_values<'a>(
 // ValidationEngine
 // ---------------------------------------------------------------------------
 
+/// The main validation engine for TypeQL queries and entity data.
+///
+/// `ValidationEngine` provides two categories of validation:
+///
+/// 1. **Syntactic validation** -- checks type names, variable names, patterns,
+///    and statements for well-formedness (e.g. reserved words, valid
+///    identifiers, `$`-prefixed variables).
+///
+/// 2. **Schema-aware semantic validation** -- given a [`TypeSchema`], checks
+///    that types exist, ownership is valid, role players match declared roles,
+///    value types are compatible, abstract types are not instantiated, and
+///    cardinality constraints are respected.
+///
+/// Additionally, the engine supports **custom validation rules** defined via a
+/// portable JSON DSL. Rules can enforce required fields, regex patterns,
+/// numeric ranges, allowed value sets, cardinality bounds, and string length
+/// limits on entity data.
 pub struct ValidationEngine {
     rules: Vec<ValidationRule>,
     /// Pre-compiled regex cache: rule_id → compiled Regex.
@@ -175,6 +276,7 @@ impl Default for ValidationEngine {
 }
 
 impl ValidationEngine {
+    /// Create a new `ValidationEngine` with no custom rules loaded.
     pub fn new() -> Self {
         ValidationEngine {
             rules: Vec::new(),
@@ -186,7 +288,11 @@ impl ValidationEngine {
     // Rule management
     // -----------------------------------------------------------------------
 
-    /// Add a single validation rule. Pre-compiles regex patterns.
+    /// Add a single custom validation rule to the engine.
+    ///
+    /// If the rule contains a [`RuleType::Regex`] variant, the pattern is
+    /// pre-compiled and cached. Returns `Err` with a description if the regex
+    /// pattern is invalid; in that case the rule is **not** added.
     pub fn add_rule(&mut self, rule: ValidationRule) -> Result<(), String> {
         if let RuleType::Regex { ref pattern } = rule.rule_type {
             let compiled = regex::Regex::new(pattern)
@@ -197,7 +303,12 @@ impl ValidationEngine {
         Ok(())
     }
 
-    /// Load rules from a JSON string. Returns list of warnings for invalid rules.
+    /// Load a set of custom validation rules from a JSON string.
+    ///
+    /// The JSON must conform to the [`ValidationRuleSet`] schema. Rules with
+    /// invalid regex patterns are skipped (not added) and their error messages
+    /// are returned as warnings. Returns `Err` if the JSON itself cannot be
+    /// parsed.
     pub fn load_rules(&mut self, json_str: &str) -> Result<Vec<String>, String> {
         let ruleset: ValidationRuleSet = serde_json::from_str(json_str)
             .map_err(|e| format!("Failed to parse rules JSON: {}", e))?;
@@ -210,19 +321,22 @@ impl ValidationEngine {
         Ok(warnings)
     }
 
-    /// Export current rules as a JSON string.
+    /// Export all currently loaded rules as a pretty-printed JSON string.
+    ///
+    /// The output conforms to the [`ValidationRuleSet`] schema and can be
+    /// re-loaded with [`load_rules`](Self::load_rules).
     pub fn export_rules(&self) -> Result<String, String> {
         let ruleset = ValidationRuleSet { rules: self.rules.clone() };
         serde_json::to_string_pretty(&ruleset).map_err(|e| e.to_string())
     }
 
-    /// Remove all rules.
+    /// Remove all custom validation rules and clear the regex cache.
     pub fn clear_rules(&mut self) {
         self.rules.clear();
         self.regex_cache.clear();
     }
 
-    /// Get the number of loaded rules.
+    /// Return the number of currently loaded custom validation rules.
     pub fn rule_count(&self) -> usize {
         self.rules.len()
     }
@@ -231,6 +345,18 @@ impl ValidationEngine {
     // Syntactic validation (unchanged API, now with severity field)
     // -----------------------------------------------------------------------
 
+    /// Validate that a variable name is well-formed.
+    ///
+    /// A valid variable name must start with `$` and have at least one
+    /// character after it. Returns a list of [`ValidationError`] diagnostics
+    /// (empty if the name is valid).
+    ///
+    /// # Arguments
+    ///
+    /// * `name` -- The variable name to validate (e.g. `"$p"`).
+    /// * `context` -- A human-readable context string for error messages
+    ///   (e.g. `"Entity"`, `"Relation"`).
+    /// * `path` -- The structural path for error reporting.
     pub fn validate_variable_name(&self, name: &str, context: &str, path: &str) -> Vec<ValidationError> {
         let mut errors = Vec::new();
         if !name.starts_with('$') {
@@ -241,6 +367,18 @@ impl ValidationEngine {
         errors
     }
 
+    /// Validate that a type name is well-formed.
+    ///
+    /// Checks that the name is non-empty, is not a TypeQL reserved word,
+    /// starts with a letter or underscore, and contains only valid identifier
+    /// characters (Unicode XID_Continue plus hyphen `-`).
+    ///
+    /// # Arguments
+    ///
+    /// * `name` -- The type name to validate (e.g. `"person"`,
+    ///   `"first-name"`).
+    /// * `context` -- A human-readable context string for error messages
+    ///   (e.g. `"Entity type"`, `"Attribute type"`).
     pub fn validate_type_name(&self, name: &str, context: &str) -> ValidationResult {
         let mut errors = Vec::new();
 
@@ -275,6 +413,12 @@ impl ValidationEngine {
         res.errors.into_iter().map(|mut e| { e.path = path.to_string(); e }).collect()
     }
 
+    /// Validate the syntactic structure of a single pattern.
+    ///
+    /// Recursively checks all variable names, type names, constraints, and
+    /// nested patterns (e.g. `Not`, `Or`) within the given [`Pattern`].
+    /// Does **not** perform schema-aware checks; use [`validate_query`](Self::validate_query)
+    /// for semantic validation.
     pub fn validate_pattern(&self, pattern: &Pattern) -> ValidationResult {
         let mut errors = Vec::new();
         self.validate_pattern_recursive(pattern, "pattern", &mut errors);
@@ -341,6 +485,11 @@ impl ValidationEngine {
         }
     }
 
+    /// Validate the syntactic structure of a single statement.
+    ///
+    /// Recursively checks variable names, type names, role players, and
+    /// inline attributes within the given [`Statement`]. Does **not** perform
+    /// schema-aware checks.
     pub fn validate_statement(&self, statement: &Statement) -> ValidationResult {
         let mut errors = Vec::new();
         self.validate_statement_recursive(statement, "statement", &mut errors);
@@ -416,6 +565,16 @@ impl ValidationEngine {
     ///
     /// This performs both syntactic validation (names, variables) and semantic
     /// validation (ownership, roles, value types, abstract types, cardinality).
+    ///
+    /// The engine first builds a type environment by scanning all `Match`
+    /// clauses to bind variables to their declared types, then validates each
+    /// clause against the schema and the inferred environment.
+    ///
+    /// # Arguments
+    ///
+    /// * `clauses` -- The ordered list of query clauses (Match, Insert,
+    ///   Delete, Update, Fetch, etc.).
+    /// * `schema` -- The [`TypeSchema`] describing the database's type system.
     pub fn validate_query(&self, clauses: &[Clause], schema: &TypeSchema) -> ValidationResult {
         let mut errors = Vec::new();
 
@@ -927,10 +1086,20 @@ impl ValidationEngine {
     // Entity data validation (custom rules)
     // -----------------------------------------------------------------------
 
-    /// Validate entity data against loaded rules and optionally a schema.
+    /// Validate entity data against loaded custom rules and optionally a schema.
     ///
-    /// `entity_data` is a JSON object with `__type__` (entity type name) and
-    /// attribute_name → value(s) pairs.
+    /// `entity_data` must be a JSON object containing a `__type__` field that
+    /// identifies the entity type, along with attribute-name to value(s)
+    /// mappings. Each loaded rule whose target matches the entity type and
+    /// attribute is evaluated.
+    ///
+    /// # Arguments
+    ///
+    /// * `entity_data` -- A JSON object with `"__type__"` (entity type name)
+    ///   and attribute_name to value(s) pairs.
+    /// * `schema` -- An optional [`TypeSchema`] used to resolve ownership
+    ///   when determining whether an `Attribute`-targeted rule applies to the
+    ///   entity.
     pub fn validate_entity(
         &self,
         entity_data: &serde_json::Value,

--- a/type-bridge-core/crates/core/src/value_coercion.rs
+++ b/type-bridge-core/crates/core/src/value_coercion.rs
@@ -1,3 +1,9 @@
+//! Value coercion and formatting for TypeDB value types.
+//!
+//! Converts JSON values to typed TypeDB values (string, long, double, boolean,
+//! decimal, date, datetime, datetime-tz, duration) with validation and range
+//! checking, and formats them as TypeQL literals.
+
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
@@ -6,27 +12,43 @@ use std::fmt;
 // Types
 // ---------------------------------------------------------------------------
 
+/// A value that has been coerced to a specific TypeDB value type.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CoercedValue {
+    /// The coerced JSON value.
     pub value: serde_json::Value,
+    /// The TypeDB value type (e.g. `"string"`, `"long"`, `"datetime"`).
     pub value_type: String,
 }
 
+/// Error returned when value coercion fails.
 #[derive(Debug, Clone)]
 pub enum CoercionError {
+    /// The value's type does not match the expected TypeDB type.
     TypeMismatch {
+        /// String representation of the value.
         value: String,
+        /// The expected TypeDB value type.
         expected: String,
+        /// The actual type encountered.
         actual: String,
     },
+    /// The value's format is invalid for the target type (e.g. bad date string).
     InvalidFormat {
+        /// String representation of the value.
         value: String,
+        /// The target TypeDB value type.
         expected_type: String,
+        /// Human-readable description of the format error.
         message: String,
     },
+    /// The value is outside the allowed range for the target type.
     OutOfRange {
+        /// String representation of the value.
         value: String,
+        /// The target TypeDB value type.
         expected_type: String,
+        /// Human-readable description of the range violation.
         message: String,
     },
 }
@@ -117,6 +139,7 @@ fn parse_digits(s: &str, n: usize) -> Option<(u32, &str)> {
 }
 
 /// Validate a date string in YYYY-MM-DD format.
+/// Validate that a string is a well-formed ISO 8601 date (`YYYY-MM-DD`).
 pub fn validate_date(s: &str) -> Result<(), String> {
     let (year, rest) = parse_digits(s, 4).ok_or("Expected 4-digit year")?;
     if !rest.starts_with('-') {
@@ -186,6 +209,7 @@ fn parse_time_part(s: &str) -> Result<&str, String> {
 
 /// Validate a datetime string: YYYY-MM-DDTHH:MM:SS[.ffffff]
 /// Rejects if timezone offset is present.
+/// Validate that a string is a well-formed ISO 8601 datetime (`YYYY-MM-DDThh:mm:ss[.fff]`).
 pub fn validate_datetime(s: &str) -> Result<(), String> {
     // Parse date part
     let (year, rest) = parse_digits(s, 4).ok_or("Expected 4-digit year")?;
@@ -229,6 +253,8 @@ pub fn validate_datetime(s: &str) -> Result<(), String> {
 
 /// Validate a datetime-tz string: YYYY-MM-DDTHH:MM:SS[.ffffff](+HH:MM|-HH:MM|Z)
 /// Requires timezone offset.
+/// Validate that a string is a well-formed datetime with timezone offset
+/// (`YYYY-MM-DDThh:mm:ss[.fff]+HH:MM` or `Z` suffix).
 pub fn validate_datetime_tz(s: &str) -> Result<(), String> {
     // Parse date part
     let (year, rest) = parse_digits(s, 4).ok_or("Expected 4-digit year")?;
@@ -291,7 +317,7 @@ pub fn validate_datetime_tz(s: &str) -> Result<(), String> {
     Err("datetime-tz requires timezone offset (+HH:MM, -HH:MM, or Z)".into())
 }
 
-/// Validate an ISO 8601 duration string: P[nY][nM][nD][T[nH][nM][n.nS]]
+/// Validate that a string is a well-formed ISO 8601 duration (`PnYnMnDTnHnMnS`).
 pub fn validate_duration(s: &str) -> Result<(), String> {
     if !s.starts_with('P') {
         return Err("Duration must start with 'P'".into());
@@ -361,6 +387,9 @@ pub fn validate_duration(s: &str) -> Result<(), String> {
 // ValueCoercer
 // ---------------------------------------------------------------------------
 
+/// Coerces JSON values to typed TypeDB values and formats them as TypeQL literals.
+///
+/// Supports optional per-attribute range constraints for numeric types.
 pub struct ValueCoercer {
     range_constraints: HashMap<String, (Option<f64>, Option<f64>)>,
 }
@@ -372,6 +401,7 @@ impl Default for ValueCoercer {
 }
 
 impl ValueCoercer {
+    /// Create a new coercer with no range constraints.
     pub fn new() -> Self {
         ValueCoercer {
             range_constraints: HashMap::new(),

--- a/type-bridge-core/crates/python/Cargo.toml
+++ b/type-bridge-core/crates/python/Cargo.toml
@@ -2,6 +2,10 @@
 name = "type-bridge-core"
 version = "0.1.0-dev.0"
 edition = "2024"
+description = "PyO3 bindings exposing the type-bridge Rust core to Python"
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
 
 [lib]
 name = "type_bridge_core"

--- a/type-bridge-core/crates/python/README.md
+++ b/type-bridge-core/crates/python/README.md
@@ -1,0 +1,74 @@
+# type-bridge-core (Python bindings)
+
+PyO3 bindings that expose the **type-bridge** Rust core to Python.
+
+## Overview
+
+This crate wraps [`type-bridge-core-lib`](../core/) and exposes it as a native
+Python extension module via [PyO3](https://pyo3.rs) and
+[maturin](https://www.maturin.rs).
+
+All complex types cross the Python ↔ Rust boundary via
+`pythonize` / `depythonize` using **serde-tagged-enum dicts**:
+
+```python
+# Pattern dict format (serde tag = "type", content = "data")
+pattern = {
+    "type": "Entity",
+    "data": {
+        "variable": "$p",
+        "type_name": "person",
+        "constraints": [],
+        "is_strict": False,
+    },
+}
+```
+
+## Available Python classes
+
+| Class | Wraps |
+|-------|-------|
+| `ValidationEngine` | `type_bridge_core_lib::validation::ValidationEngine` |
+| `QueryCompiler` | `type_bridge_core_lib::compiler::QueryCompiler` |
+| `TypeSchema` | `type_bridge_core_lib::schema::TypeSchema` |
+| `ValueCoercer` | `type_bridge_core_lib::value_coercion::ValueCoercer` |
+
+**Standalone functions:** `parse_typeql_query()`, `format_value()`, `coerce_value()`
+
+**AST wrappers:** `EntityPattern`, `RelationPattern`, `MatchClause`, `InsertClause`, etc. (mirrors of `type_bridge_core_lib::ast`)
+
+## Building
+
+```bash
+cd type-bridge-core
+
+# Development build (editable)
+PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 maturin develop
+
+# Release build
+PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 maturin build --release
+```
+
+> **Note:** `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` is required when your
+> local Python version exceeds PyO3's maximum supported version (currently 3.13).
+
+## Usage from Python
+
+```python
+from type_bridge_core import ValidationEngine, QueryCompiler, TypeSchema
+
+# Parse and compile
+compiler = QueryCompiler()
+clauses = compiler.parse("match $p isa person, has name 'Alice';")
+typeql = compiler.compile(clauses)
+
+# Schema-aware validation
+schema = TypeSchema.from_typeql("define entity person, owns name; attribute name, value string;")
+engine = ValidationEngine()
+result = schema.validate_query(clauses)
+print(result)  # {"is_valid": true, "errors": []}
+```
+
+## License
+
+MIT

--- a/type-bridge-core/crates/python/src/ast/mod.rs
+++ b/type-bridge-core/crates/python/src/ast/mod.rs
@@ -1,3 +1,10 @@
+//! PyO3 wrapper types that mirror [`type_bridge_core_lib::ast`].
+//!
+//! These are 1:1 Python-facing re-exports of the core AST structs and are
+//! intentionally undocumented — see the core crate for semantics.
+
+#![allow(missing_docs)]
+
 use pyo3::prelude::*;
 
 #[pyclass(get_all, set_all)]

--- a/type-bridge-core/crates/python/src/lib.rs
+++ b/type-bridge-core/crates/python/src/lib.rs
@@ -1,3 +1,18 @@
+//! # type-bridge-core (Python)
+//!
+//! PyO3 bindings that expose the **type-bridge** Rust core to Python.
+//!
+//! This crate re-exports the core AST types as Python classes and provides
+//! thin wrappers around [`type_bridge_core_lib::validation::ValidationEngine`],
+//! [`type_bridge_core_lib::compiler::QueryCompiler`],
+//! [`type_bridge_core_lib::schema::TypeSchema`], and
+//! [`type_bridge_core_lib::value_coercion::ValueCoercer`].
+//!
+//! All complex types cross the Python ↔ Rust boundary via
+//! `pythonize` / `depythonize` using serde-tagged-enum dicts.
+
+#![warn(missing_docs)]
+
 pub mod ast;
 
 use type_bridge_core_lib as core;
@@ -6,6 +21,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyBool;
 use pythonize::{depythonize, pythonize};
 
+/// Python-facing wrapper around the Rust [`type_bridge_core_lib::validation::ValidationEngine`].
 #[pyclass]
 pub struct ValidationEngine {
     inner: core::validation::ValidationEngine,
@@ -136,6 +152,7 @@ impl ValidationEngine {
     }
 }
 
+/// Python-facing wrapper around the Rust [`type_bridge_core_lib::compiler::QueryCompiler`].
 #[pyclass]
 pub struct QueryCompiler {
     inner: core::compiler::QueryCompiler,
@@ -182,6 +199,7 @@ impl QueryCompiler {
     }
 }
 
+/// Python-facing wrapper around the Rust [`type_bridge_core_lib::schema::TypeSchema`].
 #[pyclass]
 pub struct TypeSchema {
     inner: core::schema::TypeSchema,
@@ -291,6 +309,7 @@ impl TypeSchema {
     }
 }
 
+/// Python-facing wrapper around the Rust [`type_bridge_core_lib::value_coercion::ValueCoercer`].
 #[pyclass]
 pub struct ValueCoercer {
     inner: core::value_coercion::ValueCoercer,

--- a/type-bridge-core/crates/server/Cargo.toml
+++ b/type-bridge-core/crates/server/Cargo.toml
@@ -2,6 +2,10 @@
 name = "type-bridge-server"
 version = "0.1.0-dev.0"
 edition = "2024"
+description = "Query-intercepting proxy server for TypeDB with validation and audit logging"
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
 
 [lib]
 name = "type_bridge_server"

--- a/type_bridge/generator/utils/common.py
+++ b/type_bridge/generator/utils/common.py
@@ -1,12 +1,10 @@
 """Common utility functions for code generation."""
 
 from collections.abc import Callable
-from typing import Any, TypeVar
-
-T = TypeVar("T")
+from typing import Any
 
 
-def topological_sort(
+def topological_sort[T](
     items: dict[str, T],
     get_parent: Callable[[T], str | None],
 ) -> list[str]:


### PR DESCRIPTION
- Add Cargo.toml metadata (license, repository, authors) to workspace and all 3 crates
- Add #![warn(missing_docs)] to core and python crates with 0 warnings
- Document all 248 public items in the core crate (ast, schema, validation, value_coercion, compiler, query_parser, reserved_words)
- Add crate-level //! docs and /// module docs to all modules
- Document python crate public structs, add #[allow(missing_docs)] on PyO3 AST wrappers
- Fix all rustdoc broken intra-doc links (14 warnings → 0)
- Write READMEs for core, python crates and rewrite workspace README
- Add Rust Core section to root project README with performance numbers
- Fix Python UP047 lint (TypeVar → PEP 695 type parameter syntax)