### PR TITLE
fix(core): support grpc-only TypeDB connect (#154)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -704,14 +704,16 @@ jobs:
           TYPEDB_ADDRESS: localhost:1729
         run: npm run test:integration
 
-  # Version-gate rejection cells: each cell boots a server and checks the
-  # relevant path rejects with the expected error class.
+  # Version-gate cells: each cell boots a server and checks either a positive
+  # connect path or the expected rejection class.
+  #   POS-grpc-fallback-band8: wrong HTTP port still connects through gRPC band 8.
+  #   POS-grpc-fallback-band7: wrong HTTP port tries band 8, then connects through band 7.
   #   NEG-window: Database.connect() rejects unsupported servers.
   #   NEG-driver: Database.driver rejects incompatible installed Python drivers.
-  # The band-7 servers (3.8.3, 3.10.4) are now SERVED: they are proven green
-  # by the positive test-integration and node-integration legs and no longer
-  # need a separate rejection cell. Cell versions mirror the version SSOT in
-  # crates/core and the compatibility table.
+  # The band-7 servers (3.8.3, 3.10.4) are now SERVED: normal operation is
+  # proven green by the test-integration and node-integration legs, while the
+  # gRPC-only fallback is covered here as an explicit positive cell. Cell
+  # versions mirror the version SSOT in crates/core and the compatibility table.
   version-gate-cells:
     name: Version gate (${{ matrix.cell }})
     runs-on: ubuntu-latest
@@ -719,16 +721,30 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - cell: POS-grpc-fallback-band8
+            typedb-server: "typedb/typedb:3.11.5"
+            python-driver: "3.11.5"
+            probe: connect
+            http-port: 1
+            expect: ok
+          - cell: POS-grpc-fallback-band7
+            typedb-server: "typedb/typedb:3.10.4"
+            python-driver: "3.10.0"
+            probe: connect
+            http-port: 1
+            expect: ok
           - cell: NEG-window
             typedb-server: "typedb/typedb:3.7.3"
             python-driver: "3.11.5"
             probe: connect
-            expect-class: window
+            http-port: 8000
+            expect: window
           - cell: NEG-driver
             typedb-server: "typedb/typedb:3.11.5"
             python-driver: "3.10.0"
             probe: driver
-            expect-class: installed
+            http-port: 8000
+            expect: installed
 
     services:
       typedb:
@@ -783,5 +799,5 @@ jobs:
           done
           nc -z localhost 1729
 
-      - name: Assert version-gate rejection
-        run: uv run python scripts/ci/assert_gate_rejection.py --address localhost:1729 --probe ${{ matrix.probe }} --expect-class ${{ matrix.expect-class }}
+      - name: Assert version-gate cell
+        run: uv run python scripts/ci/assert_gate_rejection.py --address localhost:1729 --probe ${{ matrix.probe }} --http-port ${{ matrix.http-port }} --expect ${{ matrix.expect }}

--- a/docs/development/typedb.md
+++ b/docs/development/typedb.md
@@ -56,15 +56,18 @@ mismatches the server's band — before any transaction is attempted, never mid-
 The error names the relevant versions and tells you exactly what to do. It never exposes
 raw protocol numbers.
 
-The probe calls `GET :<http_port>/v1/version` on the server's HTTP API port. If that endpoint
-is unreachable the probe fails closed (connection refused, not a silent pass).
+By default, the gate calls `GET :<http_port>/v1/version` on the server's HTTP API port.
+If that endpoint is unreachable and no exact server version was supplied, TypeBridge
+falls back to gRPC protocol negotiation: it tries the band-8 driver first, then the
+band-7 driver. If both gRPC attempts fail, the gate fails loudly with all attempted
+paths in the error.
 
 ### HTTP version-probe port
 
 TypeDB exposes a version endpoint over HTTP in addition to its gRPC port. TypeBridge
 probes this endpoint at connect time to determine the server version before committing
 to a driver construction. The probe port defaults to `8000` but must match the HTTP port
-of the specific TypeDB instance being targeted.
+of the specific TypeDB instance being targeted unless you supply `server_version`.
 
 On a host running multiple TypeDB instances (for example, a primary on `:8000` and a
 test instance remapped to `:9000`), probing the wrong port silently validates the wrong
@@ -82,6 +85,37 @@ db.connect()
 db = Database(address="localhost:1729", database="mydb", http_port=9000)
 db.connect()
 ```
+
+### gRPC-only deployments
+
+If the TypeDB server exposes gRPC but disables or firewalls the HTTP API, TypeBridge
+can still connect by falling back to gRPC protocol negotiation. The fallback tries
+band 8 before band 7 and reports both failures if neither driver can open a
+connection.
+
+For strict exact-version validation on gRPC-only deployments, pass the exact server
+version explicitly:
+
+```python
+db = Database(
+    address="localhost:1729",
+    database="mydb",
+    server_version="3.10.4",
+)
+db.connect()
+```
+
+When `server_version` is set, TypeBridge skips the HTTP probe and gRPC fallback,
+validates the supplied semantic version against the same support window, derives the
+protocol band from the validated version, and then opens the matching embedded Rust
+driver.
+
+Use an exact TypeDB version such as `3.8.3`, `3.10.4`, or `3.11.5`; do not substitute a
+raw protocol band. Band 7 includes unsupported TypeDB `3.7.x` as well as supported
+`3.8.x` and `3.10.x`. When HTTP is unavailable, automatic band-7 fallback can identify
+the protocol band but not the exact semantic version; use `server_version` when that
+exact validation is required. Invalid or unsupported pinned versions still fail with
+`VersionError`.
 
 **Node binding**
 

--- a/scripts/ci/assert_gate_rejection.py
+++ b/scripts/ci/assert_gate_rejection.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
-"""Assert that the TypeBridge version gate rejects with the expected error class.
+"""Assert a TypeBridge version-gate CI matrix cell.
 
-CI's rejection cells call this against a live TypeDB service container. A cell
-is green when the requested probe path raises with the expected error class,
-and the message respects the human-version contract (no protocol band numbers,
-no ``0.0.0``).
+CI calls this against a live TypeDB service container. Rejection cells are green
+when the requested probe path raises with the expected error class, and the
+message respects the human-version contract (no protocol band numbers, no
+``0.0.0``). Positive cells are green when the requested probe path succeeds.
 
 Usage:
-    assert_gate_rejection.py --address localhost:1729 --probe connect --expect-class window
-    assert_gate_rejection.py --address localhost:1729 --probe driver --expect-class installed
+    assert_gate_rejection.py --address localhost:1729 --probe connect --expect window
+    assert_gate_rejection.py --address localhost:1729 --probe driver --expect installed
+    assert_gate_rejection.py --address localhost:1729 --probe connect --http-port 1 --expect ok
 """
 
 from __future__ import annotations
@@ -41,40 +42,67 @@ def main() -> int:
     )
     parser.add_argument(
         "--expect-class",
-        required=True,
+        required=False,
         choices=sorted(CLASS_MARKERS),
-        help="Which gate check must have produced the rejection",
+        help="Deprecated alias for --expect when expecting a rejection class",
+    )
+    parser.add_argument(
+        "--expect",
+        required=False,
+        choices=["ok", *sorted(CLASS_MARKERS)],
+        help="Expected outcome: ok for success, otherwise the rejection class",
+    )
+    parser.add_argument(
+        "--http-port",
+        type=int,
+        default=8000,
+        help="HTTP version-probe port to pass into Database",
     )
     args = parser.parse_args()
+    expect = args.expect or args.expect_class
+    if expect is None:
+        parser.error("--expect is required")
 
     import type_bridge_core
 
     from type_bridge.session import Database
 
-    db = Database(address=args.address, database="ci_gate_rejection_probe")
+    db = Database(
+        address=args.address,
+        database="ci_gate_rejection_probe",
+        http_port=args.http_port,
+    )
     try:
         if args.probe == "driver":
             _ = db.driver
         else:
             db.connect()
     except type_bridge_core.VersionError as exc:
+        if expect == "ok":
+            print(f"FAIL: {args.probe} rejected unexpectedly: {exc}")
+            return 1
         msg = str(exc)
         print(f"gate fired at {args.probe}: {msg}")
-        marker = CLASS_MARKERS[args.expect_class]
+        marker = CLASS_MARKERS[expect]
         if marker not in msg:
-            print(f"FAIL: expected the {args.expect_class!r} class marker {marker!r}")
+            print(f"FAIL: expected the {expect!r} class marker {marker!r}")
             return 1
-        if args.expect_class == "installed" and CLASS_MARKERS["embedded"] in msg:
+        if expect == "installed" and CLASS_MARKERS["embedded"] in msg:
             print("FAIL: installed-class rejection carries the embedded framing")
             return 1
         for forbidden in FORBIDDEN:
             if forbidden in msg:
                 print(f"FAIL: message exposes forbidden token {forbidden!r}")
                 return 1
-        print(f"OK: version-gate rejection with the {args.expect_class!r} error class")
+        print(f"OK: version-gate rejection with the {expect!r} error class")
         return 0
 
-    print(f"FAIL: {args.probe} succeeded — the gate did not fire")
+    db.close()
+    if expect == "ok":
+        print(f"OK: {args.probe} succeeded")
+        return 0
+
+    print(f"FAIL: {args.probe} succeeded - the gate did not fire")
     return 1
 
 

--- a/tests/integration/session/test_version_gate.py
+++ b/tests/integration/session/test_version_gate.py
@@ -184,6 +184,40 @@ class TestVersionGateExplicitHttpPort:
 
 
 @pytest.mark.integration
+@pytest.mark.order(4122)
+class TestVersionGatePinnedServerVersion:
+    """Pinned server_version bypasses the HTTP probe on a live server."""
+
+    def test_server_version_pin_connects_with_unreachable_http_port(self, test_database):
+        """A pinned exact version lets connect use gRPC even when http_port is wrong."""
+        from tests.integration.conftest import TEST_DB_ADDRESS
+
+        detected_server = _tdm.server_version(TEST_DB_ADDRESS, tls=False)
+        db = Database(
+            address=TEST_DB_ADDRESS,
+            database=test_database,
+            http_port=1,
+            server_version=detected_server,
+        )
+        db.connect()
+        assert getattr(db, "_rust_backend_database", None) is not None
+        db.close()
+
+    def test_http_probe_failure_falls_back_to_grpc(self, test_database):
+        """Without a pin, an unreachable HTTP port falls back to gRPC band negotiation."""
+        from tests.integration.conftest import TEST_DB_ADDRESS
+
+        db = Database(
+            address=TEST_DB_ADDRESS,
+            database=test_database,
+            http_port=1,
+        )
+        db.connect()
+        assert getattr(db, "_rust_backend_database", None) is not None
+        db.close()
+
+
+@pytest.mark.integration
 @pytest.mark.order(413)
 class TestDistinctOrderedFormLive:
     """The ordered-role @distinct form is the one every live server accepts."""

--- a/tests/unit/infra/test_default_band_coherence.py
+++ b/tests/unit/infra/test_default_band_coherence.py
@@ -100,11 +100,10 @@ class TestDefaultBandCoherence:
         2. Every other server image in those matrices is on a band-7 line (3.8.x or
            3.10.x) — confirmed via the version SSOT, not a hardcoded list.  Adding a
            band-7 patch bump won't break this test.
-        3. The version-gate-cells matrix contains no server whose band is a key in
-           embedded_driver_versions() EXCEPT in the NEG-driver cell (which tests the
-           installed-driver mismatch, not the embedded gate).  In practice this means
-           3.8.x and 3.10.x servers must not appear in version-gate-cells; the only
-           band-8 server allowed there is the NEG-driver cell's 3.11.5.
+        3. The version-gate-cells matrix may contain served band-7 servers only
+           as explicit positive gRPC fallback cells.  They must not reappear as
+           rejection cells, because band-7 servers are now served by the embedded
+           runtime.
         """
         versions = _embedded_versions()
         band8_pin = versions[8]
@@ -154,34 +153,47 @@ class TestDefaultBandCoherence:
                     f"band {ver_band!r}, expected band 7 (the non-band-8 served lines)"
                 )
 
-        # --- Gate cells: no SAFE (served, within-window) band-7 servers remain ---
+        # --- Gate cells: served band-7 servers are only positive fallback cells ---
         gate_block = _job_block(gate_job)
         assert gate_block, f"ci.yml: job '{gate_job}' not found"
-        gate_images = re.findall(r'"typedb/typedb:([\d.]+)"', gate_block)
+        gate_cells = re.findall(
+            r"\n\s+- cell: ([^\n]+)(.*?)(?=\n\s+- cell:|\n\s+services:)",
+            gate_block,
+            re.DOTALL,
+        )
+        assert gate_cells, f"ci.yml job '{gate_job}': no matrix cells found"
 
         # A "served" band-7 server is one that (a) is within the support window
         # (check_server_supported passes) AND (b) is on band 7.  These were
-        # formerly SAFE cells (3.8.3, 3.10.4) and must now be positive legs.
-        # Sub-window band-7 servers (e.g. 3.7.3, the NEG-window cell) are still
-        # valid gate cells — they test the window-class rejection.
-        # The NEG-driver cell's band-8 server (3.11.5) is also allowed.
-        for ver in gate_images:
-            try:
-                type_bridge_core.check_server_supported(ver)
-                server_in_window = True
-            except type_bridge_core.VersionError:
-                server_in_window = False
+        # formerly SAFE rejection cells (3.8.3, 3.10.4).  They are valid here
+        # only when the cell proves the HTTP-failure -> gRPC fallback path.
+        for cell_name, cell_block in gate_cells:
+            images = re.findall(r'"typedb/typedb:([\d.]+)"', cell_block)
+            for ver in images:
+                try:
+                    type_bridge_core.check_server_supported(ver)
+                    server_in_window = True
+                except type_bridge_core.VersionError:
+                    server_in_window = False
 
-            if not server_in_window:
-                continue  # Below-floor or out-of-window rejection cell — fine
+                if not server_in_window:
+                    continue  # Below-floor or out-of-window rejection cell — fine
 
-            server_band = type_bridge_core.band(ver)
-            assert server_band != 7, (
-                f"ci.yml job '{gate_job}': within-window band-7 server "
-                f"typedb/typedb:{ver!r} still present in version-gate-cells; "
-                f"it should be a positive test-integration/node-integration leg, "
-                f"not a rejection cell (band-7 servers are now SERVED)"
-            )
+                server_band = type_bridge_core.band(ver)
+                if server_band != 7:
+                    continue
+
+                assert cell_name.startswith("POS-grpc-fallback-"), (
+                    f"ci.yml job '{gate_job}': within-window band-7 server "
+                    f"typedb/typedb:{ver!r} appears in non-fallback cell "
+                    f"{cell_name!r}; band-7 servers must be positive fallback "
+                    f"regressions, not rejection cells"
+                )
+                assert "http-port: 1" in cell_block and "expect: ok" in cell_block, (
+                    f"ci.yml job '{gate_job}' cell {cell_name!r}: band-7 fallback "
+                    f"regression must force HTTP failure with http-port: 1 and "
+                    f"expect success with expect: ok"
+                )
 
     def test_dev_pin_matches_embedded_line(self):
         """The dev extra pins a driver on the embedded driver's minor line."""

--- a/tests/unit/session/test_version_gate.py
+++ b/tests/unit/session/test_version_gate.py
@@ -428,6 +428,61 @@ class TestPythonDriverVersionGate:
         _ = db.driver
         mock_typedb.driver.assert_called_once()
 
+    def test_server_version_pin_skips_http_probe(self, monkeypatch: pytest.MonkeyPatch):
+        """driver access validates an explicit server_version without probing HTTP."""
+        import type_bridge.session as session_mod
+        import type_bridge.typedb_driver as tdm
+        from type_bridge.session import Database
+
+        def _unexpected_server_version(*args: object, **kwargs: object) -> str:
+            raise AssertionError("server_version HTTP probe should not be called")
+
+        monkeypatch.setattr(tdm, "driver_version", lambda: "3.8.1")
+        monkeypatch.setattr(tdm, "server_version", _unexpected_server_version)
+        monkeypatch.setattr(tdm, "DriverOptions", MagicMock())
+
+        fake_driver = MagicMock()
+        mock_typedb = MagicMock()
+        mock_typedb.driver.return_value = fake_driver
+        monkeypatch.setattr(session_mod, "TypeDB", mock_typedb)
+
+        db = Database(
+            address="localhost:1729",
+            database="test_db",
+            server_version="3.8.3",
+        )
+        _ = db.driver
+
+        mock_typedb.driver.assert_called_once()
+
+    def test_unsupported_server_version_pin_rejects_before_driver(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """unsupported explicit server_version fails before TypeDB.driver."""
+        import type_bridge.session as session_mod
+        import type_bridge.typedb_driver as tdm
+        from type_bridge.session import Database
+
+        def _unexpected_server_version(*args: object, **kwargs: object) -> str:
+            raise AssertionError("server_version HTTP probe should not be called")
+
+        monkeypatch.setattr(tdm, "driver_version", lambda: "3.8.1")
+        monkeypatch.setattr(tdm, "server_version", _unexpected_server_version)
+
+        mock_typedb = MagicMock()
+        monkeypatch.setattr(session_mod, "TypeDB", mock_typedb)
+
+        db = Database(
+            address="localhost:1729",
+            database="test_db",
+            server_version="3.7.3",
+        )
+        with pytest.raises(version.UnsupportedVersionError) as exc_info:
+            _ = db.driver
+
+        assert "3.7.3" in str(exc_info.value)
+        mock_typedb.driver.assert_not_called()
+
     def test_gate_fires_before_typedb_driver_on_unsupported_pair(
         self, monkeypatch: pytest.MonkeyPatch
     ):
@@ -562,6 +617,40 @@ class TestConnectHttpPortForwarding:
         db.connect()
 
         assert recorded == [9123], f"Expected http_port=9123 forwarded to Rust, got {recorded}"
+
+    def test_database_embedded_gate_forwards_server_version(self, monkeypatch: pytest.MonkeyPatch):
+        """server_version stored on Database is forwarded to PyRustDatabase.connect."""
+        import type_bridge._rust_runtime as rust_mod
+        import type_bridge.session as session_mod
+
+        recorded: list[tuple[int, str | None]] = []
+
+        class _FakeRustDB:
+            @staticmethod
+            def connect(
+                address,
+                database,
+                username,
+                password,
+                http_port,
+                server_version=None,
+            ):
+                recorded.append((http_port, server_version))
+                return _FakeRustDB()
+
+        fake_core = MagicMock()
+        fake_core.PyRustDatabase = _FakeRustDB
+        monkeypatch.setattr(rust_mod, "rust_core", lambda: fake_core)
+
+        db = session_mod.Database(
+            address="localhost:1729",
+            database="test_db",
+            http_port=9123,
+            server_version="3.10.4",
+        )
+        db.connect()
+
+        assert recorded == [(9123, "3.10.4")]
 
 
 class TestConnectProbeUnreachable:

--- a/type-bridge-core/crates/orm/src/session/real_driver.rs
+++ b/type-bridge-core/crates/orm/src/session/real_driver.rs
@@ -94,6 +94,12 @@ pub struct ConnectOptions {
     pub http_port: u16,
     /// Whether to use TLS for the HTTP version probe.
     pub tls: bool,
+    /// Exact server version supplied by the caller.
+    ///
+    /// When set, the connect gate validates this version and skips the HTTP
+    /// `/v1/version` probe. This is the supported path for gRPC-only TypeDB
+    /// deployments where the HTTP API is disabled or unreachable.
+    pub server_version: Option<core_version::Version>,
 }
 
 impl Default for ConnectOptions {
@@ -101,6 +107,7 @@ impl Default for ConnectOptions {
         Self {
             http_port: DEFAULT_HTTP_PORT,
             tls: false,
+            server_version: None,
         }
     }
 }
@@ -120,8 +127,11 @@ pub struct RealBackend {
 
 /// Version-gated [`DriverHandle`] constructor with an injectable probe.
 ///
-/// The `probe` closure is called with `(address, http_port, tls)` and must
-/// return the server version or a [`core_version::VersionError`].  Production
+/// When `options.server_version` is set, the supplied exact version is validated
+/// and the `probe` closure is not called. Otherwise, the `probe` closure is
+/// called with `(address, http_port, tls)` and must return the server version or
+/// a [`core_version::VersionError`]. If that HTTP probe fails, the constructor
+/// falls back to gRPC driver negotiation: band 8 first, then band 7. Production
 /// code passes [`core_version::server_version`]; tests inject a recording
 /// closure to exercise the gate without a live server.
 pub(crate) async fn gated_driver_with_probe<F>(
@@ -136,25 +146,46 @@ where
         + Send
         + 'static,
 {
-    // Probe the server version over HTTP (blocking I/O; offload to a
-    // dedicated thread so we don't block the async executor).
+    if let Some(server_version) = options.server_version {
+        return driver_for_server_version(address, username, password, server_version).await;
+    }
+
+    // Probe the server version over HTTP (blocking I/O; offload to a dedicated
+    // thread so we don't block the async executor).
     let address_owned = address.to_string();
     let http_port = options.http_port;
     let tls = options.tls;
-    let server_version = tokio::task::spawn_blocking(move || probe(&address_owned, http_port, tls))
+    match tokio::task::spawn_blocking(move || probe(&address_owned, http_port, tls))
         .await
         .map_err(|e| OrmError::Connection(format!("Version probe task panicked: {e}")))?
-        .map_err(OrmError::UnsupportedVersion)?;
+    {
+        Ok(server_version) => {
+            driver_for_server_version(address, username, password, server_version).await
+        }
+        Err(http_error) => grpc_fallback_driver(address, username, password, http_error).await,
+    }
+}
 
+fn validate_server_band(server_version: &core_version::Version) -> Result<u8, OrmError> {
     // Embedded-runtime gate: accept the server when it is in-window and its
     // band is one this build embedded.  Unlike the installed-driver gate
     // (check_supported, band equality), the embedded runtime carries every
     // compiled-in band, so a band-7 server is now served, not rejected.  After
     // this passes, band(&server_version) is guaranteed ∈ EMBEDDED_BANDS.
-    core_version::check_server_supported(&server_version, EMBEDDED_BANDS)
+    core_version::check_server_supported(server_version, EMBEDDED_BANDS)
         .map_err(OrmError::UnsupportedVersion)?;
 
-    let band = core_version::band(&server_version);
+    Ok(core_version::band(server_version)
+        .expect("check_server_supported accepted a server without a mapped band"))
+}
+
+async fn driver_for_server_version(
+    address: &str,
+    username: &str,
+    password: &str,
+    server_version: core_version::Version,
+) -> Result<DriverHandle, OrmError> {
+    let band = validate_server_band(&server_version)?;
 
     tracing::debug!(
         address,
@@ -164,15 +195,10 @@ where
     );
 
     #[cfg(feature = "band7")]
-    if band == Some(7) {
-        // Band-7 driver takes a raw address string and a two-argument
-        // DriverOptions::new(tls_enabled, ca_path).  TLS is disabled.
-        let opts = B7DriverOptions::new(false, None)
-            .map_err(|e| OrmError::Connection(format!("Band-7 driver options error: {e}")))?;
-        let driver = B7Driver::new(address, B7Credentials::new(username, password), opts)
+    if band == 7 {
+        return connect_band7_driver(address, username, password)
             .await
-            .map_err(|e| OrmError::Connection(format!("Failed to connect to {address}: {e}")))?;
-        return Ok(DriverHandle::B7(driver));
+            .map(DriverHandle::B7);
     }
 
     // Every band that is not 7 is band 8 here: the gate already rejected any
@@ -180,18 +206,9 @@ where
     // band-8 server this build embedded.
     #[cfg(feature = "band8")]
     {
-        // TLS is not plumbed in this crate today; the band-8 driver's
-        // `DriverTlsConfig::default()` would ENABLE it, so disable explicitly.
-        let addresses = Addresses::try_from_address_str(address)
-            .map_err(|e| OrmError::Connection(format!("Invalid TypeDB address {address}: {e}")))?;
-        let driver = B8Driver::new(
-            addresses,
-            B8Credentials::new(username, password),
-            DriverOptions::new(DriverTlsConfig::disabled()),
-        )
-        .await
-        .map_err(|e| OrmError::Connection(format!("Failed to connect to {address}: {e}")))?;
-        Ok(DriverHandle::B8(driver))
+        connect_band8_driver(address, username, password)
+            .await
+            .map(DriverHandle::B8)
     }
 
     // Unreachable by invariant: with band8 compiled out, EMBEDDED_BANDS cannot
@@ -202,6 +219,110 @@ where
     Err(OrmError::Connection(format!(
         "No compiled driver band supports the detected server band ({band:?})"
     )))
+}
+
+#[cfg(feature = "band7")]
+async fn connect_band7_driver(
+    address: &str,
+    username: &str,
+    password: &str,
+) -> Result<B7Driver, OrmError> {
+    // Band-7 driver takes a raw address string and a two-argument
+    // DriverOptions::new(tls_enabled, ca_path).  TLS is disabled.
+    let opts = B7DriverOptions::new(false, None)
+        .map_err(|e| OrmError::Connection(format!("Band-7 driver options error: {e}")))?;
+    B7Driver::new(address, B7Credentials::new(username, password), opts)
+        .await
+        .map_err(|e| OrmError::Connection(format!("Failed to connect to {address}: {e}")))
+}
+
+#[cfg(feature = "band8")]
+async fn connect_band8_driver(
+    address: &str,
+    username: &str,
+    password: &str,
+) -> Result<B8Driver, OrmError> {
+    // TLS is not plumbed in this crate today; the band-8 driver's
+    // `DriverTlsConfig::default()` would ENABLE it, so disable explicitly.
+    let addresses = Addresses::try_from_address_str(address)
+        .map_err(|e| OrmError::Connection(format!("Invalid TypeDB address {address}: {e}")))?;
+    B8Driver::new(
+        addresses,
+        B8Credentials::new(username, password),
+        DriverOptions::new(DriverTlsConfig::disabled()),
+    )
+    .await
+    .map_err(|e| OrmError::Connection(format!("Failed to connect to {address}: {e}")))
+}
+
+async fn grpc_fallback_driver(
+    address: &str,
+    username: &str,
+    password: &str,
+    http_error: core_version::VersionError,
+) -> Result<DriverHandle, OrmError> {
+    let mut failures = vec![format!("HTTP version probe failed: {http_error}")];
+
+    #[cfg(feature = "band8")]
+    {
+        match connect_band8_driver(address, username, password).await {
+            Ok(driver) => {
+                let reported = driver.server_version().await.map_err(|e| {
+                    OrmError::Connection(format!(
+                        "Band-8 gRPC version validation failed after connect to {address}: {e}"
+                    ))
+                })?;
+                let server_version = reported
+                    .version()
+                    .parse::<core_version::Version>()
+                    .map_err(OrmError::UnsupportedVersion)?;
+                let band = validate_server_band(&server_version)?;
+                if band != 8 {
+                    return Err(OrmError::UnsupportedVersion(
+                        core_version::VersionError::Probe(format!(
+                            "band-8 gRPC connection reported non-band-8 server version {server_version}"
+                        )),
+                    ));
+                }
+                tracing::debug!(
+                    address,
+                    server_version = %server_version,
+                    "Connected through gRPC band-8 fallback after HTTP version probe failed"
+                );
+                return Ok(DriverHandle::B8(driver));
+            }
+            Err(error) => failures.push(format!("band-8 gRPC attempt failed: {error}")),
+        }
+    }
+
+    #[cfg(not(feature = "band8"))]
+    failures.push("band-8 gRPC attempt skipped: band8 feature is not compiled in".to_string());
+
+    #[cfg(feature = "band7")]
+    {
+        match connect_band7_driver(address, username, password).await {
+            Ok(driver) => {
+                tracing::warn!(
+                    address,
+                    "Connected through gRPC band-7 fallback after HTTP version probe failed; \
+                     exact server version is unavailable on band 7, so use server_version=... \
+                     for strict gRPC-only version validation"
+                );
+                return Ok(DriverHandle::B7(driver));
+            }
+            Err(error) => failures.push(format!("band-7 gRPC attempt failed: {error}")),
+        }
+    }
+
+    #[cfg(not(feature = "band7"))]
+    failures.push("band-7 gRPC attempt skipped: band7 feature is not compiled in".to_string());
+
+    Err(OrmError::UnsupportedVersion(
+        core_version::VersionError::Probe(format!(
+            "HTTP version probe and gRPC fallback both failed: {}",
+            failures.join("; ")
+        )),
+    ))
 }
 
 /// Version-gated [`DriverHandle`] constructor.
@@ -227,7 +348,8 @@ async fn gated_driver(
 impl RealBackend {
     /// Connect to a TypeDB server.
     ///
-    /// Probes the server version via HTTP before opening any gRPC connection.
+    /// Validates the supplied server version, or probes via HTTP before opening
+    /// any gRPC connection when no version is supplied.
     /// Returns [`OrmError::UnsupportedVersion`] when the server is outside the
     /// supported window or on a different protocol band than the driver.
     pub async fn connect(
@@ -244,7 +366,8 @@ impl RealBackend {
 
 /// Ensure a TypeDB database exists, creating it if absent.
 ///
-/// Probes the server version via HTTP before opening any gRPC connection.
+/// Validates the supplied server version, or probes via HTTP before opening any
+/// gRPC connection when no version is supplied.
 /// Returns [`OrmError::UnsupportedVersion`] when the server is outside the
 /// supported window or on a different protocol band than the driver.
 ///
@@ -787,13 +910,14 @@ mod tests {
         let options = ConnectOptions::default();
         assert_eq!(options.http_port, DEFAULT_HTTP_PORT);
         assert!(!options.tls);
+        assert_eq!(options.server_version, None);
     }
 
     /// The injectable probe must receive the configured port, not a
     /// hardcoded 8000.  The probe returns an in-window version so the gate
     /// proceeds to the gRPC connection attempt, which fails with a network
     /// error (no server) — the assertion is about the recorded port and
-    /// that the failure is NOT a version-gate rejection.
+    /// that the HTTP failure fallback path was not involved.
     #[tokio::test]
     async fn gated_driver_probe_receives_configured_port() {
         let recorded_port: Arc<Mutex<Option<u16>>> = Arc::new(Mutex::new(None));
@@ -806,6 +930,7 @@ mod tests {
             ConnectOptions {
                 http_port: 9123,
                 tls: false,
+                server_version: None,
             },
             move |_addr, port, _tls| {
                 *captured.lock().unwrap() = Some(port);
@@ -822,6 +947,116 @@ mod tests {
 
         if let Err(OrmError::UnsupportedVersion(_)) = result {
             panic!("expected a connection error (no server), not a version gate rejection")
+        }
+    }
+
+    /// When HTTP version detection fails, the constructor attempts gRPC band 8
+    /// and then band 7. If neither can connect, the error should preserve all
+    /// attempted paths instead of surfacing only the HTTP failure.
+    #[tokio::test]
+    async fn gated_driver_http_failure_reports_grpc_fallback_failures() {
+        let result = gated_driver_with_probe(
+            "127.0.0.1:1",
+            "admin",
+            "password",
+            ConnectOptions {
+                http_port: 9123,
+                tls: false,
+                server_version: None,
+            },
+            move |_addr, _port, _tls| {
+                Err(core_version::VersionError::Probe(
+                    "HTTP endpoint unavailable".to_string(),
+                ))
+            },
+        )
+        .await;
+
+        match result {
+            Err(OrmError::UnsupportedVersion(err)) => {
+                let msg = err.to_string();
+                assert!(msg.contains("HTTP endpoint unavailable"), "{msg}");
+                assert!(msg.contains("band-8 gRPC attempt failed"), "{msg}");
+                assert!(msg.contains("band-7 gRPC attempt failed"), "{msg}");
+            }
+            Err(other) => panic!("expected aggregated version-probe failure, got {other}"),
+            Ok(_) => panic!("expected aggregated version-probe failure, got successful connection"),
+        }
+    }
+
+    /// A caller-supplied exact server version is the gRPC-only escape hatch: it
+    /// must bypass the HTTP probe but still flow through the normal embedded
+    /// runtime gate before driver construction.
+    #[tokio::test]
+    async fn gated_driver_pinned_version_skips_probe() {
+        let probe_called = Arc::new(Mutex::new(false));
+        let captured = Arc::clone(&probe_called);
+
+        let result = gated_driver_with_probe(
+            "localhost:1729",
+            "admin",
+            "password",
+            ConnectOptions {
+                http_port: 9123,
+                tls: false,
+                server_version: Some(core_version::Version::new(3, 8, 3)),
+            },
+            move |_addr, _port, _tls| {
+                *captured.lock().unwrap() = true;
+                Ok(core_version::Version::new(3, 11, 5))
+            },
+        )
+        .await;
+
+        assert!(
+            !*probe_called.lock().unwrap(),
+            "pinned server_version must skip the HTTP probe"
+        );
+
+        if let Err(OrmError::UnsupportedVersion(_)) = result {
+            panic!("expected a connection error (no server), not a version gate rejection")
+        }
+    }
+
+    /// Pinned versions still use the exact semantic version gate. This prevents
+    /// a gRPC-only band-7 path from silently accepting unsupported 3.7 servers.
+    #[tokio::test]
+    async fn gated_driver_rejects_unsupported_pinned_version_without_probe() {
+        let probe_called = Arc::new(Mutex::new(false));
+        let captured = Arc::clone(&probe_called);
+
+        let result = gated_driver_with_probe(
+            "localhost:1729",
+            "admin",
+            "password",
+            ConnectOptions {
+                http_port: 9123,
+                tls: false,
+                server_version: Some(core_version::Version::new(3, 7, 3)),
+            },
+            move |_addr, _port, _tls| {
+                *captured.lock().unwrap() = true;
+                Ok(core_version::Version::new(3, 8, 3))
+            },
+        )
+        .await;
+
+        assert!(
+            !*probe_called.lock().unwrap(),
+            "unsupported pinned server_version must skip the HTTP probe"
+        );
+
+        match result {
+            Err(OrmError::UnsupportedVersion(err)) => {
+                assert!(
+                    err.to_string().contains("3.7.3"),
+                    "error should name rejected version: {err}"
+                );
+            }
+            Err(other) => panic!("expected unsupported-version rejection for 3.7.3, got {other}"),
+            Ok(_) => panic!(
+                "expected unsupported-version rejection for 3.7.3, got successful connection"
+            ),
         }
     }
 }

--- a/type-bridge-core/crates/python/src/orm_runtime.rs
+++ b/type-bridge-core/crates/python/src/orm_runtime.rs
@@ -443,21 +443,27 @@ impl PyRustDatabase {
 impl PyRustDatabase {
     /// Connect to TypeDB using the shared Rust ORM session layer.
     #[staticmethod]
-    #[pyo3(signature = (address, database, username=None, password=None, http_port=core_version::DEFAULT_HTTP_PORT))]
+    #[pyo3(signature = (address, database, username=None, password=None, http_port=core_version::DEFAULT_HTTP_PORT, server_version=None))]
     fn connect(
         address: &str,
         database: &str,
         username: Option<&str>,
         password: Option<&str>,
         http_port: u16,
+        server_version: Option<&str>,
     ) -> PyResult<Self> {
         let runtime = Runtime::new().map(Arc::new).map_err(|error| {
             py_runtime_error(format!("Failed to create Tokio runtime: {error}"))
         })?;
         let username = username.unwrap_or("admin").to_string();
         let password = password.unwrap_or("password").to_string();
+        let server_version: Option<core_version::Version> =
+            server_version.map(str::parse).transpose().map_err(
+                |error: core_version::VersionError| VersionError::new_err(error.to_string()),
+            )?;
         let options = type_bridge_orm::ConnectOptions {
             http_port,
+            server_version,
             ..type_bridge_orm::ConnectOptions::default()
         };
         let db = runtime

--- a/type-bridge-core/python/type_bridge_core/__init__.pyi
+++ b/type-bridge-core/python/type_bridge_core/__init__.pyi
@@ -136,4 +136,18 @@ def server_version(address: str, http_port: int = 8000, tls: bool = False) -> st
     """
     ...
 
+class PyRustDatabase:
+    """Rust-backed TypeDB database connection."""
+
+    @staticmethod
+    def connect(
+        address: str,
+        database: str,
+        username: str | None = ...,
+        password: str | None = ...,
+        http_port: int = 8000,
+        server_version: str | None = ...,
+    ) -> PyRustDatabase: ...
+    def __getattr__(self, name: str) -> Any: ...
+
 def __getattr__(name: str) -> Any: ...

--- a/type_bridge/_rust_runtime.py
+++ b/type_bridge/_rust_runtime.py
@@ -459,12 +459,16 @@ def rust_database_for(connection: Any) -> Any:
     if cached is not None:
         return cached
 
+    connect_kwargs: dict[str, object] = {"http_port": connection.http_port}
+    if connection.server_version is not None:
+        connect_kwargs["server_version"] = connection.server_version
+
     rust_db = rust_core().PyRustDatabase.connect(
         connection.address,
         connection.database_name,
         connection.username or "admin",
         connection.password or "password",
-        http_port=connection.http_port,
+        **connect_kwargs,
     )
     setattr(connection, "_rust_backend_database", rust_db)
     return rust_db

--- a/type_bridge/session.py
+++ b/type_bridge/session.py
@@ -174,6 +174,7 @@ class Database:
         driver: Driver | None = None,
         *,
         http_port: int = typedb_driver.DEFAULT_HTTP_PORT,
+        server_version: str | None = None,
     ):
         """Initialize database connection.
 
@@ -187,12 +188,16 @@ class Database:
                 The caller retains ownership and is responsible for closing it.
             http_port: TypeDB HTTP API port used by the connect-time version
                 gate probe (default 8000).
+            server_version: Exact TypeDB server version to use for connect-time
+                validation instead of probing the HTTP API. Use this for
+                gRPC-only deployments with the HTTP API disabled.
         """
         self.address = address
         self.database_name = database
         self.username = username
         self.password = password
         self.http_port = http_port
+        self.server_version = server_version
         self._driver: Driver | None = driver
         self._owns_driver: bool = driver is None  # Track ownership
 
@@ -231,8 +236,14 @@ class Database:
         logger.debug(f"TLS enabled: {is_tls_enabled}")
 
         detected_driver = typedb_driver.driver_version()
-        detected_server = typedb_driver.server_version(
-            self.address, http_port=self.http_port, tls=is_tls_enabled
+        detected_server = (
+            self.server_version
+            if self.server_version is not None
+            else typedb_driver.server_version(
+                self.address,
+                http_port=self.http_port,
+                tls=is_tls_enabled,
+            )
         )
         version.ensure_supported(detected_driver, detected_server)
         version.ensure_runtime_supported(detected_server)


### PR DESCRIPTION
## Summary

Fix #154 by making grpc-only TypeDB connections usable when the HTTP version
probe cannot be reached.

The default path still prefers the HTTP version probe.  If that probe fails,
the embedded Rust runtime now tries gRPC band 8 first, then gRPC band 7.  If
both fallback attempts fail, connect fails loudly with the HTTP and gRPC errors
included in the version-gate failure.

## Added

- Added `server_version=` as an exact-version escape hatch for
  `Database(...)` and `PyRustDatabase.connect(...)`.
- When `server_version=` is supplied, the runtime skips auto-version probing
  and selects the matching driver band directly.
- Added grpc-only fallback logic after HTTP probe failure:
  - try band 8 over gRPC;
  - then try band 7 over gRPC;
  - report all failed attempts if no fallback succeeds.
- Added CI version-gate cells for band 8 and band 7 servers with an
  unreachable HTTP port and expected connect success.

## Test

- Added CI regression coverage for grpc-only connect:
  - `POS-grpc-fallback-band8`
  - `POS-grpc-fallback-band7`
- Confirmed RED locally with the fix stashed for both band 8 and band 7.
- Confirmed PR RED on `Version gate (POS-grpc-fallback-band8)`.
- Confirmed GREEN locally after applying the fix for both band 8 and band 7.
- Confirmed PR GREEN on run `27660623853` after rerunning transient setup
  failures.

Refs #154
