### PR TITLE
fix: repair relation reads and pin TypeDB 3.10 test env 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.venv
+.pytest_cache
+.ruff_cache
+.mypy_cache
+__pycache__
+*.pyc
+*.pyo
+build
+dist
+wheels
+htmlcov
+coverage.xml
+site
+tmp
+type-bridge-core/target

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.13.5"
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -124,7 +124,7 @@ jobs:
         if: runner.os != 'Linux'
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.13.5"
 
       - name: Build wheel
         uses: PyO3/maturin-action@v1
@@ -154,7 +154,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.13.5"
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -189,7 +189,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.13.5"
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -214,7 +214,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.13"]
+        python-version: ["3.13.5"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -265,7 +265,7 @@ jobs:
     # Start TypeDB as a service container (runs first, before steps)
     services:
       typedb:
-        image: typedb/typedb:3.8.0-rc0
+        image: typedb/typedb:3.10.4
         ports:
           - 1729:1729
 
@@ -276,7 +276,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.13.5"
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.13.5"
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.13.5"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -128,7 +128,7 @@ jobs:
         if: runner.os != 'Linux'
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.13.5"
 
       - name: Build wheel
         uses: PyO3/maturin-action@v1
@@ -178,7 +178,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.13.5"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/Dockerfile.integration
+++ b/Dockerfile.integration
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1
+
+FROM docker:28.1.1-cli AS docker-cli
+FROM ghcr.io/astral-sh/uv:0.8.17 AS uv-bin
+FROM rust:1.91.1-slim-bookworm AS rust-bin
+FROM python:3.13.5-slim-bookworm
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    CARGO_HOME=/usr/local/cargo \
+    RUSTUP_HOME=/usr/local/rustup \
+    UV_CACHE_DIR=/tmp/uv-cache \
+    UV_LINK_MODE=copy \
+    PATH="/usr/local/cargo/bin:${PATH}"
+
+COPY --from=docker-cli /usr/local/bin/docker /usr/local/bin/docker
+COPY --from=docker-cli /usr/local/libexec/docker/cli-plugins/docker-compose /usr/local/libexec/docker/cli-plugins/docker-compose
+COPY --from=uv-bin /uv /uvx /usr/local/bin/
+COPY --from=rust-bin /usr/local/cargo /usr/local/cargo
+COPY --from=rust-bin /usr/local/rustup /usr/local/rustup
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        build-essential \
+        ca-certificates \
+        curl \
+        git \
+        libssl-dev \
+        netcat-openbsd \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/* \
+    && docker --version \
+    && docker compose version \
+    && rustc --version \
+    && cargo --version \
+    && uv --version
+
+WORKDIR /workspace
+
+ENTRYPOINT ["./test-integration.sh"]

--- a/README.md
+++ b/README.md
@@ -335,7 +335,10 @@ uv run pytest tests/unit/expressions/ -v  # Test query expressions
 # Option 1: Use Docker (recommended)
 ./test-integration.sh                     # Starts Docker, runs tests, stops Docker
 
-# Option 2: Use existing TypeDB server
+# Option 2: Use a pinned Docker-in-Docker runner
+./test-integration-dind.sh                # Python 3.13.5 + TypeDB 3.10.4
+
+# Option 3: Use existing TypeDB server
 USE_DOCKER=false uv run pytest -m integration -v  # Run integration tests (~60s)
 
 # Run specific integration test categories
@@ -374,7 +377,7 @@ See [`type-bridge-core/README.md`](type-bridge-core/README.md) for build instruc
 
 - Python 3.13+
 - TypeDB 3.x server
-- typedb-driver>=3.8.0
+- typedb-driver==3.10.0
 - pydantic>=2.12.4
 - isodate==0.7.2 (for Duration type support)
 - lark>=1.1.9 (for schema parsing)

--- a/docker-compose.dind.yml
+++ b/docker-compose.dind.yml
@@ -1,0 +1,41 @@
+services:
+  docker:
+    image: docker:28.1.1-dind
+    privileged: true
+    environment:
+      DOCKER_TLS_CERTDIR: ""
+    command:
+      - --host=tcp://0.0.0.0:2375
+      - --host=unix:///var/run/docker.sock
+    healthcheck:
+      test: ["CMD", "docker", "info"]
+      interval: 3s
+      timeout: 2s
+      retries: 20
+      start_period: 5s
+    volumes:
+      - dind-storage:/var/lib/docker
+
+  integration:
+    build:
+      context: .
+      dockerfile: Dockerfile.integration
+    depends_on:
+      docker:
+        condition: service_healthy
+    working_dir: /workspace
+    environment:
+      CONTAINER_TOOL: docker
+      DOCKER_HOST: tcp://docker:2375
+      DOCKER_TLS_CERTDIR: ""
+      TYPEDB_ADDRESS: docker:1730
+      TYPEDB_IMAGE: typedb/typedb:3.10.4
+      TYPEDB_PORT: 1730
+      UV_CACHE_DIR: /tmp/uv-cache
+    volumes:
+      - .:/workspace
+      - uv-cache:/tmp/uv-cache
+
+volumes:
+  dind-storage:
+  uv-cache:

--- a/docker-compose.proxy.yml
+++ b/docker-compose.proxy.yml
@@ -1,6 +1,6 @@
 services:
   typedb:
-    image: typedb/typedb:3.8.0
+    image: ${TYPEDB_IMAGE:-typedb/typedb:3.10.4}
     container_name: typedb_proxy_test
     ports:
       - "${TYPEDB_PORT:-1731}:1729"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   typedb:
-    image: typedb/typedb:3.8.0
+    image: ${TYPEDB_IMAGE:-typedb/typedb:3.10.4}
     container_name: typedb_test
     ports:
       - "${TYPEDB_PORT:-1730}:1729"

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -25,7 +25,7 @@ uv pip install -e ".[dev]"
 ### Project Dependencies
 
 The project requires:
-- `typedb-driver>=3.7.0`: Official Python driver for TypeDB connectivity
+- `typedb-driver==3.10.0`: Official Python driver for TypeDB connectivity
 - `pydantic>=2.12.4`: For validation and type coercion
 - `isodate==0.7.2`: For Duration type support (ISO 8601)
 - `lark>=1.1.9`: Parser toolkit for TypeQL schema parsing
@@ -42,7 +42,7 @@ Development dependencies include:
 
 ### Integration Tests with TypeDB
 
-Integration tests are validated against TypeDB 3.7.0-rc0. The project includes Docker/Podman configuration for automated setup.
+Integration tests are validated against TypeDB 3.10.4. The project includes Docker/Podman configuration for automated setup.
 
 **Requirements:**
 - Docker or Podman with Compose support installed
@@ -53,6 +53,9 @@ Integration tests are validated against TypeDB 3.7.0-rc0. The project includes D
 ```bash
 ./test-integration.sh          # Starts Docker, runs tests, stops Docker
 ./test-integration.sh -v       # With verbose output
+
+# Fully pinned runner using Docker-in-Docker
+./test-integration-dind.sh     # Python 3.13.5 + TypeDB 3.10.4
 ```
 
 ### Manual Docker Control
@@ -242,6 +245,9 @@ debug_report.md         # Don't put in root
 
    # Full: with integration tests
    ./test-integration.sh
+
+   # Reproducible containerized integration environment
+   ./test-integration-dind.sh
    ```
 
 4. **Check code quality**:

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -241,6 +241,14 @@ Integration tests require a running TypeDB 3.x server.
 # - Stopped after tests (even on failure)
 ```
 
+**Option 1b: Use Docker-in-Docker (Pinned Environment)**
+
+```bash
+# Runs tests in Python 3.13.5 with Docker 28.1.1 and TypeDB 3.10.4
+./test-integration-dind.sh
+./test-integration-dind.sh tests/integration/crud/relations/test_fetch.py -v
+```
+
 **Option 2: Use Existing TypeDB Server**
 
 ```bash
@@ -321,19 +329,14 @@ uv run pytest tests/integration/crud/relations/test_multi_role.py -v
 
 **Configuration:**
 
-The project includes `docker-compose.yml` for TypeDB 3.7.0-rc0:
+The project includes `docker-compose.yml` for TypeDB 3.10.4:
 
 ```yaml
 services:
   typedb:
-    image: typedb/typedb:3.7.0-rc0
+    image: ${TYPEDB_IMAGE:-typedb/typedb:3.10.4}
     ports:
-      - "1729:1729"
-    volumes:
-      - typedb-data:/opt/typedb/server/data
-
-volumes:
-  typedb-data:
+      - "${TYPEDB_PORT:-1730}:1729"
 ```
 
 **Manual Docker control:**

--- a/docs/development/typedb.md
+++ b/docs/development/typedb.md
@@ -7,11 +7,11 @@ This guide covers TypeDB-specific concepts, driver API, TypeQL syntax, and integ
 - [Key TypeDB Concepts](#key-typedb-concepts)
 - [TypeDB ORM Design Considerations](#typedb-orm-design-considerations)
 - [TypeQL Syntax Requirements](#typeql-syntax-requirements)
-**Verified with TypeDB 3.7.0-rc0 and typedb-driver>=3.7.0rc3.**
+**Verified with TypeDB 3.10.4 and typedb-driver==3.10.0.**
 
-## TypeDB Driver 3.7.x API
+## TypeDB Driver 3.x API
 
-- [TypeDB Driver 3.7.x API](#typedb-driver-37x-api)
+- [TypeDB Driver 3.x API](#typedb-driver-3x-api)
 - [TypeDB 3.x Syntax and Behavior Changes](#typedb-3x-syntax-and-behavior-changes)
 
 ## Key TypeDB Concepts
@@ -314,9 +314,9 @@ entity person,
     owns email @key @card(1..1);  # Don't specify both
 ```
 
-## TypeDB Driver 3.7.x API
+## TypeDB Driver 3.x API
 
-The driver API for 3.7.x differs from earlier versions:
+The driver API for 3.x differs from earlier versions:
 
 ### 1. No Separate Sessions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "type-bridge"
 version = "1.4.4"
 description = "A modern, Pythonic ORM for TypeDB with an Attribute-based API"
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.13,<3.15"
 license = {text = "MIT"}
 authors = [
     {name = "ds1sqe", email = "ds1sqe@mensakorea.org"}
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "typedb-driver>=3.8.0",
+    "typedb-driver==3.10.0",
     "pydantic>=2.12.4",
     "isodate==0.7.2",
     "lark>=1.1.9",

--- a/test-integration-dind.sh
+++ b/test-integration-dind.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Run integration tests inside a pinned Python runner that talks to Docker-in-Docker.
+
+set -euo pipefail
+
+cleanup() {
+    docker compose -f docker-compose.dind.yml down -v
+}
+trap cleanup EXIT
+
+docker compose -f docker-compose.dind.yml run --rm integration "$@"

--- a/test-integration.sh
+++ b/test-integration.sh
@@ -23,6 +23,6 @@ echo -e "${GREEN}Running integration tests with ${CONTAINER_TOOL:-auto-detect}..
 
 # Run pytest with integration marker
 # Container management is handled by conftest.py
-uv run pytest -m integration "$@"
+uv run --extra dev pytest -m integration "$@"
 
 echo -e "${GREEN}Integration tests completed!${NC}"

--- a/test-proxy-integration.sh
+++ b/test-proxy-integration.sh
@@ -23,6 +23,6 @@ echo -e "${GREEN}Running proxy integration tests with ${CONTAINER_TOOL:-auto-det
 
 # Run pytest with proxy marker
 # Container management is handled by conftest.py
-uv run pytest -m proxy "$@"
+uv run --extra dev pytest -m proxy "$@"
 
 echo -e "${GREEN}Proxy integration tests completed!${NC}"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,7 +1,6 @@
 """Pytest fixtures for integration tests."""
 
 import pytest
-from typedb.driver import DriverOptions
 
 from tests.utils.typedb_lifecycle import (
     TEST_DB_ADDRESS,
@@ -9,7 +8,7 @@ from tests.utils.typedb_lifecycle import (
     start_typedb_container,
     stop_typedb_container,
 )
-from type_bridge import Credentials, Database, TypeDB
+from type_bridge import Credentials, Database, TypeDB, create_driver_options
 
 
 @pytest.fixture(scope="session")
@@ -45,7 +44,7 @@ def typedb_driver(docker_typedb):
         driver = TypeDB.driver(
             address=TEST_DB_ADDRESS,
             credentials=Credentials(username="admin", password="password"),
-            driver_options=DriverOptions(is_tls_enabled=False),
+            driver_options=create_driver_options(is_tls_enabled=False),
         )
         yield driver
         driver.close()

--- a/tests/integration/crud/relations/test_fetch.py
+++ b/tests/integration/crud/relations/test_fetch.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from type_bridge import Entity, Flag, Key, Relation, Role, String, TypeFlags
+from type_bridge import Card, Entity, Flag, Key, Relation, Role, SchemaManager, String, TypeFlags
 
 
 @pytest.mark.integration
@@ -95,3 +95,56 @@ def test_fetch_relation_by_attribute(db_with_schema):
     results_by_pos = employment_manager.get(position="CTO")
     assert len(results_by_pos) == 1
     assert results_by_pos[0].position.value == "CTO"
+
+
+@pytest.mark.integration
+def test_fetch_all_includes_relations_with_empty_optional_roles(clean_db):
+    """Regression for #127: optional role players must not filter out relations."""
+
+    class Name(String):
+        pass
+
+    class Person(Entity):
+        flags = TypeFlags(name="person")
+        name: Name = Flag(Key)
+
+    class Club(Entity):
+        flags = TypeFlags(name="club")
+        name: Name = Flag(Key)
+
+    class Sponsor(Entity):
+        flags = TypeFlags(name="sponsor")
+        name: Name = Flag(Key)
+
+    class Membership(Relation):
+        flags = TypeFlags(name="membership")
+        person: Role[Person] = Role("person", Person)
+        club: Role[Club] = Role("club", Club)
+        sponsor: Role[Sponsor] = Role("sponsor", Sponsor, cardinality=Card(0))
+
+    schema = SchemaManager(clean_db)
+    schema.register(Person, Club, Sponsor, Membership)
+    schema.sync_schema(force=True)
+
+    person_manager = Person.manager(clean_db)
+    club_manager = Club.manager(clean_db)
+    sponsor_manager = Sponsor.manager(clean_db)
+    membership_manager = Membership.manager(clean_db)
+
+    alice = person_manager.insert(Person(name=Name("Alice")))
+    bob = person_manager.insert(Person(name=Name("Bob")))
+    chess = club_manager.insert(Club(name=Name("Chess")))
+    hiking = club_manager.insert(Club(name=Name("Hiking")))
+    acme = sponsor_manager.insert(Sponsor(name=Name("Acme")))
+
+    membership_manager.insert(Membership(person=alice, club=chess, sponsor=[acme]))
+    membership_manager.insert(Membership(person=bob, club=hiking, sponsor=[]))
+
+    memberships = membership_manager.all()
+
+    assert len(memberships) == 2
+    assert {membership.person.name.value for membership in memberships} == {"Alice", "Bob"}
+
+    sponsored = membership_manager.get(sponsor=acme)
+    assert len(sponsored) == 1
+    assert sponsored[0].person.name.value == "Alice"

--- a/tests/integration/proxy/conftest.py
+++ b/tests/integration/proxy/conftest.py
@@ -1,5 +1,6 @@
 """Pytest fixtures for proxy integration tests."""
 
+import os
 from collections.abc import Generator
 
 import pytest
@@ -11,6 +12,41 @@ from tests.utils.proxy_lifecycle import (
     stop_proxy_containers,
 )
 from type_bridge.proxy import ProxyDatabase
+
+
+def _prepare_proxy_database() -> None:
+    """Create the proxy test database and a minimal schema for raw query tests."""
+    from type_bridge import (
+        AttributeFlags,
+        Database,
+        Entity,
+        Flag,
+        Key,
+        SchemaManager,
+        String,
+        TypeFlags,
+    )
+
+    typedb_address = os.getenv("PROXY_TYPEDB_ADDRESS", "localhost:1731")
+
+    class Name(String):
+        flags = AttributeFlags(name="name")
+
+    class Person(Entity):
+        flags = TypeFlags(name="person")
+        name: Name = Flag(Key)
+
+    database = Database(address=typedb_address, database=PROXY_DB_NAME)
+    database.connect()
+    try:
+        database.delete_database()
+        database.create_database()
+
+        schema_manager = SchemaManager(database)
+        schema_manager.register(Person)
+        schema_manager.sync_schema(force=True)
+    finally:
+        database.close()
 
 
 @pytest.fixture(scope="session")
@@ -33,6 +69,7 @@ def proxy_db(docker_proxy: None) -> Generator[ProxyDatabase]:
         Connected ProxyDatabase instance
     """
     try:
+        _prepare_proxy_database()
         proxy = ProxyDatabase(proxy_url=PROXY_ADDRESS, database=PROXY_DB_NAME)
         proxy.connect()
         yield proxy

--- a/tests/integration/proxy/test_proxy_audit.py
+++ b/tests/integration/proxy/test_proxy_audit.py
@@ -18,7 +18,7 @@ def test_audit_interceptor_applied(proxy_db: ProxyDatabase) -> None:
         {
             "database": proxy_db.database_name,
             "transaction_type": "read",
-            "query": "match $p isa person; fetch { };",
+            "query": 'match $p isa person; fetch { "person": { $p.* } };',
             "metadata": {},
         },
     )
@@ -35,7 +35,7 @@ def test_audit_interceptor_on_write(proxy_db: ProxyDatabase) -> None:
         {
             "database": proxy_db.database_name,
             "transaction_type": "write",
-            "query": "insert $p isa person, has name 'AuditTest';",
+            "query": 'insert $p isa person; $p has name "AuditTest";',
             "metadata": {},
         },
     )
@@ -53,7 +53,7 @@ def test_multiple_queries_all_audited(proxy_db: ProxyDatabase) -> None:
             {
                 "database": proxy_db.database_name,
                 "transaction_type": "read",
-                "query": f"match $p isa person, has name 'test_{i}'; fetch {{ }};",
+                "query": f'match $p isa person, has name "test_{i}"; fetch {{ "person": {{ $p.* }} }};',
                 "metadata": {"test_index": i},
             },
         )

--- a/tests/integration/proxy/test_proxy_crud.py
+++ b/tests/integration/proxy/test_proxy_crud.py
@@ -12,24 +12,19 @@ from type_bridge.proxy import ProxyDatabase, ProxyError
 
 @pytest.mark.proxy
 def test_raw_query_passthrough(proxy_db: ProxyDatabase) -> None:
-    """Raw TypeQL query is parsed, compiled, and returned (stub mode)."""
+    """Raw TypeQL query is parsed, compiled, and executed."""
     results = proxy_db.execute_query(
-        "match $p isa person; fetch { };",
+        'match $p isa person; fetch { "person": { $p.* } };',
         transaction_type="read",
     )
     assert isinstance(results, list)
-    # In stub mode, the server returns the compiled TypeQL
-    if isinstance(results, list) and len(results) > 0:
-        result = results[0] if isinstance(results[0], dict) else results
-        # Stub response includes compiled_typeql
-        assert "compiled_typeql" in str(result) or "stub" in str(result)
 
 
 @pytest.mark.proxy
 def test_raw_query_with_write_transaction(proxy_db: ProxyDatabase) -> None:
     """Write queries flow through the proxy pipeline."""
     results = proxy_db.execute_query(
-        "insert $p isa person, has name 'Alice';",
+        'insert $p isa person; $p has name "Alice";',
         transaction_type="write",
     )
     assert isinstance(results, list)
@@ -39,7 +34,7 @@ def test_raw_query_with_write_transaction(proxy_db: ProxyDatabase) -> None:
 def test_transaction_context_execute(proxy_db: ProxyDatabase) -> None:
     """Queries work through transaction context."""
     with proxy_db.transaction("read") as tx:
-        results = tx.execute("match $p isa person; fetch { };")
+        results = tx.execute('match $p isa person; fetch { "person": { $p.* } };')
         assert isinstance(results, list)
 
 
@@ -47,7 +42,7 @@ def test_transaction_context_execute(proxy_db: ProxyDatabase) -> None:
 def test_transaction_context_write(proxy_db: ProxyDatabase) -> None:
     """Write transaction context auto-commits on exit."""
     with proxy_db.transaction("write") as tx:
-        results = tx.execute("insert $p isa person, has name 'Bob';")
+        results = tx.execute('insert $p isa person; $p has name "Bob";')
         assert isinstance(results, list)
     # Transaction should be closed after context exit
     assert tx.transaction.is_open is False
@@ -61,7 +56,7 @@ def test_query_response_metadata(proxy_db: ProxyDatabase) -> None:
         {
             "database": proxy_db.database_name,
             "transaction_type": "read",
-            "query": "match $p isa person; fetch { };",
+            "query": 'match $p isa person; fetch { "person": { $p.* } };',
             "metadata": {},
         },
     )

--- a/tests/integration/queries/test_compiler_integration.py
+++ b/tests/integration/queries/test_compiler_integration.py
@@ -115,15 +115,13 @@ fun list-test-person-names() -> { person-name }:
 @pytest.fixture
 def db(docker_typedb):
     """Provide database connection."""
-    from typedb.driver import DriverOptions
-
     from tests.integration.conftest import TEST_DB_ADDRESS
-    from type_bridge import Credentials, TypeDB
+    from type_bridge import Credentials, TypeDB, create_driver_options
 
     driver = TypeDB.driver(
         address=TEST_DB_ADDRESS,
         credentials=Credentials(username="admin", password="password"),
-        driver_options=DriverOptions(is_tls_enabled=False),
+        driver_options=create_driver_options(is_tls_enabled=False),
     )
     db_name = "test_compiler_integration"
     if driver.databases.contains(db_name):

--- a/tests/integration/queries/test_function_query.py
+++ b/tests/integration/queries/test_function_query.py
@@ -72,16 +72,14 @@ fun get-artifacts-with-score($min_score: integer) -> { artifact-id, artifact-sco
 @pytest.fixture
 def db(docker_typedb):
     """Provide database connection."""
-    from typedb.driver import DriverOptions
-
     from tests.integration.conftest import TEST_DB_ADDRESS
-    from type_bridge import Credentials, TypeDB
+    from type_bridge import Credentials, TypeDB, create_driver_options
 
     # Create database if needed
     driver = TypeDB.driver(
         address=TEST_DB_ADDRESS,
         credentials=Credentials(username="admin", password="password"),
-        driver_options=DriverOptions(is_tls_enabled=False),
+        driver_options=create_driver_options(is_tls_enabled=False),
     )
     db_name = "test_function_query"
     if driver.databases.contains(db_name):

--- a/tests/unit/core/test_relation_to_ast.py
+++ b/tests/unit/core/test_relation_to_ast.py
@@ -2,6 +2,7 @@
 
 from type_bridge import (
     Boolean,
+    Card,
     Entity,
     Flag,
     Integer,
@@ -11,7 +12,8 @@ from type_bridge import (
     String,
     TypeFlags,
 )
-from type_bridge.query.ast import InsertClause, LiteralValue, RelationStatement
+from type_bridge.fields.role import RoleRef
+from type_bridge.query.ast import EntityPattern, InsertClause, LiteralValue, RelationStatement
 
 
 class Name(String):
@@ -42,6 +44,12 @@ class Employment(Relation):
     employer: Role[Company] = Role("employer", Company)
     salary: Salary | None = None
     full_time: FullTime | None = None
+
+
+class OptionalEmployment(Relation):
+    flags = TypeFlags(name="optional-employment")
+    employee: Role[Employee] = Role("employee", Employee)
+    employer: Role[Company] = Role("employer", Company, cardinality=Card(min=0, max=None))
 
 
 def test_relation_to_ast_basic():
@@ -113,3 +121,51 @@ def test_relation_to_ast_type_refinement():
     assert isinstance(ft_attr.value, LiteralValue)
     assert ft_attr.value.value_type == "boolean"
     assert ft_attr.value.value is False
+
+
+def test_optional_role_omitted_defaults_to_none_not_role_ref():
+    """Unset optional roles must not store the class-level RoleRef default."""
+    emp = Employee(name=Name("Alice"))
+
+    employment = OptionalEmployment(employee=emp)
+
+    assert employment.__dict__["employer"] is None
+    assert employment.employer is None
+    assert not isinstance(employment.__dict__["employer"], RoleRef)
+
+
+def test_optional_role_accepts_explicit_none():
+    """Users can explicitly pass None for an optional role."""
+    emp = Employee(name=Name("Alice"))
+
+    employment = OptionalEmployment(employee=emp, employer=None)  # pyright: ignore[reportArgumentType]
+
+    assert employment.__dict__["employer"] is None
+
+
+def test_optional_role_omitted_is_not_rendered_in_insert_ast():
+    """Missing optional roles are skipped when building insert role players."""
+    emp = Employee(name=Name("Alice"))
+    employment = OptionalEmployment(employee=emp)
+
+    result = employment.to_ast("$r")
+    rel_stmt = result.statements[0]
+    assert isinstance(rel_stmt, RelationStatement)
+
+    assert [player.role for player in rel_stmt.role_players] == ["employee"]
+
+
+def test_optional_role_omitted_is_skipped_by_relation_insert_strategy():
+    """The CRUD insert strategy should not identify missing optional roles."""
+    from type_bridge.crud.strategies import RelationStrategy
+
+    emp = Employee(name=Name("Alice"))
+    employment = OptionalEmployment(employee=emp)
+
+    match_clause, _ = RelationStrategy().build_insert(employment, "$r")
+
+    assert match_clause is not None
+    assert len(match_clause.patterns) == 1
+    pattern = match_clause.patterns[0]
+    assert isinstance(pattern, EntityPattern)
+    assert pattern.type_name == "employee"

--- a/tests/unit/crud/test_polymorphic_role_player.py
+++ b/tests/unit/crud/test_polymorphic_role_player.py
@@ -9,6 +9,7 @@ the union.
 from type_bridge import Entity, Flag, Key, Relation, Role, String, TypeFlags
 from type_bridge.crud.utils import (
     build_role_player_fetch_items,
+    extract_role_players_from_results,
     resolve_entity_class_from_label,
 )
 
@@ -227,3 +228,41 @@ class TestPolymorphicRolePlayerResolutionIntegration:
         resolved = resolve_entity_class_from_label("task", allowed)
         assert resolved is Task
         assert resolved is not Person
+
+    def test_relation_role_player_hydrates_from_iid_only_placeholder(self):
+        """Relation role players may be fetched by IID without their own roles."""
+        role_info = {"mentioned": ("$mentioned", (About,))}
+        result_group = [
+            {
+                "mentioned": {},
+                "mentioned_iid": "0xabc",
+                "mentioned_type": "about",
+            }
+        ]
+
+        role_players = extract_role_players_from_results(result_group, role_info, set())
+
+        mentioned = role_players["mentioned"]
+        assert isinstance(mentioned, About)
+        assert getattr(mentioned, "_iid") == "0xabc"
+
+    def test_relation_role_player_deduplicates_by_iid_not_empty_attributes(self):
+        """Multiple attribute-less relation players must not collapse together."""
+        role_info = {"mentioned": ("$mentioned", (About,))}
+        result_group = [
+            {
+                "mentioned": {},
+                "mentioned_iid": "0xabc",
+                "mentioned_type": "about",
+            },
+            {
+                "mentioned": {},
+                "mentioned_iid": "0xdef",
+                "mentioned_type": "about",
+            },
+        ]
+
+        role_players = extract_role_players_from_results(result_group, role_info, {"mentioned"})
+
+        mentioned = role_players["mentioned"]
+        assert [getattr(player, "_iid") for player in mentioned] == ["0xabc", "0xdef"]

--- a/tests/unit/crud/test_typedb_manager.py
+++ b/tests/unit/crud/test_typedb_manager.py
@@ -15,6 +15,7 @@ from type_bridge import (
     String,
     TypeFlags,
 )
+from type_bridge.crud.strategies import RelationStrategy
 from type_bridge.crud.typedb_manager import TypeDBManager
 
 
@@ -33,6 +34,54 @@ class _RecordingTypeDBManager(TypeDBManager):
 # ============================================================================
 # Update tests
 # ============================================================================
+
+
+def test_relation_fetch_wraps_unconstrained_optional_roles_in_try():
+    """Unfiltered relation fetch should not require optional role players."""
+
+    class Doc(String):
+        pass
+
+    class User(Entity):
+        flags = TypeFlags(name="optional_user")
+        doc: Doc = Flag(Key)
+
+    class Link(Relation):
+        flags = TypeFlags(name="optional_link")
+        source: Role[User] = Role("source", User)
+        target: Role[User] = Role("target", User, cardinality=Card(0))
+
+    query = RelationStrategy().build_fetch_query(Link, "$rel", {}, [])
+
+    assert "$rel isa! $t (source: $source)" in query
+    assert "target: $target" not in query.split("try {", 1)[0]
+    assert "try {\n  $rel links (target: $target);\n  $target isa! $target_type;\n}" in query
+
+
+def test_relation_fetch_requires_filtered_optional_roles():
+    """Filtering by an optional role should bind it in the main match pattern."""
+
+    class Doc(String):
+        pass
+
+    class User(Entity):
+        flags = TypeFlags(name="filtered_optional_user")
+        doc: Doc = Flag(Key)
+
+    class Link(Relation):
+        flags = TypeFlags(name="filtered_optional_link")
+        source: Role[User] = Role("source", User)
+        target: Role[User] = Role("target", User, cardinality=Card(0))
+
+    query = RelationStrategy().build_fetch_query(
+        Link,
+        "$rel",
+        {"target": User(doc=Doc("b"))},
+        [],
+    )
+
+    assert "$rel isa! $t (source: $source, target: $target)" in query
+    assert "try {\n  $rel links (target: $target)" not in query
 
 
 def test_update_multi_value_uses_guards():

--- a/type-bridge-core/.dockerignore
+++ b/type-bridge-core/.dockerignore
@@ -1,0 +1,4 @@
+target/
+.pytest_cache/
+dist/
+*.egg-info/

--- a/type-bridge-core/Dockerfile.server
+++ b/type-bridge-core/Dockerfile.server
@@ -5,29 +5,10 @@ WORKDIR /app
 # Install build dependencies
 RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
 
-# Copy workspace manifests first for layer caching
-COPY Cargo.toml ./
-COPY crates/core/Cargo.toml crates/core/Cargo.toml
-COPY crates/server/Cargo.toml crates/server/Cargo.toml
-
-# Create dummy python crate manifest (not built in server image)
-RUN mkdir -p crates/python/src && echo '' > crates/python/src/lib.rs
-COPY crates/python/Cargo.toml crates/python/Cargo.toml
-
-# Create dummy source files to cache dependency builds
-RUN mkdir -p crates/core/src && echo 'pub mod ast; pub mod compiler; pub mod parser; pub mod query_parser; pub mod reserved_words; pub mod schema; pub mod validation; pub mod value_coercion;' > crates/core/src/lib.rs
-RUN for f in ast compiler parser query_parser reserved_words schema validation value_coercion; do echo '' > crates/core/src/$f.rs; done
-RUN mkdir -p crates/server/src && echo 'fn main() {}' > crates/server/src/main.rs
-
-# Build dependencies only (cached layer)
-RUN cargo build --release -p type-bridge-server 2>/dev/null || true
-
-# Copy actual source code
-COPY crates/core/src crates/core/src
-COPY crates/server/src crates/server/src
-
-# Touch source files to invalidate previous build artifacts
-RUN touch crates/core/src/lib.rs crates/server/src/main.rs
+# Copy the full workspace. The server crate does not depend on every member,
+# but Cargo still needs all workspace manifests to resolve the package graph.
+COPY Cargo.toml Cargo.lock ./
+COPY crates crates
 
 # Build the server
 RUN cargo build --release -p type-bridge-server

--- a/type-bridge-core/crates/orm/src/expr.rs
+++ b/type-bridge-core/crates/orm/src/expr.rs
@@ -324,10 +324,8 @@ impl Expr {
         seen: &mut std::collections::HashSet<String>,
     ) {
         match self {
-            Self::RolePlayer { role, .. } => {
-                if seen.insert(role.clone()) {
-                    roles.push(role.clone());
-                }
+            Self::RolePlayer { role, .. } if seen.insert(role.clone()) => {
+                roles.push(role.clone());
             }
             Self::And(children) | Self::Or(children) => {
                 for child in children {

--- a/type-bridge-core/crates/server/src/config.rs
+++ b/type-bridge-core/crates/server/src/config.rs
@@ -100,8 +100,31 @@ fn default_audit_output() -> String {
 impl ServerConfig {
     pub fn from_file(path: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let content = std::fs::read_to_string(path)?;
-        let config: ServerConfig = toml::from_str(&content)?;
+        let mut config: ServerConfig = toml::from_str(&content)?;
+        config.apply_env_overrides();
         Ok(config)
+    }
+
+    fn apply_env_overrides(&mut self) {
+        self.apply_env_overrides_from(|name| std::env::var(name).ok());
+    }
+
+    fn apply_env_overrides_from<F>(&mut self, mut get_env: F)
+    where
+        F: FnMut(&str) -> Option<String>,
+    {
+        if let Some(address) = get_env("TYPEDB_ADDRESS") {
+            self.typedb.address = address;
+        }
+        if let Some(database) = get_env("TYPEDB_DATABASE") {
+            self.typedb.database = database;
+        }
+        if let Some(username) = get_env("TYPEDB_USERNAME") {
+            self.typedb.username = username;
+        }
+        if let Some(password) = get_env("TYPEDB_PASSWORD") {
+            self.typedb.password = password;
+        }
     }
 }
 
@@ -166,6 +189,23 @@ database = "mydb"
         assert_eq!(audit.file_path, "/tmp/audit.log");
         assert_eq!(config.logging.level, "debug");
         assert_eq!(config.logging.format, "text");
+    }
+
+    #[test]
+    fn env_overrides_typedb_section() {
+        let mut config: ServerConfig = toml::from_str(FULL_CONFIG).unwrap();
+        config.apply_env_overrides_from(|name| match name {
+            "TYPEDB_ADDRESS" => Some("typedb:1729".to_string()),
+            "TYPEDB_DATABASE" => Some("docker_db".to_string()),
+            "TYPEDB_USERNAME" => Some("docker_user".to_string()),
+            "TYPEDB_PASSWORD" => Some("docker_pass".to_string()),
+            _ => None,
+        });
+
+        assert_eq!(config.typedb.address, "typedb:1729");
+        assert_eq!(config.typedb.database, "docker_db");
+        assert_eq!(config.typedb.username, "docker_user");
+        assert_eq!(config.typedb.password, "docker_pass");
     }
 
     #[test]

--- a/type-bridge-core/crates/server/src/transport/http.rs
+++ b/type-bridge-core/crates/server/src/transport/http.rs
@@ -6,6 +6,7 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde::Serialize;
+use type_bridge_core_lib::query_parser::parse_typeql_query;
 
 use crate::error::PipelineError;
 use crate::pipeline::{QueryInput, QueryPipeline, ValidateInput};
@@ -58,6 +59,7 @@ impl IntoResponse for PipelineError {
 pub fn create_router(pipeline: Arc<QueryPipeline>) -> Router {
     Router::new()
         .route("/query", post(handle_query))
+        .route("/query/raw", post(handle_raw_query))
         .route("/query/validate", post(handle_validate))
         .route("/health", get(handle_health))
         .route("/schema", get(handle_schema))
@@ -75,6 +77,32 @@ async fn handle_query(
             database: req.database,
             transaction_type: req.transaction_type,
             clauses: req.clauses,
+            metadata: req.metadata,
+        })
+        .await?;
+
+    Ok(Json(QueryResponse {
+        status: "ok".to_string(),
+        results: output.results,
+        metadata: ResponseMetadata {
+            request_id: output.request_id,
+            execution_time_ms: output.execution_time_ms,
+            interceptors_applied: output.interceptors_applied,
+        },
+    }))
+}
+
+async fn handle_raw_query(
+    State(pipeline): State<Arc<QueryPipeline>>,
+    Json(req): Json<RawQueryRequest>,
+) -> Result<Json<QueryResponse>, PipelineError> {
+    let clauses = parse_typeql_query(&req.query).map_err(|e| PipelineError::Parse(e.to_string()))?;
+
+    let output = pipeline
+        .execute_query(QueryInput {
+            database: req.database,
+            transaction_type: req.transaction_type,
+            clauses,
             metadata: req.metadata,
         })
         .await?;
@@ -375,6 +403,37 @@ mod tests {
         let json = body_json(resp).await;
         assert_eq!(json["status"], "ok");
         assert!(!json["metadata"]["request_id"].as_str().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn raw_query_success() {
+        let router = app(MockExecutor::new(), false);
+        let body = serde_json::json!({
+            "transaction_type": "read",
+            "query": "match $p isa person; fetch { \"person\": { $p.* } };"
+        });
+        let req = json_request("POST", "/query/raw", body);
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let json = body_json(resp).await;
+        assert_eq!(json["status"], "ok");
+        assert!(!json["metadata"]["request_id"].as_str().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn raw_query_parse_error() {
+        let router = app(MockExecutor::new(), false);
+        let body = serde_json::json!({
+            "transaction_type": "read",
+            "query": "this is not valid typeql!!!"
+        });
+        let req = json_request("POST", "/query/raw", body);
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        let json = body_json(resp).await;
+        assert_eq!(json["error"]["code"], "PARSE_ERROR");
     }
 
     #[tokio::test]

--- a/type-bridge-core/crates/server/src/transport/types.rs
+++ b/type-bridge-core/crates/server/src/transport/types.rs
@@ -12,6 +12,16 @@ pub struct QueryRequest {
     pub metadata: HashMap<String, serde_json::Value>,
 }
 
+/// Request body for POST /query/raw.
+#[derive(Debug, Deserialize)]
+pub struct RawQueryRequest {
+    pub database: Option<String>,
+    pub transaction_type: String,
+    pub query: String,
+    #[serde(default)]
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+
 /// Request body for POST /query/validate.
 #[derive(Debug, Deserialize)]
 pub struct ValidateRequest {

--- a/type-bridge-core/pyproject.toml
+++ b/type-bridge-core/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 name = "type-bridge-core"
 version = "1.4.4"
 description = "Rust core for type-bridge ORM"
-requires-python = ">=3.13"
+requires-python = ">=3.13,<3.15"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",

--- a/type_bridge/__init__.py
+++ b/type_bridge/__init__.py
@@ -49,7 +49,7 @@ from type_bridge.models import Entity, Relation, Role, TypeDBType
 from type_bridge.proxy import ProxyDatabase, ProxyError
 from type_bridge.query import Query, QueryBuilder
 from type_bridge.session import Connection, Database, TransactionContext
-from type_bridge.typedb_driver import Credentials, TransactionType, TypeDB
+from type_bridge.typedb_driver import Credentials, TransactionType, TypeDB, create_driver_options
 
 __version__ = "1.4.4"
 
@@ -62,6 +62,7 @@ __all__ = [
     "Credentials",
     "TransactionType",
     "TypeDB",
+    "create_driver_options",
     # Models
     "TypeDBType",
     "Entity",

--- a/type_bridge/crud/role_players.py
+++ b/type_bridge/crud/role_players.py
@@ -1,12 +1,13 @@
 """Role player utilities for relations."""
 
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
 from type_bridge.crud.formatting import format_value
 from type_bridge.crud.types import hydrate_attributes, wrap_attribute_value
 
 if TYPE_CHECKING:
-    from type_bridge.models import Entity, Relation
+    from type_bridge.models import Relation, TypeDBType
 
 
 def build_role_player_match(var_name: str, entity: Any, entity_type_name: str) -> str:
@@ -60,8 +61,8 @@ def build_role_player_match(var_name: str, entity: Any, entity_type_name: str) -
 
 def resolve_entity_class_from_label(
     type_label: str | None,
-    allowed_entity_classes: tuple[type["Entity"], ...],
-) -> type["Entity"]:
+    allowed_entity_classes: tuple[type["TypeDBType"], ...],
+) -> type["TypeDBType"]:
     """Resolve the correct Python entity class from a TypeDB type label.
 
     This is a thin wrapper around ModelRegistry.resolve() that provides
@@ -134,6 +135,24 @@ def group_results_by_iid(results: list[dict[str, Any]]) -> dict[str, list[dict[s
     return grouped
 
 
+def _set_iid(instance: Any, iid: str | None) -> None:
+    """Set the TypeDB IID on a hydrated instance."""
+    if not iid:
+        return
+
+    private = getattr(instance, "__pydantic_private__", None)
+    if private is not None:
+        private["_iid"] = iid
+    else:
+        object.__setattr__(instance, "_iid", iid)
+
+
+def _is_relation_class(model_class: type[Any]) -> bool:
+    from type_bridge.models import Relation
+
+    return issubclass(model_class, Relation)
+
+
 def extract_relation_attributes(
     model_class: type["Relation"],
     result: dict[str, Any],
@@ -175,7 +194,7 @@ def extract_relation_attributes(
 
 def extract_role_players_from_results(
     result_group: list[dict[str, Any]],
-    role_info: dict[str, tuple[str, tuple[type["Entity"], ...]]],
+    role_info: Mapping[str, tuple[str, tuple[type["TypeDBType"], ...]]],
     multi_player_roles: set[str],
 ) -> dict[str, Any]:
     """Extract and deduplicate role players from grouped query results.
@@ -214,15 +233,25 @@ def extract_role_players_from_results(
                     entity_class, player_data, wrap_values=True
                 )
 
-                # Create entity instance if we have any non-None attributes
-                # Note: Relations as role players may have no owned attributes
-                if player_attrs == {} or any(v is not None for v in player_attrs.values()):
-                    # Deduplicate players based on their attribute values
-                    if key_values not in seen_player_keys:
-                        seen_player_keys.add(key_values)
-                        player_entity = entity_class(**player_attrs)
-                        if player_iid:
-                            object.__setattr__(player_entity, "_iid", player_iid)
+                # Create a role-player instance if the row proves a player exists.
+                # Relations used as role players are fetched as nested placeholders:
+                # TypeDB returns their IID/type and owned attributes, but not their
+                # own role players. Construct them without validation so required
+                # roles are not demanded for a partial reference.
+                has_player_data = (
+                    player_iid is not None
+                    or player_attrs == {}
+                    or any(v is not None for v in player_attrs.values())
+                )
+                if has_player_data:
+                    player_key = ("iid", player_iid) if player_iid else ("keys", key_values)
+                    if player_key not in seen_player_keys:
+                        seen_player_keys.add(player_key)
+                        if _is_relation_class(entity_class):
+                            player_entity = entity_class.model_construct(**player_attrs)
+                        else:
+                            player_entity = entity_class(**player_attrs)
+                        _set_iid(player_entity, player_iid)
                         collected_players.append(player_entity)
 
         # Store collected players

--- a/type_bridge/crud/strategies.py
+++ b/type_bridge/crud/strategies.py
@@ -155,19 +155,66 @@ class RelationStrategy(ModelStrategy["Relation"]):
             role_vars[role_name] = role_var
             role_info[role_name] = (role_var, role.player_entity_types)
 
+        constrained_roles = set()
+        for field_name in filters:
+            if field_name in roles:
+                constrained_roles.add(field_name)
+        for field_name, _ in order_by or []:
+            role_name = field_name.split("__", 1)[0]
+            if role_name in roles:
+                constrained_roles.add(role_name)
+
+        if expressions:
+            from type_bridge.expressions.role_player import RolePlayerExpr
+
+            constrained_roles.update(
+                expr.role_name for expr in expressions if isinstance(expr, RolePlayerExpr)
+            )
+
         # Build match clause using isa! pattern for type variable binding
         # This enables label($t) to fetch the actual type name
-        role_player_parts = [f"{roles[rn].role_name}: {rv}" for rn, rv in role_vars.items()]
+        required_role_names = [
+            role_name
+            for role_name, role in roles.items()
+            if not role.is_optional or role_name in constrained_roles
+        ]
+        optional_role_names = [
+            role_name
+            for role_name, role in roles.items()
+            if role.is_optional and role_name not in constrained_roles
+        ]
+
+        role_player_parts = [
+            f"{roles[role_name].role_name}: {role_vars[role_name]}"
+            for role_name in required_role_names
+        ]
         roles_str = ", ".join(role_player_parts)
 
         # Use isa! to bind exact type to $t for label() function
-        match_clauses = [f"{var} isa! $t ({roles_str})", f"$t sub {base_type}"]
+        relation_pattern = f"{var} isa! $t"
+        if roles_str:
+            relation_pattern += f" ({roles_str})"
+        match_clauses = [relation_pattern, f"$t sub {base_type}"]
 
-        # Add type variable bindings for each role player to enable label() fetch
-        for role_name in roles:
-            role_var = f"${role_name}"
+        # Add type variable bindings for required role players to enable label() fetch
+        for role_name in required_role_names:
+            role_var = role_vars[role_name]
             type_var = f"{role_var}_type"
             match_clauses.append(f"{role_var} isa! {type_var}")
+
+        # Optional roles must not participate in the primary relation pattern.
+        # Matching them inside try blocks lets relation instances with no player
+        # for that role remain visible while still fetching players when present.
+        for role_name in optional_role_names:
+            role = roles[role_name]
+            role_var = role_vars[role_name]
+            type_var = f"{role_var}_type"
+            match_clauses.append(
+                "try {\n"
+                f"  {var} links ({role.role_name}: {role_var});\n"
+                f"  {role_var} isa! {type_var};\n"
+                "}"
+            )
 
         # Add attribute filter clauses to relation match
         for field_name, value in filters.items():

--- a/type_bridge/crud/types.py
+++ b/type_bridge/crud/types.py
@@ -8,7 +8,7 @@ from type_bridge.attribute import AttributeFlags
 from type_bridge.crud.formatting import unwrap_attribute
 
 if TYPE_CHECKING:
-    from type_bridge.models import Entity
+    from type_bridge.models import TypeDBType
     from type_bridge.models.utils import ModelAttrInfo
 
 
@@ -141,7 +141,7 @@ def build_metadata_fetch(var: str) -> str:
 
 
 def hydrate_attributes(
-    entity_class: type[Entity],
+    entity_class: type[TypeDBType],
     raw_data: dict[str, Any],
     wrap_values: bool = False,
 ) -> tuple[dict[str, Any], tuple[tuple[str, Any], ...]]:

--- a/type_bridge/models/registry.py
+++ b/type_bridge/models/registry.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, TypeVar, cast
 
 if TYPE_CHECKING:
     from type_bridge.models.base import TypeDBType
-    from type_bridge.models.entity import Entity
 
 logger = logging.getLogger(__name__)
 
@@ -63,8 +62,8 @@ class ModelRegistry:
     def resolve(
         cls,
         type_label: str | None,
-        allowed_classes: tuple[type[Entity], ...],
-    ) -> type[Entity]:
+        allowed_classes: tuple[type[T], ...],
+    ) -> type[T]:
         """Resolve a TypeDB type label to a Python model class.
 
         This is the unified method for polymorphic class resolution. It:
@@ -88,7 +87,7 @@ class ModelRegistry:
             # Verify the cached class is compatible with allowed_classes
             for allowed in allowed_classes:
                 if issubclass(cached, allowed):
-                    return cached  # type: ignore[return-value]
+                    return cast("type[T]", cached)
 
         # Try central registry
         registered = cls._registry.get(type_label)
@@ -97,7 +96,7 @@ class ModelRegistry:
             for allowed in allowed_classes:
                 if issubclass(registered, allowed):
                     cls._resolution_cache[type_label] = registered
-                    return registered  # type: ignore[return-value]
+                    return cast("type[T]", registered)
 
         # Quick check: direct match against allowed classes
         for allowed_cls in allowed_classes:
@@ -106,12 +105,12 @@ class ModelRegistry:
                 return allowed_cls
 
         # Fallback: search through subclasses
-        def find_in_subclasses(search_cls: type[Entity]) -> type[Entity] | None:
+        def find_in_subclasses(search_cls: type[T]) -> type[T] | None:
             """Recursively search subclasses for matching type name."""
             for subclass in search_cls.__subclasses__():
                 if subclass.get_type_name() == type_label:
-                    return subclass
-                found = find_in_subclasses(subclass)
+                    return cast("type[T]", subclass)
+                found = find_in_subclasses(cast("type[T]", subclass))
                 if found:
                     return found
             return None

--- a/type_bridge/models/relation.py
+++ b/type_bridge/models/relation.py
@@ -7,11 +7,13 @@ from typing import (
     TYPE_CHECKING,
     Any,
     ClassVar,
+    Self,
     TypeVar,
+    cast,
     dataclass_transform,
 )
 
-from pydantic import ConfigDict
+from pydantic import ConfigDict, model_validator
 
 from type_bridge.attribute import AttributeFlags, TypeFlags
 from type_bridge.crud.utils import extract_entity_key, unwrap_attribute
@@ -124,6 +126,36 @@ class Relation(TypeDBType):
             Dictionary mapping role names to Role instances
         """
         return cls._roles
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_unset_roles(cls, values: Any) -> Any:
+        """Prevent class-level RoleRef defaults from leaking into instances."""
+        if not isinstance(values, dict):
+            return values
+
+        from type_bridge.fields.role import RoleRef
+
+        data = dict(values)
+        for role_name in cls._roles:
+            value = data.get(role_name)
+            if role_name not in data or isinstance(value, RoleRef):
+                data[role_name] = None
+        return data
+
+    @model_validator(mode="after")
+    def _validate_required_roles(self) -> Self:
+        """Reject missing role players for roles with required cardinality."""
+        from type_bridge.fields.role import RoleRef
+
+        for role_name, role in self.__class__._roles.items():
+            value = self.__dict__.get(role_name)
+            if isinstance(value, RoleRef):
+                value = None
+                cast("dict[str, Any]", self.__dict__)[role_name] = None
+            if value is None and not role.is_optional:
+                raise ValueError(f"Role player '{role_name}' is required")
+        return self
 
     def to_ast(self, var: str = "$r") -> InsertClause:
         """Generate AST InsertClause for this relation instance.

--- a/type_bridge/models/role.py
+++ b/type_bridge/models/role.py
@@ -122,6 +122,11 @@ class Role[T: "TypeDBType"]:
             return False  # Default is single player
         return self.cardinality.max is None or self.cardinality.max > 1
 
+    @property
+    def is_optional(self) -> bool:
+        """Check if this role allows zero players."""
+        return self.cardinality is not None and self.cardinality.min == 0
+
     def __set_name__(self, owner: type, name: str) -> None:
         """Called when role is assigned to a class."""
         self.attr_name = name
@@ -158,6 +163,13 @@ class Role[T: "TypeDBType"]:
         For roles with cardinality > 1, accepts a list of entities.
         For single-player roles, accepts a single entity.
         """
+        if value is None:
+            if not self.is_optional:
+                allowed = ", ".join(pt.__name__ for pt in self.player_entity_types)
+                raise TypeError(f"Role '{self.role_name}' expects types ({allowed}), got NoneType")
+            obj.__dict__[self.attr_name] = None
+            return
+
         if isinstance(value, list):
             # Multi-player role - validate each item in the list
             if not self.is_multi_player:
@@ -245,6 +257,9 @@ class Role[T: "TypeDBType"]:
             E.g., if Document is allowed and Report is a subclass of Document,
             Report instances are accepted.
             """
+            if value is None:
+                return None
+
             if not allowed_names:
                 # No type constraints - allow anything
                 return value

--- a/type_bridge/session.py
+++ b/type_bridge/session.py
@@ -6,7 +6,6 @@ from typing import Any, overload
 from typedb.driver import (
     Credentials,
     Driver,
-    DriverOptions,
     TransactionType,
     TypeDB,
 )
@@ -15,6 +14,7 @@ from typedb.driver import (
 )
 
 from type_bridge.proxy import ProxyDatabase, ProxyTransaction, ProxyTransactionContext
+from type_bridge.typedb_driver import create_driver_options
 
 logger = logging.getLogger(__name__)
 
@@ -195,7 +195,7 @@ class Database:
             # Create driver options
             # Disable TLS for local connections (non-HTTPS addresses)
             is_tls_enabled = self.address.startswith("https://")
-            driver_options = DriverOptions(is_tls_enabled=is_tls_enabled)
+            driver_options = create_driver_options(is_tls_enabled=is_tls_enabled)
             logger.debug(f"TLS enabled: {is_tls_enabled}")
 
             # Connect to TypeDB

--- a/type_bridge/typedb_driver.py
+++ b/type_bridge/typedb_driver.py
@@ -11,10 +11,29 @@ Example:
     # from type_bridge import Database
 """
 
-from typedb.driver import Credentials, TransactionType, TypeDB
+from typedb.driver import Credentials, DriverOptions, TransactionType, TypeDB
+
+
+def create_driver_options(is_tls_enabled: bool = False) -> DriverOptions:
+    """Create TypeDB driver options across supported driver versions."""
+    try:
+        return DriverOptions(is_tls_enabled=is_tls_enabled)
+    except TypeError:
+        typedb_driver = __import__("typedb.driver", fromlist=["DriverTlsConfig"])
+        driver_tls_config = getattr(typedb_driver, "DriverTlsConfig")
+
+        tls_config = (
+            driver_tls_config.enabled_with_native_root_ca()
+            if is_tls_enabled
+            else driver_tls_config.disabled()
+        )
+        return DriverOptions(tls_config)
+
 
 __all__ = [
     "Credentials",
+    "DriverOptions",
     "TransactionType",
     "TypeDB",
+    "create_driver_options",
 ]


### PR DESCRIPTION
## Summary

- Bugfix of #126: base commit `9c21f91` hydrates relation role-player
  references by IID.
- Bugfix of #127: this branch fixes relation fetch queries so optional roles
  do not hide relation instances when those roles have no players.
- Driver/runtime update: this branch pins the TypeDB driver/runtime test
  environment used to reproduce and verify both relation-read fixes.

## Bugfix of #126

Base commit `9c21f91` (`fix: hydrate relation role-player references by IID`)
normalizes omitted optional roles and lets nested relation role players hydrate
as partial IID-backed references.

That matters for this PR because #127 also works in the relation-read path, and
its regression coverage depends on relation hydration preserving missing
optional roles correctly.

## Bugfix of #127

- Exclude unconstrained `Card(0, ...)` roles from the primary relation match.
- Fetch optional role players through TypeQL `try` blocks when present.
- Keep optional roles required when filters, role expressions, or ordering
  explicitly reference that role.
- Add a live regression test where `manager.all()` returns relations both with
  and without an optional role player.

## Driver/Runtime Update

- Add a pinned Docker-in-Docker integration runner for Python 3.13.5 and
  TypeDB Server 3.10.4.
- Pin the Python driver line to `typedb-driver==3.10.0`.

## Verification

- `uv run --extra dev ruff check --fix .`
- `uv run --extra dev ruff format .`
- `uv run --extra dev pyright type_bridge/`
- `uv run --extra dev pyright tests/`
- `uv run --extra dev pytest tests/unit/ -x`
- `./test-integration-dind.sh -v --tb=short`
- `./test-proxy-integration.sh -v --tb=short`
- `cargo test --manifest-path type-bridge-core/Cargo.toml --all-targets`

Focused #127 regression:

```bash
./test-integration-dind.sh \
  tests/integration/crud/relations/test_fetch.py::test_fetch_all_includes_relations_with_empty_optional_roles \
  -v --tb=short
```

Fixes: #126
Fixes: #127