### PR TITLE
fix: hydrate relation role-player references by IID

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,7 +1,6 @@
 """Pytest fixtures for integration tests."""
 
 import pytest
-from typedb.driver import DriverOptions
 
 from tests.utils.typedb_lifecycle import (
     TEST_DB_ADDRESS,
@@ -9,7 +8,7 @@ from tests.utils.typedb_lifecycle import (
     start_typedb_container,
     stop_typedb_container,
 )
-from type_bridge import Credentials, Database, TypeDB
+from type_bridge import Credentials, Database, TypeDB, create_driver_options
 
 
 @pytest.fixture(scope="session")
@@ -45,7 +44,7 @@ def typedb_driver(docker_typedb):
         driver = TypeDB.driver(
             address=TEST_DB_ADDRESS,
             credentials=Credentials(username="admin", password="password"),
-            driver_options=DriverOptions(is_tls_enabled=False),
+            driver_options=create_driver_options(is_tls_enabled=False),
         )
         yield driver
         driver.close()

--- a/tests/integration/queries/test_compiler_integration.py
+++ b/tests/integration/queries/test_compiler_integration.py
@@ -115,15 +115,13 @@ fun list-test-person-names() -> { person-name }:
 @pytest.fixture
 def db(docker_typedb):
     """Provide database connection."""
-    from typedb.driver import DriverOptions
-
     from tests.integration.conftest import TEST_DB_ADDRESS
-    from type_bridge import Credentials, TypeDB
+    from type_bridge import Credentials, TypeDB, create_driver_options
 
     driver = TypeDB.driver(
         address=TEST_DB_ADDRESS,
         credentials=Credentials(username="admin", password="password"),
-        driver_options=DriverOptions(is_tls_enabled=False),
+        driver_options=create_driver_options(is_tls_enabled=False),
     )
     db_name = "test_compiler_integration"
     if driver.databases.contains(db_name):

--- a/tests/integration/queries/test_function_query.py
+++ b/tests/integration/queries/test_function_query.py
@@ -72,16 +72,14 @@ fun get-artifacts-with-score($min_score: integer) -> { artifact-id, artifact-sco
 @pytest.fixture
 def db(docker_typedb):
     """Provide database connection."""
-    from typedb.driver import DriverOptions
-
     from tests.integration.conftest import TEST_DB_ADDRESS
-    from type_bridge import Credentials, TypeDB
+    from type_bridge import Credentials, TypeDB, create_driver_options
 
     # Create database if needed
     driver = TypeDB.driver(
         address=TEST_DB_ADDRESS,
         credentials=Credentials(username="admin", password="password"),
-        driver_options=DriverOptions(is_tls_enabled=False),
+        driver_options=create_driver_options(is_tls_enabled=False),
     )
     db_name = "test_function_query"
     if driver.databases.contains(db_name):

--- a/tests/unit/core/test_relation_to_ast.py
+++ b/tests/unit/core/test_relation_to_ast.py
@@ -2,6 +2,7 @@
 
 from type_bridge import (
     Boolean,
+    Card,
     Entity,
     Flag,
     Integer,
@@ -11,7 +12,8 @@ from type_bridge import (
     String,
     TypeFlags,
 )
-from type_bridge.query.ast import InsertClause, LiteralValue, RelationStatement
+from type_bridge.fields.role import RoleRef
+from type_bridge.query.ast import EntityPattern, InsertClause, LiteralValue, RelationStatement
 
 
 class Name(String):
@@ -42,6 +44,12 @@ class Employment(Relation):
     employer: Role[Company] = Role("employer", Company)
     salary: Salary | None = None
     full_time: FullTime | None = None
+
+
+class OptionalEmployment(Relation):
+    flags = TypeFlags(name="optional-employment")
+    employee: Role[Employee] = Role("employee", Employee)
+    employer: Role[Company] = Role("employer", Company, cardinality=Card(min=0, max=None))
 
 
 def test_relation_to_ast_basic():
@@ -113,3 +121,51 @@ def test_relation_to_ast_type_refinement():
     assert isinstance(ft_attr.value, LiteralValue)
     assert ft_attr.value.value_type == "boolean"
     assert ft_attr.value.value is False
+
+
+def test_optional_role_omitted_defaults_to_none_not_role_ref():
+    """Unset optional roles must not store the class-level RoleRef default."""
+    emp = Employee(name=Name("Alice"))
+
+    employment = OptionalEmployment(employee=emp)
+
+    assert employment.__dict__["employer"] is None
+    assert employment.employer is None
+    assert not isinstance(employment.__dict__["employer"], RoleRef)
+
+
+def test_optional_role_accepts_explicit_none():
+    """Users can explicitly pass None for an optional role."""
+    emp = Employee(name=Name("Alice"))
+
+    employment = OptionalEmployment(employee=emp, employer=None)  # pyright: ignore[reportArgumentType]
+
+    assert employment.__dict__["employer"] is None
+
+
+def test_optional_role_omitted_is_not_rendered_in_insert_ast():
+    """Missing optional roles are skipped when building insert role players."""
+    emp = Employee(name=Name("Alice"))
+    employment = OptionalEmployment(employee=emp)
+
+    result = employment.to_ast("$r")
+    rel_stmt = result.statements[0]
+    assert isinstance(rel_stmt, RelationStatement)
+
+    assert [player.role for player in rel_stmt.role_players] == ["employee"]
+
+
+def test_optional_role_omitted_is_skipped_by_relation_insert_strategy():
+    """The CRUD insert strategy should not identify missing optional roles."""
+    from type_bridge.crud.strategies import RelationStrategy
+
+    emp = Employee(name=Name("Alice"))
+    employment = OptionalEmployment(employee=emp)
+
+    match_clause, _ = RelationStrategy().build_insert(employment, "$r")
+
+    assert match_clause is not None
+    assert len(match_clause.patterns) == 1
+    pattern = match_clause.patterns[0]
+    assert isinstance(pattern, EntityPattern)
+    assert pattern.type_name == "employee"

--- a/tests/unit/crud/test_polymorphic_role_player.py
+++ b/tests/unit/crud/test_polymorphic_role_player.py
@@ -9,6 +9,7 @@ the union.
 from type_bridge import Entity, Flag, Key, Relation, Role, String, TypeFlags
 from type_bridge.crud.utils import (
     build_role_player_fetch_items,
+    extract_role_players_from_results,
     resolve_entity_class_from_label,
 )
 
@@ -227,3 +228,41 @@ class TestPolymorphicRolePlayerResolutionIntegration:
         resolved = resolve_entity_class_from_label("task", allowed)
         assert resolved is Task
         assert resolved is not Person
+
+    def test_relation_role_player_hydrates_from_iid_only_placeholder(self):
+        """Relation role players may be fetched by IID without their own roles."""
+        role_info = {"mentioned": ("$mentioned", (About,))}
+        result_group = [
+            {
+                "mentioned": {},
+                "mentioned_iid": "0xabc",
+                "mentioned_type": "about",
+            }
+        ]
+
+        role_players = extract_role_players_from_results(result_group, role_info, set())
+
+        mentioned = role_players["mentioned"]
+        assert isinstance(mentioned, About)
+        assert getattr(mentioned, "_iid") == "0xabc"
+
+    def test_relation_role_player_deduplicates_by_iid_not_empty_attributes(self):
+        """Multiple attribute-less relation players must not collapse together."""
+        role_info = {"mentioned": ("$mentioned", (About,))}
+        result_group = [
+            {
+                "mentioned": {},
+                "mentioned_iid": "0xabc",
+                "mentioned_type": "about",
+            },
+            {
+                "mentioned": {},
+                "mentioned_iid": "0xdef",
+                "mentioned_type": "about",
+            },
+        ]
+
+        role_players = extract_role_players_from_results(result_group, role_info, {"mentioned"})
+
+        mentioned = role_players["mentioned"]
+        assert [getattr(player, "_iid") for player in mentioned] == ["0xabc", "0xdef"]

--- a/type_bridge/__init__.py
+++ b/type_bridge/__init__.py
@@ -49,7 +49,7 @@ from type_bridge.models import Entity, Relation, Role, TypeDBType
 from type_bridge.proxy import ProxyDatabase, ProxyError
 from type_bridge.query import Query, QueryBuilder
 from type_bridge.session import Connection, Database, TransactionContext
-from type_bridge.typedb_driver import Credentials, TransactionType, TypeDB
+from type_bridge.typedb_driver import Credentials, TransactionType, TypeDB, create_driver_options
 
 __version__ = "1.4.4"
 
@@ -62,6 +62,7 @@ __all__ = [
     "Credentials",
     "TransactionType",
     "TypeDB",
+    "create_driver_options",
     # Models
     "TypeDBType",
     "Entity",

--- a/type_bridge/crud/role_players.py
+++ b/type_bridge/crud/role_players.py
@@ -1,12 +1,13 @@
 """Role player utilities for relations."""
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 from type_bridge.crud.formatting import format_value
 from type_bridge.crud.types import hydrate_attributes, wrap_attribute_value
 
 if TYPE_CHECKING:
-    from type_bridge.models import Entity, Relation
+    from type_bridge.models import Relation, TypeDBType
 
 
 def build_role_player_match(var_name: str, entity: Any, entity_type_name: str) -> str:
@@ -60,8 +61,8 @@ def build_role_player_match(var_name: str, entity: Any, entity_type_name: str) -
 
 def resolve_entity_class_from_label(
     type_label: str | None,
-    allowed_entity_classes: tuple[type["Entity"], ...],
-) -> type["Entity"]:
+    allowed_entity_classes: tuple[type["TypeDBType"], ...],
+) -> type["TypeDBType"]:
     """Resolve the correct Python entity class from a TypeDB type label.
 
     This is a thin wrapper around ModelRegistry.resolve() that provides
@@ -134,6 +135,24 @@ def group_results_by_iid(results: list[dict[str, Any]]) -> dict[str, list[dict[s
     return grouped
 
 
+def _set_iid(instance: Any, iid: str | None) -> None:
+    """Set the TypeDB IID on a hydrated instance."""
+    if not iid:
+        return
+
+    private = getattr(instance, "__pydantic_private__", None)
+    if private is not None:
+        private["_iid"] = iid
+    else:
+        object.__setattr__(instance, "_iid", iid)
+
+
+def _is_relation_class(model_class: type[Any]) -> bool:
+    from type_bridge.models import Relation
+
+    return issubclass(model_class, Relation)
+
+
 def extract_relation_attributes(
     model_class: type["Relation"],
     result: dict[str, Any],
@@ -175,7 +194,7 @@ def extract_relation_attributes(
 
 def extract_role_players_from_results(
     result_group: list[dict[str, Any]],
-    role_info: dict[str, tuple[str, tuple[type["Entity"], ...]]],
+    role_info: Mapping[str, tuple[str, tuple[type["TypeDBType"], ...]]],
     multi_player_roles: set[str],
 ) -> dict[str, Any]:
     """Extract and deduplicate role players from grouped query results.
@@ -214,15 +233,25 @@ def extract_role_players_from_results(
                     entity_class, player_data, wrap_values=True
                 )
 
-                # Create entity instance if we have any non-None attributes
-                # Note: Relations as role players may have no owned attributes
-                if player_attrs == {} or any(v is not None for v in player_attrs.values()):
-                    # Deduplicate players based on their attribute values
-                    if key_values not in seen_player_keys:
-                        seen_player_keys.add(key_values)
-                        player_entity = entity_class(**player_attrs)
-                        if player_iid:
-                            object.__setattr__(player_entity, "_iid", player_iid)
+                # Create a role-player instance if the row proves a player exists.
+                # Relations used as role players are fetched as nested placeholders:
+                # TypeDB returns their IID/type and owned attributes, but not their
+                # own role players. Construct them without validation so required
+                # roles are not demanded for a partial reference.
+                has_player_data = (
+                    player_iid is not None
+                    or player_attrs == {}
+                    or any(v is not None for v in player_attrs.values())
+                )
+                if has_player_data:
+                    player_key = ("iid", player_iid) if player_iid else ("keys", key_values)
+                    if player_key not in seen_player_keys:
+                        seen_player_keys.add(player_key)
+                        if _is_relation_class(entity_class):
+                            player_entity = entity_class.model_construct(**player_attrs)
+                        else:
+                            player_entity = entity_class(**player_attrs)
+                        _set_iid(player_entity, player_iid)
                         collected_players.append(player_entity)
 
         # Store collected players

--- a/type_bridge/crud/types.py
+++ b/type_bridge/crud/types.py
@@ -8,7 +8,7 @@ from type_bridge.attribute import AttributeFlags
 from type_bridge.crud.formatting import unwrap_attribute
 
 if TYPE_CHECKING:
-    from type_bridge.models import Entity
+    from type_bridge.models import TypeDBType
     from type_bridge.models.utils import ModelAttrInfo
 
 
@@ -141,7 +141,7 @@ def build_metadata_fetch(var: str) -> str:
 
 
 def hydrate_attributes(
-    entity_class: type[Entity],
+    entity_class: type[TypeDBType],
     raw_data: dict[str, Any],
     wrap_values: bool = False,
 ) -> tuple[dict[str, Any], tuple[tuple[str, Any], ...]]:

--- a/type_bridge/models/registry.py
+++ b/type_bridge/models/registry.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, TypeVar, cast
 
 if TYPE_CHECKING:
     from type_bridge.models.base import TypeDBType
-    from type_bridge.models.entity import Entity
 
 logger = logging.getLogger(__name__)
 
@@ -63,8 +62,8 @@ class ModelRegistry:
     def resolve(
         cls,
         type_label: str | None,
-        allowed_classes: tuple[type[Entity], ...],
-    ) -> type[Entity]:
+        allowed_classes: tuple[type[T], ...],
+    ) -> type[T]:
         """Resolve a TypeDB type label to a Python model class.
 
         This is the unified method for polymorphic class resolution. It:
@@ -88,7 +87,7 @@ class ModelRegistry:
             # Verify the cached class is compatible with allowed_classes
             for allowed in allowed_classes:
                 if issubclass(cached, allowed):
-                    return cached  # type: ignore[return-value]
+                    return cast("type[T]", cached)
 
         # Try central registry
         registered = cls._registry.get(type_label)
@@ -97,7 +96,7 @@ class ModelRegistry:
             for allowed in allowed_classes:
                 if issubclass(registered, allowed):
                     cls._resolution_cache[type_label] = registered
-                    return registered  # type: ignore[return-value]
+                    return cast("type[T]", registered)
 
         # Quick check: direct match against allowed classes
         for allowed_cls in allowed_classes:
@@ -106,12 +105,12 @@ class ModelRegistry:
                 return allowed_cls
 
         # Fallback: search through subclasses
-        def find_in_subclasses(search_cls: type[Entity]) -> type[Entity] | None:
+        def find_in_subclasses(search_cls: type[T]) -> type[T] | None:
             """Recursively search subclasses for matching type name."""
             for subclass in search_cls.__subclasses__():
                 if subclass.get_type_name() == type_label:
-                    return subclass
-                found = find_in_subclasses(subclass)
+                    return cast("type[T]", subclass)
+                found = find_in_subclasses(cast("type[T]", subclass))
                 if found:
                     return found
             return None

--- a/type_bridge/models/relation.py
+++ b/type_bridge/models/relation.py
@@ -7,11 +7,13 @@ from typing import (
     TYPE_CHECKING,
     Any,
     ClassVar,
+    Self,
     TypeVar,
+    cast,
     dataclass_transform,
 )
 
-from pydantic import ConfigDict
+from pydantic import ConfigDict, model_validator
 
 from type_bridge.attribute import AttributeFlags, TypeFlags
 from type_bridge.crud.utils import extract_entity_key, unwrap_attribute
@@ -124,6 +126,36 @@ class Relation(TypeDBType):
             Dictionary mapping role names to Role instances
         """
         return cls._roles
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_unset_roles(cls, values: Any) -> Any:
+        """Prevent class-level RoleRef defaults from leaking into instances."""
+        if not isinstance(values, dict):
+            return values
+
+        from type_bridge.fields.role import RoleRef
+
+        data = dict(values)
+        for role_name in cls._roles:
+            value = data.get(role_name)
+            if role_name not in data or isinstance(value, RoleRef):
+                data[role_name] = None
+        return data
+
+    @model_validator(mode="after")
+    def _validate_required_roles(self) -> Self:
+        """Reject missing role players for roles with required cardinality."""
+        from type_bridge.fields.role import RoleRef
+
+        for role_name, role in self.__class__._roles.items():
+            value = self.__dict__.get(role_name)
+            if isinstance(value, RoleRef):
+                value = None
+                cast("dict[str, Any]", self.__dict__)[role_name] = None
+            if value is None and not role.is_optional:
+                raise ValueError(f"Role player '{role_name}' is required")
+        return self
 
     def to_ast(self, var: str = "$r") -> InsertClause:
         """Generate AST InsertClause for this relation instance.

--- a/type_bridge/models/role.py
+++ b/type_bridge/models/role.py
@@ -122,6 +122,11 @@ class Role[T: "TypeDBType"]:
             return False  # Default is single player
         return self.cardinality.max is None or self.cardinality.max > 1
 
+    @property
+    def is_optional(self) -> bool:
+        """Check if this role allows zero players."""
+        return self.cardinality is not None and self.cardinality.min == 0
+
     def __set_name__(self, owner: type, name: str) -> None:
         """Called when role is assigned to a class."""
         self.attr_name = name
@@ -158,6 +163,13 @@ class Role[T: "TypeDBType"]:
         For roles with cardinality > 1, accepts a list of entities.
         For single-player roles, accepts a single entity.
         """
+        if value is None:
+            if not self.is_optional:
+                allowed = ", ".join(pt.__name__ for pt in self.player_entity_types)
+                raise TypeError(f"Role '{self.role_name}' expects types ({allowed}), got NoneType")
+            obj.__dict__[self.attr_name] = None
+            return
+
         if isinstance(value, list):
             # Multi-player role - validate each item in the list
             if not self.is_multi_player:
@@ -245,6 +257,9 @@ class Role[T: "TypeDBType"]:
             E.g., if Document is allowed and Report is a subclass of Document,
             Report instances are accepted.
             """
+            if value is None:
+                return None
+
             if not allowed_names:
                 # No type constraints - allow anything
                 return value

--- a/type_bridge/session.py
+++ b/type_bridge/session.py
@@ -6,7 +6,6 @@ from typing import Any, overload
 from typedb.driver import (
     Credentials,
     Driver,
-    DriverOptions,
     TransactionType,
     TypeDB,
 )
@@ -15,6 +14,7 @@ from typedb.driver import (
 )
 
 from type_bridge.proxy import ProxyDatabase, ProxyTransaction, ProxyTransactionContext
+from type_bridge.typedb_driver import create_driver_options
 
 logger = logging.getLogger(__name__)
 
@@ -195,7 +195,7 @@ class Database:
             # Create driver options
             # Disable TLS for local connections (non-HTTPS addresses)
             is_tls_enabled = self.address.startswith("https://")
-            driver_options = DriverOptions(is_tls_enabled=is_tls_enabled)
+            driver_options = create_driver_options(is_tls_enabled=is_tls_enabled)
             logger.debug(f"TLS enabled: {is_tls_enabled}")
 
             # Connect to TypeDB

--- a/type_bridge/typedb_driver.py
+++ b/type_bridge/typedb_driver.py
@@ -11,10 +11,29 @@ Example:
     # from type_bridge import Database
 """
 
-from typedb.driver import Credentials, TransactionType, TypeDB
+from typedb.driver import Credentials, DriverOptions, TransactionType, TypeDB
+
+
+def create_driver_options(is_tls_enabled: bool = False) -> DriverOptions:
+    """Create TypeDB driver options across supported driver versions."""
+    try:
+        return DriverOptions(is_tls_enabled=is_tls_enabled)
+    except TypeError:
+        typedb_driver = __import__("typedb.driver", fromlist=["DriverTlsConfig"])
+        driver_tls_config = getattr(typedb_driver, "DriverTlsConfig")
+
+        tls_config = (
+            driver_tls_config.enabled_with_native_root_ca()
+            if is_tls_enabled
+            else driver_tls_config.disabled()
+        )
+        return DriverOptions(tls_config)
+
 
 __all__ = [
     "Credentials",
+    "DriverOptions",
     "TransactionType",
     "TypeDB",
+    "create_driver_options",
 ]


### PR DESCRIPTION
Fix relation-as-role-player hydration when TypeDB fetch results include only the nested relation IID/type metadata.

These relation references are now built as partial IID-backed instances instead of going through normal constructor validation, which avoids requiring the nested relation's own role players.

Also prevent omitted optional roles from retaining class-level `RoleRef` defaults on relation instances.

Closes: #126