### PR TITLE
feat(core): add database lifecycle APIs (#155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to TypeBridge will be documented in this file.
 
 ## [Unreleased]
 
+### New Features
+
+- **Band-aware server database admin API (#155)** - `type_bridge_server::typedb::TypeDBClient`
+  now exposes `database_exists`, `create_database`, `delete_database`, and
+  `reset_database`, dispatching through the embedded TypeDB driver band selected
+  at connection time.
+
 ## [1.5.0] - 2026-06-15
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to TypeBridge will be documented in this file.
   now exposes `database_exists`, `create_database`, `delete_database`, and
   `reset_database`, dispatching through the embedded TypeDB driver band selected
   at connection time.
+- **Node database lifecycle parity (#155)** - `@type-bridge/node` `RustDatabase`
+  now exposes `databaseExists`, `createDatabase`, `deleteDatabase`, and
+  `resetDatabase` on the bound database handle, matching the Python/Rust ORM
+  lifecycle surface.
 
 ## [1.5.0] - 2026-06-15
 

--- a/docs/guide/typescript.md
+++ b/docs/guide/typescript.md
@@ -262,6 +262,30 @@ people.delete(inserted);
 Every hydrated instance carries its TypeDB internal id on `_iid` and is a real
 instance of your class (so it also carries `toDict()`).
 
+### Database lifecycle
+
+`RustDatabase` is bound to one database name and exposes the same lifecycle
+helpers as the Python ORM:
+
+```ts
+import { RustDatabase } from "@type-bridge/node";
+
+const db = RustDatabase.connect("localhost:1730", "scratch", {
+  username: "admin",
+  password: "password",
+});
+
+if (!db.databaseExists()) {
+  db.createDatabase();
+}
+
+db.resetDatabase(); // delete if present, then create
+db.deleteDatabase();
+```
+
+The top-level `ensureDatabase(address, database, options?)` helper remains
+available for setup code that does not need to keep a bound handle.
+
 ## Queries and expressions
 
 Build expression-form queries with `manager.query()`. Comparison operators are

--- a/tests/integration/session/test_version_gate.py
+++ b/tests/integration/session/test_version_gate.py
@@ -53,9 +53,9 @@ class TestServerVersionLive:
 
     def test_server_version_returns_string(self):
         """server_version(address) returns a non-empty version string."""
-        from tests.integration.conftest import TEST_DB_ADDRESS
+        from tests.integration.conftest import TEST_DB_ADDRESS, TEST_DB_HTTP_PORT
 
-        result = _tdm.server_version(TEST_DB_ADDRESS)
+        result = _tdm.server_version(TEST_DB_ADDRESS, http_port=TEST_DB_HTTP_PORT)
         assert isinstance(result, str)
         assert len(result) > 0
 
@@ -63,18 +63,18 @@ class TestServerVersionLive:
         """server_version(address) returns something that looks like a version."""
         import re
 
-        from tests.integration.conftest import TEST_DB_ADDRESS
+        from tests.integration.conftest import TEST_DB_ADDRESS, TEST_DB_HTTP_PORT
 
-        result = _tdm.server_version(TEST_DB_ADDRESS)
+        result = _tdm.server_version(TEST_DB_ADDRESS, http_port=TEST_DB_HTTP_PORT)
         assert re.match(r"\d+\.\d+\.\d+", result), (
             f"server_version did not return a semver-like string: {result!r}"
         )
 
     def test_server_version_matches_runtime_accepted_range(self):
         """server_version result is accepted by the embedded Rust runtime."""
-        from tests.integration.conftest import TEST_DB_ADDRESS
+        from tests.integration.conftest import TEST_DB_ADDRESS, TEST_DB_HTTP_PORT
 
-        sv = _tdm.server_version(TEST_DB_ADDRESS)
+        sv = _tdm.server_version(TEST_DB_ADDRESS, http_port=TEST_DB_HTTP_PORT)
         # TypeBridge's default backend uses embedded Rust drivers, not the
         # optional Python typedb-driver package.  The installed Python driver
         # may target a different protocol band from the live test server.
@@ -110,9 +110,11 @@ class TestVersionGateLiveNegative:
         causes direct driver access to raise UnsupportedVersionError before TypeDB.driver is
         called."""
         import type_bridge.session as session_mod
-        from tests.integration.conftest import TEST_DB_ADDRESS
+        from tests.integration.conftest import TEST_DB_ADDRESS, TEST_DB_HTTP_PORT
 
-        detected_server = _tdm.server_version(TEST_DB_ADDRESS, tls=False)
+        detected_server = _tdm.server_version(
+            TEST_DB_ADDRESS, http_port=TEST_DB_HTTP_PORT, tls=False
+        )
         mismatched = _mismatched_driver_version(detected_server)
         monkeypatch.setattr(_tdm, "driver_version", lambda: mismatched)
 
@@ -131,7 +133,11 @@ class TestVersionGateLiveNegative:
 
         monkeypatch.setattr(session_mod, "TypeDB", _SpyTypeDB())
 
-        db = Database(address=TEST_DB_ADDRESS, database="test_gate_negative")
+        db = Database(
+            address=TEST_DB_ADDRESS,
+            database="test_gate_negative",
+            http_port=TEST_DB_HTTP_PORT,
+        )
         with pytest.raises(version.UnsupportedVersionError):
             _ = db.driver
 
@@ -141,13 +147,19 @@ class TestVersionGateLiveNegative:
         self, monkeypatch: pytest.MonkeyPatch
     ):
         """Error message from live gate contains both driver and server version strings."""
-        from tests.integration.conftest import TEST_DB_ADDRESS
+        from tests.integration.conftest import TEST_DB_ADDRESS, TEST_DB_HTTP_PORT
 
-        detected_server = _tdm.server_version(TEST_DB_ADDRESS, tls=False)
+        detected_server = _tdm.server_version(
+            TEST_DB_ADDRESS, http_port=TEST_DB_HTTP_PORT, tls=False
+        )
         mismatched = _mismatched_driver_version(detected_server)
         monkeypatch.setattr(_tdm, "driver_version", lambda: mismatched)
 
-        db = Database(address=TEST_DB_ADDRESS, database="test_gate_message")
+        db = Database(
+            address=TEST_DB_ADDRESS,
+            database="test_gate_message",
+            http_port=TEST_DB_HTTP_PORT,
+        )
         with pytest.raises(version.UnsupportedVersionError) as exc_info:
             _ = db.driver
 
@@ -190,9 +202,11 @@ class TestVersionGatePinnedServerVersion:
 
     def test_server_version_pin_connects_with_unreachable_http_port(self, test_database):
         """A pinned exact version lets connect use gRPC even when http_port is wrong."""
-        from tests.integration.conftest import TEST_DB_ADDRESS
+        from tests.integration.conftest import TEST_DB_ADDRESS, TEST_DB_HTTP_PORT
 
-        detected_server = _tdm.server_version(TEST_DB_ADDRESS, tls=False)
+        detected_server = _tdm.server_version(
+            TEST_DB_ADDRESS, http_port=TEST_DB_HTTP_PORT, tls=False
+        )
         db = Database(
             address=TEST_DB_ADDRESS,
             database=test_database,

--- a/type-bridge-core/Dockerfile.server
+++ b/type-bridge-core/Dockerfile.server
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/li
 # but Cargo still needs all workspace manifests to resolve the package graph.
 COPY Cargo.toml Cargo.lock ./
 COPY crates crates
+COPY vendor vendor
 
 # Build the server
 RUN cargo build --release -p type-bridge-server

--- a/type-bridge-core/crates/node/src/lib.rs
+++ b/type-bridge-core/crates/node/src/lib.rs
@@ -237,6 +237,43 @@ impl NodeRustDatabase {
         self.db.database_name().to_string()
     }
 
+    /// Return whether the bound database exists on the connected server.
+    #[napi(js_name = "databaseExists")]
+    pub fn database_exists(&self) -> Result<bool> {
+        self.runtime
+            .block_on(self.db.database_exists())
+            .map_err(napi_orm_error)
+    }
+
+    /// Create the bound database if it does not already exist.
+    #[napi(js_name = "createDatabase")]
+    pub fn create_database(&self) -> Result<()> {
+        self.runtime
+            .block_on(self.db.create_database())
+            .map_err(napi_orm_error)
+    }
+
+    /// Delete the bound database if it exists.
+    #[napi(js_name = "deleteDatabase")]
+    pub fn delete_database(&self) -> Result<()> {
+        self.runtime
+            .block_on(self.db.delete_database())
+            .map_err(napi_orm_error)
+    }
+
+    /// Delete the bound database if present, then create it.
+    #[napi(js_name = "resetDatabase")]
+    pub fn reset_database(&self) -> Result<()> {
+        self.runtime
+            .block_on(async {
+                if self.db.database_exists().await? {
+                    self.db.delete_database().await?;
+                }
+                self.db.create_database().await
+            })
+            .map_err(napi_orm_error)
+    }
+
     /// Open a Rust-owned transaction context.
     #[napi(js_name = "transaction")]
     pub fn transaction(

--- a/type-bridge-core/crates/node/tests/dts-baseline/flags.d.ts
+++ b/type-bridge-core/crates/node/tests/dts-baseline/flags.d.ts
@@ -38,12 +38,18 @@ export interface FlagSpec {
     readonly kind: "flag";
     readonly annotations: Annotation[];
     readonly cardinality: [number, number | null] | null;
+    readonly isOrdered: boolean;
+    readonly isDistinct: boolean;
 }
 /** Marks a field as the type's key attribute (implies cardinality `[1, 1]`). */
 export declare const Key = "Key";
 /** Marks a field's attribute value as unique across the type. */
 export declare const Unique = "Unique";
-export type FlagInput = typeof Key | typeof Unique | CardSpec | FlagSpec;
+/** Declares this owns clause as a list attribute (`owns attr[]`). Schema-only. */
+export declare const Ordered = "Ordered";
+/** Emits `@distinct` on the owns clause. Requires `Ordered`. Schema-only. */
+export declare const Distinct = "Distinct";
+export type FlagInput = typeof Key | typeof Unique | typeof Ordered | typeof Distinct | CardSpec | FlagSpec;
 /** Type-level config for an `Entity`/`Relation` (explicit name, abstract, base, case). */
 export declare function TypeFlags(options?: TypeFlagsOptions): ResolvedTypeFlags;
 /** Attribute-level config: an explicit attribute name and/or case override. */
@@ -55,7 +61,7 @@ export declare function Card<const Min extends number, const Max extends number 
  * of descriptor annotations plus a derived cardinality.
  */
 export declare function Flag(...flags: FlagInput[]): FlagSpec;
-/** Lower a flag list to its `{ annotations, cardinality }` descriptor form. */
+/** Lower a flag list to its `{ annotations, cardinality, isOrdered, isDistinct }` descriptor form. */
 export declare function resolveFlags(flags: readonly FlagInput[]): FlagSpec;
 /** Convert a model class name to its TypeDB type name under the given case. */
 export declare function formatTypeName(className: string, typeCase: TypeNameCase): string;

--- a/type-bridge-core/crates/node/tests/dts-baseline/index.d.ts
+++ b/type-bridge-core/crates/node/tests/dts-baseline/index.d.ts
@@ -9,6 +9,9 @@ export interface OwnedAttributeDescriptor {
     value_type: ValueType;
     annotations: Annotation[];
     is_optional: boolean;
+    /** Whether this ownership is declared as an ordered list (`owns name[]`).
+     * Instance-level list semantics are engine-unimplemented (REP256); this is a
+     * schema-emission marker only. */
     is_ordered: boolean;
     parent_type?: string | null;
     is_abstract?: boolean;
@@ -27,9 +30,17 @@ export interface RoleDescriptor {
     role_name: string;
     player_type_names: string[];
     cardinality: [number, number | null] | null;
+    /** Plays-side cardinality for this role's players. Authoring datum consumed
+     * by `SchemaInfo.from_descriptors` to build the per-player `plays_cardinalities`
+     * overlay. `null` when no plays-side constraint is declared. */
+    plays_cardinality: [number, number | null] | null;
     overrides: string | null;
     is_abstract: boolean;
+    /** Whether this role is declared as an ordered list (`relates name[]`).
+     * Instance-level list semantics are engine-unimplemented (REP256); this is a
+     * schema-emission marker only. */
     ordered: boolean;
+    /** Whether this role carries `@distinct`. Valid only when `ordered` is true. */
     distinct: boolean;
 }
 export interface RelationDescriptor {
@@ -50,15 +61,25 @@ export interface OwnedAttributeEntry {
     attr_name: string;
     value_type: ValueType;
     annotations: Annotation[];
+    /** Whether this ownership is declared as an ordered list (`owns name[]`).
+     * Instance-level list semantics are engine-unimplemented (REP256); this is a
+     * schema-emission marker only. */
     is_ordered: boolean;
 }
 export interface RoleEntry {
     role_name: string;
     player_type_names: string[];
     cardinality: [number, number | null] | null;
+    /** Plays-side cardinality authoring datum. Mirrors `RoleDescriptor.plays_cardinality`
+     * at the SchemaInfo (info-level) role entry. `null` when not declared. */
+    plays_cardinality: [number, number | null] | null;
     overrides: string | null;
     is_abstract: boolean;
+    /** Whether this role is declared as an ordered list (`relates name[]`).
+     * Instance-level list semantics are engine-unimplemented (REP256); this is a
+     * schema-emission marker only. */
     ordered: boolean;
+    /** Whether this role carries `@distinct`. Valid only when `ordered` is true. */
     distinct: boolean;
 }
 export interface EntitySchemaEntry {
@@ -277,6 +298,10 @@ interface NativeMarshalling {
 export interface NativeRustDatabase {
     isConnected(): boolean;
     databaseName(): string;
+    databaseExists(): boolean;
+    createDatabase(): void;
+    deleteDatabase(): void;
+    resetDatabase(): void;
     transaction(transactionType?: TransactionType): NativeRustTransactionContext;
     entityManagerJson(descriptorJson: string): NativeDynamicEntityManager;
     relationManagerJson(descriptorJson: string): NativeDynamicRelationManager;
@@ -389,6 +414,10 @@ export declare class RustDatabase {
     static connect(native: NativeRuntime, address: string, database: string, options?: RustDatabaseConnectOptions): RustDatabase;
     isConnected(): boolean;
     databaseName(): string;
+    databaseExists(): boolean;
+    createDatabase(): void;
+    deleteDatabase(): void;
+    resetDatabase(): void;
     transaction(transactionType?: TransactionType): RustTransactionContext;
     entityManager(descriptor: EntityDescriptor): RustDynamicEntityManager;
     relationManager(descriptor: RelationDescriptor): RustDynamicRelationManager;

--- a/type-bridge-core/crates/node/tests/dts-baseline/model.d.ts
+++ b/type-bridge-core/crates/node/tests/dts-baseline/model.d.ts
@@ -71,18 +71,41 @@ export declare class ListFieldSpec<Attr extends AttributeClass, Optional extends
     /** Explicit cardinality `[min, max | null]`. Always present for list fields. */
     readonly card: [number, number | null];
     readonly isOptional: Optional;
-    constructor(attrType: Attr, cardSpec: CardSpec);
+    /** True when the parent FieldSpec carried the `Ordered` flag. A multi-value
+     * `Card` field is a set, not a TypeDB list: only the `Ordered` flag makes
+     * the descriptor emit `is_ordered: true` (and `[]` in the define block). */
+    readonly isOrdered: boolean;
+    /** True when the parent FieldSpec carried the `Distinct` flag. */
+    readonly isDistinct: boolean;
+    constructor(attrType: Attr, cardSpec: CardSpec, isOrdered?: boolean, isDistinct?: boolean);
 }
 /**
- * A declared relation role: its permitted player model(s) and optional
- * cardinality. Produced by `role()`; consumed by the model factory to emit
- * `roles[*]`. Multi-player roles list more than one player token.
+ * A declared relation role: its permitted player model(s), optional
+ * relates-side cardinality, and optional plays-side cardinality. Produced by
+ * `role()`; consumed by the model factory to emit `roles[*]` plus metadata
+ * used by `DescriptorRegistry.schemaInfo()`. Multi-player roles list more than
+ * one player token.
  */
 export declare class RoleSpec<Players extends readonly ModelToken[]> {
     readonly players: Players;
     readonly kind = "role";
     readonly cardinality: [number, number | null] | null;
-    constructor(players: Players, cardinality?: CardSpec | null);
+    readonly playsCardinality: [number, number | null] | null;
+    /** Parent role name this role specializes via TypeDB's `relates child as parent` syntax.
+     * Used only for descriptor computation (effective-set role exclusion); specialization
+     * semantics are resolved at schema-define time. */
+    readonly overrides: string | undefined;
+    /** When ``true``, this role is abstract at the TypeDB schema level (``@abstract`` on
+     * the ``relates`` clause). The engine rejects direct players at the declaring
+     * relation's own scope; subtypes that plain-inherit or override the role are
+     * unaffected. */
+    readonly isAbstract: boolean;
+    /** When ``true``, declares this role as a list role (``relates name[]`` in TypeQL).
+     * Schema-only; instance-level list writes are not yet supported by the engine. */
+    readonly ordered: boolean;
+    /** When ``true``, emits ``@distinct`` on the relates clause. Requires ``ordered``. */
+    readonly distinct: boolean;
+    constructor(players: Players, cardinality?: CardSpec | null, playsCardinality?: CardSpec | null, overrides?: string, isAbstract?: boolean, ordered?: boolean, distinct?: boolean);
 }
 export type SchemaSpec = FieldSpec<AttributeClass, boolean> | ListFieldSpec<AttributeClass, boolean> | RoleSpec<readonly ModelToken[]>;
 export type EntitySchema = Record<string, FieldSpec<AttributeClass, boolean> | ListFieldSpec<AttributeClass, boolean>>;
@@ -133,7 +156,7 @@ type OptionalKeys<Schema extends Record<string, SchemaSpec>> = {
 }[keyof Schema];
 type RequiredKeys<Schema extends Record<string, SchemaSpec>> = Exclude<keyof Schema, OptionalKeys<Schema>>;
 type RoleValue<Players extends readonly ModelToken[]> = Players extends readonly [] ? undefined : RolePlayerInstance<Players[number]> | readonly RolePlayerInstance<Players[number]>[];
-type RolePlayerInstance<Token> = Token extends string ? never : Token extends new (values: never) => infer Instance ? Instance : never;
+type RolePlayerInstance<Token> = Token extends string ? object : Token extends new (values: never) => infer Instance ? Instance : never;
 /**
  * The canonical hydrated-instance type for a model schema. This is the single
  * source of truth for what `class X extends Entity(...) {}` produces AND what a
@@ -184,12 +207,15 @@ export type ModelClass<Schema extends Record<string, SchemaSpec>, Descriptor ext
 export declare function field<Attr extends AttributeClass>(attrType: Attr, ...flags: FlagInput[]): FieldSpec<Attr, false>;
 /**
  * Declare a relation role. Pass zero or more player model tokens, optionally
- * followed by `{ cardinality }`. Player tokens may be model classes or raw type
- * name strings (the latter for players whose typed class is not yet declared).
+ * followed by `{ cardinality, playsCardinality }`. Player tokens may be model
+ * classes or raw type name strings (the latter for players whose typed class is
+ * not yet declared). `cardinality` is relates-side; `playsCardinality` is
+ * player-side and therefore requires at least one player token.
  */
 export declare function role(): RoleSpec<readonly []>;
-export declare function role(options: RoleOptions): RoleSpec<readonly []>;
-export declare function role<const Players extends readonly [ModelToken, ...ModelToken[]]>(...playersAndOptions: RoleArguments<Players>): RoleSpec<Players>;
+export declare function role(options: RelatesOnlyRoleOptions): RoleSpec<readonly []>;
+export declare function role<const Players extends readonly [ModelToken, ...ModelToken[]]>(...players: Players): RoleSpec<Players>;
+export declare function role<const Players extends readonly [ModelToken, ...ModelToken[]]>(...playersAndOptions: [...Players, RoleOptions]): RoleSpec<Players>;
 /**
  * Build a hard-typed entity base class from a name (or `TypeFlags`) and a field
  * schema. Extend the result to declare the model:
@@ -208,13 +234,28 @@ export declare function Entity<const ParentSchema extends EntitySchema, const Sc
  * contain `role(...)` specs, which are emitted as `roles[*]` in the descriptor.
  *
  * Pass a third `{ parent: ParentClass }` argument to declare a parent relation
- * type. The child's descriptor emits `parent_type` and the full flattened
- * `owned_attributes`; inherited roles are also re-listed.
+ * type. The child's descriptor emits `parent_type`, the full flattened
+ * `owned_attributes`, and the **effective role set**: plain-inherited parent roles
+ * first (in the parent's own effective order), then child-local roles — excluding
+ * any parent role whose name appears as the `overrides` target of a child role.
+ * This mirrors the Python descriptor contract (see `internals.md`, "Descriptor Contract").
  */
 export declare function Relation<const Schema extends RelationSchema>(typeNameOrFlags: string | ResolvedTypeFlags, schema: Schema): ModelClass<Schema, RelationDescriptor>;
 export declare function Relation<const ParentSchema extends RelationSchema, const Schema extends RelationSchema>(typeNameOrFlags: string | ResolvedTypeFlags, schema: Schema, options: ParentOption<ParentSchema>): ModelClass<MergedSchema<ParentSchema, Schema>, RelationDescriptor>;
+type RelatesOnlyRoleOptions = {
+    readonly cardinality?: CardSpec | null;
+    readonly playsCardinality?: never;
+    readonly overrides?: string;
+    readonly abstract?: boolean;
+    readonly ordered?: boolean;
+    readonly distinct?: boolean;
+};
 type RoleOptions = {
     readonly cardinality?: CardSpec | null;
+    readonly playsCardinality?: CardSpec | null;
+    readonly overrides?: string;
+    readonly abstract?: boolean;
+    readonly ordered?: boolean;
+    readonly distinct?: boolean;
 };
-type RoleArguments<Players extends readonly ModelToken[]> = [...Players] | [...Players, RoleOptions];
 export type { IidBearing };

--- a/type-bridge-core/crates/node/tests/dts-baseline/parser.d.ts
+++ b/type-bridge-core/crates/node/tests/dts-baseline/parser.d.ts
@@ -9,6 +9,8 @@ export interface OwnedAttribute {
     is_cascade: boolean;
     subkey_group: string | null;
     cardinality: Cardinality | null;
+    ordered: boolean;
+    distinct: boolean;
 }
 export interface PlayedRole {
     role_ref: string;
@@ -20,6 +22,7 @@ export interface RoleSpec {
     cardinality: Cardinality | null;
     distinct: boolean;
     ordered: boolean;
+    is_abstract: boolean;
 }
 export interface EntityType {
     name: string;

--- a/type-bridge-core/crates/node/tests/integration/common/index.ts
+++ b/type-bridge-core/crates/node/tests/integration/common/index.ts
@@ -81,6 +81,7 @@ export const INTG_DATABASE =
   process.env.TYPE_BRIDGE_NODE_INTG_DATABASE ?? "type_bridge_test";
 export const TYPEDB_USERNAME = process.env.TYPEDB_USERNAME ?? "admin";
 export const TYPEDB_PASSWORD = process.env.TYPEDB_PASSWORD ?? "password";
+export const TYPEDB_HTTP_PORT = Number(process.env.TYPEDB_HTTP_PORT ?? "8000");
 
 // ---------------------------------------------------------------------------
 // Schema suffix generator — mirrors integration_support.rs unique_schema_suffix
@@ -107,10 +108,12 @@ export function connectIntegration() {
   ensureDatabase(TYPEDB_ADDRESS, INTG_DATABASE, {
     username: TYPEDB_USERNAME,
     password: TYPEDB_PASSWORD,
+    httpPort: TYPEDB_HTTP_PORT,
   });
   return RustDatabase.connect(TYPEDB_ADDRESS, INTG_DATABASE, {
     username: TYPEDB_USERNAME,
     password: TYPEDB_PASSWORD,
+    httpPort: TYPEDB_HTTP_PORT,
   });
 }
 

--- a/type-bridge-core/crates/node/tests/integration/typed/entity-crud.test.ts
+++ b/type-bridge-core/crates/node/tests/integration/typed/entity-crud.test.ts
@@ -14,6 +14,7 @@ const address = process.env.TYPEDB_ADDRESS ?? "localhost:1730";
 const database = process.env.TYPE_BRIDGE_NODE_INTG_DATABASE ?? "type_bridge_test";
 const username = process.env.TYPEDB_USERNAME ?? "admin";
 const password = process.env.TYPEDB_PASSWORD ?? "password";
+const httpPort = Number(process.env.TYPEDB_HTTP_PORT ?? "8000");
 
 const suffix = `typed-entity-${process.pid}-${Date.now()}`;
 const allType = `${suffix}-all`;
@@ -104,8 +105,8 @@ describe("typed entity manager CRUD", () => {
 });
 
 function connectIntegration() {
-  typeBridge.ensureDatabase(address, database, { username, password });
-  return typeBridge.RustDatabase.connect(address, database, { username, password });
+  typeBridge.ensureDatabase(address, database, { username, password, httpPort });
+  return typeBridge.RustDatabase.connect(address, database, { username, password, httpPort });
 }
 
 function defineSchema(db: ReturnType<typeof connectIntegration>, typeql: string): void {

--- a/type-bridge-core/crates/node/tests/integration/typed/inheritance.test.ts
+++ b/type-bridge-core/crates/node/tests/integration/typed/inheritance.test.ts
@@ -20,6 +20,7 @@ const address = process.env.TYPEDB_ADDRESS ?? "localhost:1730";
 const database = process.env.TYPE_BRIDGE_NODE_INTG_DATABASE ?? "type_bridge_test";
 const username = process.env.TYPEDB_USERNAME ?? "admin";
 const password = process.env.TYPEDB_PASSWORD ?? "password";
+const httpPort = Number(process.env.TYPEDB_HTTP_PORT ?? "8000");
 
 // Per-run suffix ensures fixture types never collide with other test runs or
 // existing schema types (plan requirement: per-test unique type-name suffix).
@@ -191,8 +192,8 @@ describe("typed entity manager CRUD over an inherited model", () => {
 // ---------------------------------------------------------------------------
 
 function connectIntegration() {
-  typeBridge.ensureDatabase(address, database, { username, password });
-  return typeBridge.RustDatabase.connect(address, database, { username, password });
+  typeBridge.ensureDatabase(address, database, { username, password, httpPort });
+  return typeBridge.RustDatabase.connect(address, database, { username, password, httpPort });
 }
 
 function defineSchema(db: ReturnType<typeof connectIntegration>, typeql: string): void {

--- a/type-bridge-core/crates/node/tests/integration/typed/multivalue.test.ts
+++ b/type-bridge-core/crates/node/tests/integration/typed/multivalue.test.ts
@@ -21,6 +21,7 @@ const address = process.env.TYPEDB_ADDRESS ?? "localhost:1730";
 const database = process.env.TYPE_BRIDGE_NODE_INTG_DATABASE ?? "type_bridge_test";
 const username = process.env.TYPEDB_USERNAME ?? "admin";
 const password = process.env.TYPEDB_PASSWORD ?? "password";
+const httpPort = Number(process.env.TYPEDB_HTTP_PORT ?? "8000");
 
 // Per-run suffix isolates fixture types.
 const suffix = `typed-mv-${process.pid}-${Date.now()}`;
@@ -181,8 +182,8 @@ describe("typed multi-value (list) attribute CRUD", () => {
 // ---------------------------------------------------------------------------
 
 function connectIntegration() {
-  typeBridge.ensureDatabase(address, database, { username, password });
-  return typeBridge.RustDatabase.connect(address, database, { username, password });
+  typeBridge.ensureDatabase(address, database, { username, password, httpPort });
+  return typeBridge.RustDatabase.connect(address, database, { username, password, httpPort });
 }
 
 function defineSchema(db: ReturnType<typeof connectIntegration>, typeql: string): void {

--- a/type-bridge-core/crates/node/tests/integration/typed/query-aggregates.test.ts
+++ b/type-bridge-core/crates/node/tests/integration/typed/query-aggregates.test.ts
@@ -14,6 +14,7 @@ const address = process.env.TYPEDB_ADDRESS ?? "localhost:1730";
 const database = process.env.TYPE_BRIDGE_NODE_INTG_DATABASE ?? "type_bridge_test";
 const username = process.env.TYPEDB_USERNAME ?? "admin";
 const password = process.env.TYPEDB_PASSWORD ?? "password";
+const httpPort = Number(process.env.TYPEDB_HTTP_PORT ?? "8000");
 
 const suffix = `typed-agg-${process.pid}-${Date.now()}`;
 const personType = `${suffix}-person`;
@@ -73,8 +74,8 @@ describe("typed aggregate and group-by queries", () => {
 });
 
 function connectIntegration() {
-  typeBridge.ensureDatabase(address, database, { username, password });
-  return typeBridge.RustDatabase.connect(address, database, { username, password });
+  typeBridge.ensureDatabase(address, database, { username, password, httpPort });
+  return typeBridge.RustDatabase.connect(address, database, { username, password, httpPort });
 }
 
 function defineSchema(db: ReturnType<typeof connectIntegration>, typeql: string): void {

--- a/type-bridge-core/crates/node/tests/integration/typed/query-expressions.test.ts
+++ b/type-bridge-core/crates/node/tests/integration/typed/query-expressions.test.ts
@@ -14,6 +14,7 @@ const address = process.env.TYPEDB_ADDRESS ?? "localhost:1730";
 const database = process.env.TYPE_BRIDGE_NODE_INTG_DATABASE ?? "type_bridge_test";
 const username = process.env.TYPEDB_USERNAME ?? "admin";
 const password = process.env.TYPEDB_PASSWORD ?? "password";
+const httpPort = Number(process.env.TYPEDB_HTTP_PORT ?? "8000");
 
 const suffix = `typed-query-${process.pid}-${Date.now()}`;
 
@@ -144,8 +145,8 @@ describe("typed relation query expressions", () => {
 });
 
 function connectIntegration() {
-  typeBridge.ensureDatabase(address, database, { username, password });
-  return typeBridge.RustDatabase.connect(address, database, { username, password });
+  typeBridge.ensureDatabase(address, database, { username, password, httpPort });
+  return typeBridge.RustDatabase.connect(address, database, { username, password, httpPort });
 }
 
 function defineSchema(db: ReturnType<typeof connectIntegration>, typeql: string): void {

--- a/type-bridge-core/crates/node/tests/integration/typed/relation-crud.test.ts
+++ b/type-bridge-core/crates/node/tests/integration/typed/relation-crud.test.ts
@@ -23,6 +23,7 @@ const address = process.env.TYPEDB_ADDRESS ?? "localhost:1730";
 const database = process.env.TYPE_BRIDGE_NODE_INTG_DATABASE ?? "type_bridge_test";
 const username = process.env.TYPEDB_USERNAME ?? "admin";
 const password = process.env.TYPEDB_PASSWORD ?? "password";
+const httpPort = Number(process.env.TYPEDB_HTTP_PORT ?? "8000");
 
 const suffix = `typed-relation-${process.pid}-${Date.now()}`;
 const personType = `${suffix}-person`;
@@ -153,8 +154,8 @@ describe("typed relation manager CRUD", () => {
 });
 
 function connectIntegration() {
-  typeBridge.ensureDatabase(address, database, { username, password });
-  return typeBridge.RustDatabase.connect(address, database, { username, password });
+  typeBridge.ensureDatabase(address, database, { username, password, httpPort });
+  return typeBridge.RustDatabase.connect(address, database, { username, password, httpPort });
 }
 
 function defineSchema(db: ReturnType<typeof connectIntegration>, typeql: string): void {

--- a/type-bridge-core/crates/node/tests/parity/typed-reader.ts
+++ b/type-bridge-core/crates/node/tests/parity/typed-reader.ts
@@ -316,7 +316,8 @@ function readLive(): { version: number; mode: string; entities: ReaderSection[];
     "type_bridge_test";
   const username = process.env.TYPEDB_USERNAME ?? "admin";
   const password = process.env.TYPEDB_PASSWORD ?? "password";
-  const db = typeBridge.RustDatabase.connect(address, database, { username, password });
+  const httpPort = Number(process.env.TYPEDB_HTTP_PORT ?? "8000");
+  const db = typeBridge.RustDatabase.connect(address, database, { username, password, httpPort });
 
   const entities: ReaderSection[] = ENTITY_READERS.map(({ typeName, model }) => ({
     type_name: typeName,

--- a/type-bridge-core/crates/node/tests/typed-integration/connect-http-port.test.ts
+++ b/type-bridge-core/crates/node/tests/typed-integration/connect-http-port.test.ts
@@ -14,19 +14,19 @@ const address = process.env.TYPEDB_ADDRESS ?? "localhost:1730";
 const database = process.env.TYPE_BRIDGE_NODE_INTG_DATABASE ?? "type_bridge_test";
 const username = process.env.TYPEDB_USERNAME ?? "admin";
 const password = process.env.TYPEDB_PASSWORD ?? "password";
+const httpPort = Number(process.env.TYPEDB_HTTP_PORT ?? "8000");
 
 describe("connect honors an explicit httpPort", () => {
-  test("ensureDatabase and RustDatabase.connect accept explicit httpPort 8000", () => {
-    // Pass the default HTTP port explicitly — proves the plumbed path is live
-    // without requiring a remapped server.  If the port forwarding is broken,
-    // the version probe will fail before any gRPC connection is attempted.
-    typeBridge.ensureDatabase(address, database, { username, password, httpPort: 8000 });
+  test("ensureDatabase and RustDatabase.connect accept an explicit httpPort", () => {
+    // Pass the active HTTP port explicitly. In isolated test runs this is a
+    // dynamically mapped host port, so a broken option path fails before gRPC.
+    typeBridge.ensureDatabase(address, database, { username, password, httpPort });
     const db = typeBridge.RustDatabase.connect(address, database, {
       username,
       password,
-      httpPort: 8000,
+      httpPort,
     });
-    assert.ok(db.isConnected(), "connection with explicit httpPort=8000 must succeed");
+    assert.ok(db.isConnected(), "connection with an explicit httpPort must succeed");
   });
 
   test("an out-of-range httpPort is rejected at the binding boundary", () => {

--- a/type-bridge-core/crates/node/tests/typed-integration/database-lifecycle.test.ts
+++ b/type-bridge-core/crates/node/tests/typed-integration/database-lifecycle.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { describe, test } from "node:test";
+
+import type {} from "../../typescript/index.js";
+
+type RuntimePackage = typeof import("../../typescript/index.js");
+
+const requirePackage = createRequire(path.join(process.cwd(), "typed-integration.cjs"));
+const typeBridge = requirePackage(process.cwd()) as RuntimePackage;
+
+const address = process.env.TYPEDB_ADDRESS ?? "localhost:1730";
+const database = `type_bridge_node_lifecycle_${process.pid}_${Date.now()}`;
+const username = process.env.TYPEDB_USERNAME ?? "admin";
+const password = process.env.TYPEDB_PASSWORD ?? "password";
+const httpPort = Number(process.env.TYPEDB_HTTP_PORT ?? "8000");
+
+describe("bound RustDatabase lifecycle methods", () => {
+  test("create, delete, and reset operate on the bound database name", () => {
+    const db = typeBridge.RustDatabase.connect(address, database, {
+      username,
+      password,
+      httpPort,
+    });
+
+    try {
+      assert.equal(db.databaseName(), database);
+
+      if (db.databaseExists()) {
+        db.deleteDatabase();
+      }
+      assert.equal(db.databaseExists(), false);
+
+      db.createDatabase();
+      assert.equal(db.databaseExists(), true);
+
+      db.createDatabase();
+      assert.equal(db.databaseExists(), true);
+
+      db.deleteDatabase();
+      assert.equal(db.databaseExists(), false);
+
+      db.deleteDatabase();
+      assert.equal(db.databaseExists(), false);
+
+      db.resetDatabase();
+      assert.equal(db.databaseExists(), true);
+
+      db.resetDatabase();
+      assert.equal(db.databaseExists(), true);
+    } finally {
+      try {
+        db.deleteDatabase();
+      } catch {
+        // Test cleanup should not mask the assertion that failed first.
+      }
+    }
+  });
+});

--- a/type-bridge-core/crates/node/tests/typed-integration/model-layer.test.ts
+++ b/type-bridge-core/crates/node/tests/typed-integration/model-layer.test.ts
@@ -24,6 +24,7 @@ const address = process.env.TYPEDB_ADDRESS ?? "localhost:1730";
 const database = process.env.TYPE_BRIDGE_NODE_INTG_DATABASE ?? "type_bridge_test";
 const username = process.env.TYPEDB_USERNAME ?? "admin";
 const password = process.env.TYPEDB_PASSWORD ?? "password";
+const httpPort = Number(process.env.TYPEDB_HTTP_PORT ?? "8000");
 
 const suffix = `typed-model-${process.pid}-${Date.now()}`;
 const personType = `${suffix}-person`;
@@ -179,8 +180,8 @@ describe("typed model layer integration", () => {
 });
 
 function connectIntegration() {
-  typeBridge.ensureDatabase(address, database, { username, password });
-  return typeBridge.RustDatabase.connect(address, database, { username, password });
+  typeBridge.ensureDatabase(address, database, { username, password, httpPort });
+  return typeBridge.RustDatabase.connect(address, database, { username, password, httpPort });
 }
 
 function defineSchema(db: ReturnType<typeof connectIntegration>, typeql: string): void {

--- a/type-bridge-core/crates/node/typescript/index.ts
+++ b/type-bridge-core/crates/node/typescript/index.ts
@@ -432,6 +432,10 @@ interface NativeMarshalling {
 export interface NativeRustDatabase {
   isConnected(): boolean;
   databaseName(): string;
+  databaseExists(): boolean;
+  createDatabase(): void;
+  deleteDatabase(): void;
+  resetDatabase(): void;
   transaction(transactionType?: TransactionType): NativeRustTransactionContext;
   entityManagerJson(descriptorJson: string): NativeDynamicEntityManager;
   relationManagerJson(descriptorJson: string): NativeDynamicRelationManager;
@@ -757,6 +761,22 @@ export class RustDatabase {
 
   databaseName(): string {
     return this.#native.databaseName();
+  }
+
+  databaseExists(): boolean {
+    return this.#native.databaseExists();
+  }
+
+  createDatabase(): void {
+    this.#native.createDatabase();
+  }
+
+  deleteDatabase(): void {
+    this.#native.deleteDatabase();
+  }
+
+  resetDatabase(): void {
+    this.#native.resetDatabase();
   }
 
   transaction(transactionType: TransactionType = "read"): RustTransactionContext {

--- a/type-bridge-core/crates/server/src/typedb/backend.rs
+++ b/type-bridge-core/crates/server/src/typedb/backend.rs
@@ -56,6 +56,15 @@ pub(crate) trait DriverBackend: Send + Sync {
         tx_type: TransactionType,
     ) -> BoxFuture<'_, Result<Box<dyn TransactionOps>, PipelineError>>;
 
+    /// Check whether a database exists.
+    fn database_exists(&self, database: &str) -> BoxFuture<'_, Result<bool, PipelineError>>;
+
+    /// Create a database.
+    fn create_database(&self, database: &str) -> BoxFuture<'_, Result<(), PipelineError>>;
+
+    /// Delete a database.
+    fn delete_database(&self, database: &str) -> BoxFuture<'_, Result<(), PipelineError>>;
+
     /// Check if the driver connection is open.
     fn is_open(&self) -> bool;
 }

--- a/type-bridge-core/crates/server/src/typedb/client.rs
+++ b/type-bridge-core/crates/server/src/typedb/client.rs
@@ -74,6 +74,29 @@ impl TypeDBClient {
         Ok(results)
     }
 
+    /// Return whether a TypeDB database exists on the connected server.
+    pub async fn database_exists(&self, database: &str) -> Result<bool, PipelineError> {
+        self.backend.database_exists(database).await
+    }
+
+    /// Create a TypeDB database.
+    pub async fn create_database(&self, database: &str) -> Result<(), PipelineError> {
+        self.backend.create_database(database).await
+    }
+
+    /// Delete a TypeDB database.
+    pub async fn delete_database(&self, database: &str) -> Result<(), PipelineError> {
+        self.backend.delete_database(database).await
+    }
+
+    /// Delete a TypeDB database if it exists, then create it.
+    pub async fn reset_database(&self, database: &str) -> Result<(), PipelineError> {
+        if self.database_exists(database).await? {
+            self.delete_database(database).await?;
+        }
+        self.create_database(database).await
+    }
+
     /// Check if the driver connection is open.
     pub fn is_connected(&self) -> bool {
         self.backend.is_open()
@@ -248,6 +271,7 @@ pub(crate) fn value_to_json_b8(value: &typedb_driver::concept::Value) -> serde_j
 #[cfg(feature = "band8")]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use std::collections::VecDeque;
     use std::future::Future;
     use std::pin::Pin;
     use std::sync::Arc;
@@ -333,11 +357,23 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct MockDatabaseAdmin {
+        exists_results: std::sync::Mutex<VecDeque<Result<bool, String>>>,
+        create_errors: std::sync::Mutex<VecDeque<String>>,
+        delete_errors: std::sync::Mutex<VecDeque<String>>,
+        exists_called: AtomicUsize,
+        create_called: AtomicUsize,
+        delete_called: AtomicUsize,
+        operations: std::sync::Mutex<Vec<String>>,
+    }
+
     struct MockBackend {
         transaction: std::sync::Mutex<Option<MockTransaction>>,
         open_error: Option<String>,
         is_open: bool,
         open_called: Arc<AtomicUsize>,
+        database_admin: Arc<MockDatabaseAdmin>,
     }
 
     impl MockBackend {
@@ -347,6 +383,7 @@ mod tests {
                 open_error: None,
                 is_open: true,
                 open_called: Arc::new(AtomicUsize::new(0)),
+                database_admin: Arc::new(MockDatabaseAdmin::default()),
             }
         }
 
@@ -356,7 +393,29 @@ mod tests {
                 open_error: Some(msg.to_string()),
                 is_open: true,
                 open_called: Arc::new(AtomicUsize::new(0)),
+                database_admin: Arc::new(MockDatabaseAdmin::default()),
             }
+        }
+
+        fn with_database_exists_results(self, results: Vec<Result<bool, String>>) -> Self {
+            *self.database_admin.exists_results.lock().unwrap() = results.into();
+            self
+        }
+
+        fn with_create_errors(self, errors: Vec<&str>) -> Self {
+            *self.database_admin.create_errors.lock().unwrap() =
+                errors.into_iter().map(str::to_string).collect();
+            self
+        }
+
+        fn with_delete_errors(self, errors: Vec<&str>) -> Self {
+            *self.database_admin.delete_errors.lock().unwrap() =
+                errors.into_iter().map(str::to_string).collect();
+            self
+        }
+
+        fn database_admin_state(&self) -> Arc<MockDatabaseAdmin> {
+            Arc::clone(&self.database_admin)
         }
     }
 
@@ -383,6 +442,80 @@ mod tests {
 
         fn is_open(&self) -> bool {
             self.is_open
+        }
+
+        fn database_exists(
+            &self,
+            database: &str,
+        ) -> Pin<Box<dyn Future<Output = Result<bool, PipelineError>> + Send + '_>> {
+            self.database_admin
+                .exists_called
+                .fetch_add(1, Ordering::SeqCst);
+            self.database_admin
+                .operations
+                .lock()
+                .unwrap()
+                .push(format!("exists:{database}"));
+            let result = self
+                .database_admin
+                .exists_results
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or(Ok(false));
+            Box::pin(async move { result.map_err(PipelineError::Connection) })
+        }
+
+        fn create_database(
+            &self,
+            database: &str,
+        ) -> Pin<Box<dyn Future<Output = Result<(), PipelineError>> + Send + '_>> {
+            self.database_admin
+                .create_called
+                .fetch_add(1, Ordering::SeqCst);
+            self.database_admin
+                .operations
+                .lock()
+                .unwrap()
+                .push(format!("create:{database}"));
+            let error = self
+                .database_admin
+                .create_errors
+                .lock()
+                .unwrap()
+                .pop_front();
+            Box::pin(async move {
+                if let Some(msg) = error {
+                    return Err(PipelineError::Connection(msg));
+                }
+                Ok(())
+            })
+        }
+
+        fn delete_database(
+            &self,
+            database: &str,
+        ) -> Pin<Box<dyn Future<Output = Result<(), PipelineError>> + Send + '_>> {
+            self.database_admin
+                .delete_called
+                .fetch_add(1, Ordering::SeqCst);
+            self.database_admin
+                .operations
+                .lock()
+                .unwrap()
+                .push(format!("delete:{database}"));
+            let error = self
+                .database_admin
+                .delete_errors
+                .lock()
+                .unwrap()
+                .pop_front();
+            Box::pin(async move {
+                if let Some(msg) = error {
+                    return Err(PipelineError::Connection(msg));
+                }
+                Ok(())
+            })
         }
     }
 
@@ -651,6 +784,170 @@ mod tests {
         backend.is_open = false;
         let client = make_client(backend);
         assert!(!client.is_connected());
+    }
+
+    // =============================================
+    // database admin tests (via MockBackend)
+    // =============================================
+
+    #[tokio::test]
+    async fn database_exists_true_delegates_to_backend() {
+        let backend = MockBackend::new(MockTransaction::new(QueryResultKind::Ok))
+            .with_database_exists_results(vec![Ok(true)]);
+        let admin = backend.database_admin_state();
+        let client = make_client(backend);
+
+        assert!(client.database_exists("admin_db").await.unwrap());
+        assert_eq!(admin.exists_called.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            admin.operations.lock().unwrap().clone(),
+            vec!["exists:admin_db".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn database_exists_false_delegates_to_backend() {
+        let backend = MockBackend::new(MockTransaction::new(QueryResultKind::Ok))
+            .with_database_exists_results(vec![Ok(false)]);
+        let admin = backend.database_admin_state();
+        let client = make_client(backend);
+
+        assert!(!client.database_exists("missing_db").await.unwrap());
+        assert_eq!(admin.exists_called.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            admin.operations.lock().unwrap().clone(),
+            vec!["exists:missing_db".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn create_database_delegates_to_backend() {
+        let backend = MockBackend::new(MockTransaction::new(QueryResultKind::Ok));
+        let admin = backend.database_admin_state();
+        let client = make_client(backend);
+
+        client.create_database("new_db").await.unwrap();
+        assert_eq!(admin.create_called.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            admin.operations.lock().unwrap().clone(),
+            vec!["create:new_db".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_database_delegates_to_backend() {
+        let backend = MockBackend::new(MockTransaction::new(QueryResultKind::Ok));
+        let admin = backend.database_admin_state();
+        let client = make_client(backend);
+
+        client.delete_database("old_db").await.unwrap();
+        assert_eq!(admin.delete_called.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            admin.operations.lock().unwrap().clone(),
+            vec!["delete:old_db".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn reset_database_deletes_existing_database_before_create() {
+        let backend = MockBackend::new(MockTransaction::new(QueryResultKind::Ok))
+            .with_database_exists_results(vec![Ok(true)]);
+        let admin = backend.database_admin_state();
+        let client = make_client(backend);
+
+        client.reset_database("reset_db").await.unwrap();
+        assert_eq!(admin.exists_called.load(Ordering::SeqCst), 1);
+        assert_eq!(admin.delete_called.load(Ordering::SeqCst), 1);
+        assert_eq!(admin.create_called.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            admin.operations.lock().unwrap().clone(),
+            vec![
+                "exists:reset_db".to_string(),
+                "delete:reset_db".to_string(),
+                "create:reset_db".to_string(),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn reset_database_creates_when_database_is_absent() {
+        let backend = MockBackend::new(MockTransaction::new(QueryResultKind::Ok))
+            .with_database_exists_results(vec![Ok(false)]);
+        let admin = backend.database_admin_state();
+        let client = make_client(backend);
+
+        client.reset_database("reset_db").await.unwrap();
+        assert_eq!(admin.exists_called.load(Ordering::SeqCst), 1);
+        assert_eq!(admin.delete_called.load(Ordering::SeqCst), 0);
+        assert_eq!(admin.create_called.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            admin.operations.lock().unwrap().clone(),
+            vec!["exists:reset_db".to_string(), "create:reset_db".to_string(),]
+        );
+    }
+
+    #[tokio::test]
+    async fn database_exists_propagates_backend_error() {
+        let backend = MockBackend::new(MockTransaction::new(QueryResultKind::Ok))
+            .with_database_exists_results(vec![Err("lookup failed".to_string())]);
+        let client = make_client(backend);
+
+        let err = client.database_exists("db").await.unwrap_err();
+        assert!(matches!(&err, PipelineError::Connection(msg) if msg.contains("lookup failed")));
+    }
+
+    #[tokio::test]
+    async fn create_database_propagates_backend_error() {
+        let backend = MockBackend::new(MockTransaction::new(QueryResultKind::Ok))
+            .with_create_errors(vec!["create failed"]);
+        let client = make_client(backend);
+
+        let err = client.create_database("db").await.unwrap_err();
+        assert!(matches!(&err, PipelineError::Connection(msg) if msg.contains("create failed")));
+    }
+
+    #[tokio::test]
+    async fn delete_database_propagates_backend_error() {
+        let backend = MockBackend::new(MockTransaction::new(QueryResultKind::Ok))
+            .with_delete_errors(vec!["delete failed"]);
+        let client = make_client(backend);
+
+        let err = client.delete_database("db").await.unwrap_err();
+        assert!(matches!(&err, PipelineError::Connection(msg) if msg.contains("delete failed")));
+    }
+
+    #[tokio::test]
+    async fn reset_database_propagates_lookup_error_without_mutating() {
+        let backend = MockBackend::new(MockTransaction::new(QueryResultKind::Ok))
+            .with_database_exists_results(vec![Err("lookup failed".to_string())]);
+        let admin = backend.database_admin_state();
+        let client = make_client(backend);
+
+        let err = client.reset_database("db").await.unwrap_err();
+        assert!(matches!(&err, PipelineError::Connection(msg) if msg.contains("lookup failed")));
+        assert_eq!(admin.delete_called.load(Ordering::SeqCst), 0);
+        assert_eq!(admin.create_called.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            admin.operations.lock().unwrap().clone(),
+            vec!["exists:db".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn reset_database_propagates_delete_error_without_create() {
+        let backend = MockBackend::new(MockTransaction::new(QueryResultKind::Ok))
+            .with_database_exists_results(vec![Ok(true)])
+            .with_delete_errors(vec!["delete failed"]);
+        let admin = backend.database_admin_state();
+        let client = make_client(backend);
+
+        let err = client.reset_database("db").await.unwrap_err();
+        assert!(matches!(&err, PipelineError::Connection(msg) if msg.contains("delete failed")));
+        assert_eq!(admin.create_called.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            admin.operations.lock().unwrap().clone(),
+            vec!["exists:db".to_string(), "delete:db".to_string()]
+        );
     }
 
     // =============================================
@@ -926,6 +1223,51 @@ mod tests {
         let result = TypeDBClient::connect(&live_config()).await;
         assert!(result.is_ok());
         assert!(result.unwrap().is_connected());
+    }
+
+    #[tokio::test]
+    #[ignore = "requires running TypeDB server"]
+    #[cfg_attr(coverage_nightly, coverage(off))]
+    async fn integration_database_admin_roundtrip() {
+        let config = live_config();
+        let client = TypeDBClient::connect(&config)
+            .await
+            .expect("connect failed");
+        let database = format!("type_bridge_server_admin_{}", uuid::Uuid::new_v4().simple());
+
+        if client.database_exists(&database).await.unwrap_or(false) {
+            let _ = client.delete_database(&database).await;
+        }
+
+        assert!(!client.database_exists(&database).await.unwrap());
+        client
+            .create_database(&database)
+            .await
+            .expect("create failed");
+        assert!(client.database_exists(&database).await.unwrap());
+
+        client
+            .reset_database(&database)
+            .await
+            .expect("reset existing database failed");
+        assert!(client.database_exists(&database).await.unwrap());
+
+        client
+            .delete_database(&database)
+            .await
+            .expect("delete failed");
+        assert!(!client.database_exists(&database).await.unwrap());
+
+        client
+            .reset_database(&database)
+            .await
+            .expect("reset absent database failed");
+        assert!(client.database_exists(&database).await.unwrap());
+
+        client
+            .delete_database(&database)
+            .await
+            .expect("cleanup delete failed");
     }
 
     #[tokio::test]

--- a/type-bridge-core/crates/server/src/typedb/real_driver.rs
+++ b/type-bridge-core/crates/server/src/typedb/real_driver.rs
@@ -247,6 +247,72 @@ impl DriverBackend for RealTypeDBBackend {
             DriverHandle::B8(d) => d.is_open(),
         }
     }
+
+    fn database_exists(&self, database: &str) -> BoxFuture<'_, Result<bool, PipelineError>> {
+        let database = database.to_string();
+        Box::pin(async move {
+            match &self.driver {
+                #[cfg(feature = "band7")]
+                DriverHandle::B7(d) => {
+                    d.databases().contains(database).await.map_err(|e| {
+                        PipelineError::Connection(format!("Database lookup failed: {e}"))
+                    })
+                }
+                #[cfg(feature = "band8")]
+                DriverHandle::B8(d) => {
+                    d.databases().contains(database).await.map_err(|e| {
+                        PipelineError::Connection(format!("Database lookup failed: {e}"))
+                    })
+                }
+            }
+        })
+    }
+
+    fn create_database(&self, database: &str) -> BoxFuture<'_, Result<(), PipelineError>> {
+        let database = database.to_string();
+        Box::pin(async move {
+            match &self.driver {
+                #[cfg(feature = "band7")]
+                DriverHandle::B7(d) => {
+                    d.databases().create(database).await.map_err(|e| {
+                        PipelineError::Connection(format!("Database create failed: {e}"))
+                    })
+                }
+                #[cfg(feature = "band8")]
+                DriverHandle::B8(d) => {
+                    d.databases().create(database).await.map_err(|e| {
+                        PipelineError::Connection(format!("Database create failed: {e}"))
+                    })
+                }
+            }
+        })
+    }
+
+    fn delete_database(&self, database: &str) -> BoxFuture<'_, Result<(), PipelineError>> {
+        let database = database.to_string();
+        Box::pin(async move {
+            match &self.driver {
+                #[cfg(feature = "band7")]
+                DriverHandle::B7(d) => {
+                    let db = d.databases().get(&database).await.map_err(|e| {
+                        PipelineError::Connection(format!("Database lookup failed: {e}"))
+                    })?;
+                    db.delete().await.map_err(|e| {
+                        PipelineError::Connection(format!("Database delete failed: {e}"))
+                    })
+                }
+                #[cfg(feature = "band8")]
+                DriverHandle::B8(d) => {
+                    let db = d.databases().get(database).await.map_err(|e| {
+                        PipelineError::Connection(format!("Database lookup failed: {e}"))
+                    })?;
+                    db.delete().await.map_err(|e| {
+                        PipelineError::Connection(format!("Database delete failed: {e}"))
+                    })
+                }
+            }
+        })
+    }
 }
 
 /// Band-tagged transaction inner state.


### PR DESCRIPTION
## Summary

Adds database lifecycle/admin APIs for #155 across the server client and Node
binding surfaces.

## Key Changes

- Add `TypeDBClient::{database_exists, create_database, delete_database,
  reset_database}` in the server crate.
- Route server database lifecycle calls through the backend abstraction with
  band-aware TypeDB driver dispatch.
- Add bound Node `RustDatabase` lifecycle methods:
  `databaseExists`, `createDatabase`, `deleteDatabase`, and `resetDatabase`.
- Add Node typed-integration coverage for create/delete/reset transitions on a
  disposable database.
- Keep isolated test runs aligned with dynamic TypeDB HTTP ports and make the
  proxy server image build include vendored driver crates.
- Update TypeScript declarations, docs, and changelog.

## Verification

- `env UV_CACHE_DIR=/tmp/uv-cache ./test.sh --proxy`
- `env UV_CACHE_DIR=/tmp/uv-cache ./scripts/check.sh all`
- `npm run test:integration` from `type-bridge-core/crates/node` against an
  isolated TypeDB container

Refs #155
