### PR TITLE
feat(migration): add ORM data migrations and snapshot history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to TypeBridge will be documented in this file.
 
 ## [Unreleased]
 
+## [1.5.3] - 2026-06-24
+
+### New Features
+
+- **ORM-backed Python data migrations (#158)** - migrations can now use
+  `ops.RunPython(...)` to run normal TypeBridge ORM code during migration
+  execution, including `User.manager(db).filter(...)`, bulk inserts, updates,
+  deletes, and JSON/TOML-backed data loading.
+- **Database-backed migration history (#158)** - applied migration state and
+  execution attempts are stored in TypeDB through `type_bridge_migration` and
+  `type_bridge_migration_run`, including run IDs, checksums, direction, status,
+  timestamps, errors, and executor metadata when available.
+- **Historical snapshot bindings for generated migrations (#160)** - generated
+  migrations now import stable time-state bindings such as
+  `migrations.snapshots.v0001.User` instead of the active generated model
+  package, keeping old migrations replayable after later bindgen output removes
+  or reshapes types.
+
+### Changes
+
+- **Snapshot drift protection (#160)** - existing snapshot packages are
+  validated by schema hash, generated file hash manifest, and top-level binding
+  exports before reuse, so stale or hand-edited historical bindings fail
+  clearly instead of silently changing migration semantics.
+
+### Documentation
+
+- **Migration guide added (#158/#160)** - added a dedicated migration guide that
+  explains the generated migration workflow, why snapshots matter, `RunPython`
+  data migrations, rollback, sidecar checksum drift, and TypeDB-backed
+  migration/run history.
+
 ## [1.5.2] - 2026-06-18
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ See [`type-bridge-core/README.md`](type-bridge-core/README.md) for build instruc
 
 - Python 3.12–3.13
 - TypeDB 3.8.0–3.11.x server (see the [compatibility table](docs/development/typedb.md#server-and-driver-compatibility) for the full support window; band-7 and band-8 servers are all served by one artifact)
-- type-bridge-core>=1.5.2
+- type-bridge-core>=1.5.3
 - pydantic>=2.12.4
 - isodate==0.7.2 (for Duration type support)
 - jinja2>=3.1.0 (for code generation)

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -25,7 +25,7 @@ uv pip install -e ".[dev]"
 ### Project Dependencies
 
 The project requires:
-- `type-bridge-core>=1.5.2rc1`: Rust runtime for ORM connectivity and query execution
+- `type-bridge-core>=1.5.3`: Rust runtime for ORM connectivity and query execution
 - `pydantic>=2.12.4`: For validation and type coercion
 - `isodate==0.7.2`: For Duration type support (ISO 8601)
 - `jinja2>=3.1.0`: Template engine for code generation

--- a/docs/guide/generator.md
+++ b/docs/guide/generator.md
@@ -51,25 +51,34 @@ python -m type_bridge.migration makemigrations \
 python -m type_bridge.migration migrate --migrations-dir migrations
 ```
 
-Generated migration files use typed operations by default:
+Generated migration files use historical snapshot bindings by default, so
+historical migrations do not import the latest generated model package:
 
 ```python
+from migrations.snapshots.v0001 import Name, Person
+from type_bridge.migration import operations as ops
+
 operations = [
     ops.AddAttribute(Name),
     ops.AddEntity(Person),
-    ops.AddOwnership(Person, Email, optional=True),
+    ops.AddOwnership(Person, Name, key=True),
 ]
 ```
 
-The `.json` sidecar beside the migration keeps the same typed Rust
-`OperationSpec` variants. `ops.RunTypeQL` remains available for explicit custom
-TypeQL, but schema diffs are not flattened to `RunTypeQL` by default.
+The `.json` sidecar beside the migration keeps the typed Rust `OperationSpec`
+payloads needed for execution. The `.py` file stays readable and stable across
+bindgen removals because `migrations.snapshots.vNNNN` is append-only migration
+history, not the active application model package. `ops.RunTypeQL` remains
+available for explicit custom TypeQL, but schema diffs are not flattened to
+`RunTypeQL` by default.
 
 Existing files in `--migrations-dir` determine the next migration number and
 dependency. The current diff source is the live TypeDB schema, so apply each
 generated migration before generating the next one. See
 [`examples/advanced/toml_migration`](../../examples/advanced/toml_migration/)
-for a two-step `schema.toml` example.
+for a two-step `schema.toml` example, and see [Migrations](migrations.md) for
+the full migration workflow, snapshot rationale, data migrations, rollback, and
+database-backed migration state.
 
 ### Programmatic Usage
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -20,7 +20,8 @@ TypeBridge provides a Pythonic interface to TypeDB that aligns with TypeDB's typ
 - **[CRUD Operations](crud.md)** - Create, read, update, delete with type-safe managers
 - **[Queries](queries.md)** - Query expressions, filtering, aggregations, and pagination
 - **[Functions](functions.md)** - TypeDB schema-defined functions and FunctionQuery
-- **[Schema Management](schema.md)** - Schema operations, conflict detection, and migrations
+- **[Schema Management](schema.md)** - Schema operations and conflict detection
+- **[Migrations](migrations.md)** - Schema history, snapshots, data migrations, and rollback
 
 ### Code Generation
 
@@ -196,6 +197,7 @@ entity person,
 - [Queries Documentation](queries.md)
 - [Functions Documentation](functions.md)
 - [Schema Management Documentation](schema.md)
+- [Migration Documentation](migrations.md)
 - [Generator Documentation](generator.md)
 - [API DTOs Documentation](dto.md)
 - [Validation Documentation](validation.md)

--- a/docs/guide/migrations.md
+++ b/docs/guide/migrations.md
@@ -1,0 +1,364 @@
+# Migrations
+
+TypeBridge migrations are ordered Python files that apply schema and data
+changes to a TypeDB database. They are intended for production workflows where
+schema history must be replayable, data backfills must use the ORM, and applied
+state must live in the database.
+
+## Workflow
+
+For a generated model package, the normal loop is:
+
+```bash
+python -m type_bridge.generator schema.toml -o generated_models
+
+python -m type_bridge.migration makemigrations \
+  --models generated_models \
+  --migrations-dir migrations \
+  --name initial \
+  --database app
+
+python -m type_bridge.migration migrate \
+  --migrations-dir migrations \
+  --database app
+```
+
+Then edit the schema, regenerate models, make the next migration, and apply it:
+
+```bash
+python -m type_bridge.generator schema.toml -o generated_models
+
+python -m type_bridge.migration makemigrations \
+  --models generated_models \
+  --migrations-dir migrations \
+  --name add_full_name \
+  --database app
+
+python -m type_bridge.migration migrate \
+  --migrations-dir migrations \
+  --database app
+```
+
+`makemigrations` compares the current model package with the live TypeDB schema.
+Apply each generated migration before generating the next one so the live schema
+is the previous state for the next diff.
+
+## Migration Files
+
+Migration files live in a migrations directory and use the
+`NNNN_name.py` naming pattern:
+
+```text
+migrations/
+|-- 0001_initial.py
+|-- 0001_initial.json
+|-- 0002_add_full_name.py
+|-- 0002_add_full_name.json
+`-- snapshots/
+    |-- __init__.py
+    |-- v0001/
+    `-- v0002/
+```
+
+A generated migration uses typed operations:
+
+```python
+from typing import ClassVar
+
+from migrations.snapshots.v0001 import Name, User
+from type_bridge.migration import Migration
+from type_bridge.migration import operations as ops
+from type_bridge.migration.operations import Operation
+
+
+class InitialMigration(Migration):
+    dependencies: ClassVar[list[tuple[str, str]]] = []
+    operations: ClassVar[list[Operation]] = [
+        ops.AddAttribute(Name),
+        ops.AddEntity(User),
+        ops.AddOwnership(User, Name, key=True),
+    ]
+```
+
+The `.json` sidecar beside a generated migration stores the typed Rust
+`OperationSpec` used for fast portable schema execution. The `.py` file remains
+readable and is also the checksum source. If the `.py` file and sidecar drift
+apart, migration loading fails before any schema or data change runs.
+
+For hand-authored Python data migrations, prefer an empty migration:
+
+```bash
+python -m type_bridge.migration makemigrations \
+  --empty \
+  --migrations-dir migrations \
+  --name load_users \
+  --database app
+```
+
+## Why Snapshots Matter
+
+The active model package is the current application API. It is not migration
+history.
+
+That distinction matters when a migration is replayed from an empty database.
+Suppose migration `0001` creates `User.name`, migration `0002` adds
+`User.full_name`, and migration `0003` removes `User.name`. After `0003`, the
+active generated package no longer has the old `User.name` field. If `0001` or
+`0002` imported from the active package, a fresh replay would import the wrong
+schema shape, or fail because a removed type or field is gone.
+
+Snapshots solve that by making the import path carry schema time:
+
+```python
+from migrations.snapshots.v0001 import User as OldUser
+from migrations.snapshots.v0002 import FullName, Name, User
+```
+
+`migrations.snapshots.v0001.User` is the `User` binding for the schema state
+after `0001` was generated. `migrations.snapshots.v0002.User` is the `User`
+binding for the schema state after `0002`. Both can be imported in one
+migration, with aliases when symbols collide.
+
+This gives migrations two important properties:
+
+- Fresh replay works after active bindgen output changes.
+- Data migrations can use the ORM against the schema state that exists at that
+  point in the migration plan.
+
+A snapshot does not bypass TypeDB schema rules. The imported class determines
+how TypeBridge compiles ORM operations, but the live database must still have
+the matching schema at that point. For example, use `OldUser` before removing
+the old ownership, and use the newer `User` after adding the new ownership.
+
+## Schema And Data In One Plan
+
+Use generated schema operations for portable schema changes, and `RunPython`
+for data movement that needs application logic or external files.
+
+For an expand/backfill/contract rename, use separate migration states:
+
+1. Expand the schema so both old and new fields can exist.
+2. Backfill data with `RunPython`.
+3. Contract the schema by removing the old ownership or type.
+
+Example backfill:
+
+```python
+from typing import ClassVar
+
+from migrations.snapshots.v0001 import User as OldUser
+from migrations.snapshots.v0002 import FullName, Name, User
+from type_bridge.migration import Migration
+from type_bridge.migration import operations as ops
+from type_bridge.migration.operations import Operation
+
+
+def forwards(db: object) -> None:
+    for old_user in OldUser.manager(db).filter().execute():
+        User.manager(db).update(
+            User(
+                name=Name(str(old_user.name)),
+                full_name=FullName(str(old_user.name)),
+            )
+        )
+
+
+class BackfillFullNameMigration(Migration):
+    dependencies: ClassVar[list[tuple[str, str]]] = [
+        ("migrations", "0002_expand_user"),
+    ]
+    operations: ClassVar[list[Operation]] = [
+        ops.RunPython(
+            forwards,
+            description="copy user name to full_name",
+        ),
+    ]
+```
+
+The `db` argument is the same database connection used by the migration
+executor. Normal manager APIs work:
+
+```python
+users = User.manager(db).filter(full_name__startswith="A").execute()
+count = User.manager(db).filter().count()
+User.manager(db).insert_many(users_to_create)
+User.manager(db).update(user)
+User.manager(db).filter(email="old@example.com").delete()
+```
+
+## Loading JSON Or TOML During Migration
+
+`RunPython` is useful for programmatic imports, fixture loading, and large data
+creation. Declare files in `resources` so the executor validates that they exist
+before running the migration body.
+
+```python
+from pathlib import Path
+from typing import ClassVar
+
+import json
+import tomllib
+
+from migrations.snapshots.v0001 import Team, TeamSlug, User, UserEmail
+from type_bridge.migration import Migration
+from type_bridge.migration import operations as ops
+from type_bridge.migration.operations import Operation
+
+
+def forwards(db: object) -> None:
+    migration_dir = Path(__file__).parent
+    teams = tomllib.loads((migration_dir / "data" / "teams.toml").read_text())["teams"]
+    users = json.loads((migration_dir / "data" / "users.json").read_text())
+
+    Team.manager(db).insert_many([
+        Team(slug=TeamSlug(row["slug"]))
+        for row in teams
+    ])
+    User.manager(db).insert_many([
+        User(email=UserEmail(row["email"]))
+        for row in users
+    ])
+
+
+class LoadUsersMigration(Migration):
+    dependencies: ClassVar[list[tuple[str, str]]] = [
+        ("migrations", "0001_initial"),
+    ]
+    operations: ClassVar[list[Operation]] = [
+        ops.RunPython(
+            forwards,
+            description="load users and teams",
+            resources=["data/teams.toml", "data/users.json"],
+            import_checks=["json", "tomllib"],
+        )
+    ]
+```
+
+`sqlmigrate` previews Python operations as comments, including resources and
+import checks:
+
+```bash
+python -m type_bridge.migration sqlmigrate 0002_load_users \
+  --migrations-dir migrations \
+  --database app
+```
+
+## Rollback
+
+Schema operations are reversible only when they can produce rollback TypeQL.
+Destructive operations such as removing a type are generally not reversible
+because deleted data cannot be reconstructed.
+
+For Python data migrations, pass a reverse callable:
+
+```python
+def reverse(db: object) -> None:
+    User.manager(db).filter(email__startswith="seed-").delete()
+
+
+operations = [
+    ops.RunPython(
+        forwards,
+        reverse=reverse,
+        description="seed users",
+    )
+]
+```
+
+Rollback to a target migration with:
+
+```bash
+python -m type_bridge.migration migrate 0001_initial \
+  --migrations-dir migrations \
+  --database app
+```
+
+If any operation in the rollback path is irreversible, the executor raises an
+error before pretending the rollback succeeded.
+
+## Migration State In TypeDB
+
+TypeBridge stores migration state in TypeDB, not in memory or local files. This
+is the database source of truth used by `migrate`, `showmigrations`, and
+checksum drift checks.
+
+Two internal entity types are created automatically:
+
+- `type_bridge_migration`: one row for each applied migration, including
+  `app_label`, `name`, `applied_at`, and `checksum`.
+- `type_bridge_migration_run`: one row for each execution attempt, including
+  `run_id`, `app_label`, `name`, `checksum`, `direction`, `status`,
+  `started_at`, `finished_at`, `error`, and executor metadata when available.
+
+You can read this state through the Python facade:
+
+```python
+from type_bridge.migration import MigrationStateManager
+
+state_manager = MigrationStateManager(db)
+state = state_manager.load_state()
+runs = state_manager.load_runs()
+
+for record in state.applied:
+    print(record.app_label, record.name, record.checksum)
+
+for run in runs:
+    print(run.run_id, run.name, run.direction, run.status, run.error)
+```
+
+Because the state is in TypeDB, a different process can inspect the same
+migration history, and TypeDB Studio can view the internal migration entities
+after the migration tracking schema has been ensured.
+
+## Sidecars And Hand Editing
+
+Generated migrations have a `.json` sidecar. Do not hand-edit a sidecar-backed
+generated migration and expect the sidecar to remain valid. The loader compares
+the sidecar checksum with the current `.py` checksum and fails on drift.
+
+Use one of these patterns:
+
+- For pure generated schema changes, leave the `.py` and `.json` pair together.
+- For custom data movement, create an empty migration and write `RunPython`.
+- For custom TypeQL, use `ops.RunTypeQL` in a hand-authored migration.
+
+This keeps generated schema execution portable while keeping user-authored
+Python migrations explicit.
+
+## Commands
+
+```bash
+# Generate a migration from models.
+python -m type_bridge.migration makemigrations \
+  --models generated_models \
+  --migrations-dir migrations \
+  --name add_email \
+  --database app
+
+# Create an empty migration for hand-authored Python or TypeQL.
+python -m type_bridge.migration makemigrations \
+  --empty \
+  --migrations-dir migrations \
+  --name load_users \
+  --database app
+
+# Apply all pending migrations.
+python -m type_bridge.migration migrate \
+  --migrations-dir migrations \
+  --database app
+
+# Roll back to a target migration.
+python -m type_bridge.migration migrate 0001_initial \
+  --migrations-dir migrations \
+  --database app
+
+# Show applied and pending migrations.
+python -m type_bridge.migration showmigrations \
+  --migrations-dir migrations \
+  --database app
+
+# Preview forward or reverse TypeQL/comments.
+python -m type_bridge.migration sqlmigrate 0002_load_users \
+  --migrations-dir migrations \
+  --database app
+```

--- a/docs/guide/schema.md
+++ b/docs/guide/schema.md
@@ -365,72 +365,13 @@ class MatchResult(Entity):
     pass
 ```
 
-## Migration Manager
+## Migrations
 
-For complex schema migrations, use `MigrationManager`:
-
-```python
-from type_bridge.schema import MigrationManager
-
-migration_manager = MigrationManager(db)
-```
-
-### Add Migrations
-
-```python
-# Add individual migration
-migration_manager.add_migration(
-    name="add_email_to_person",
-    schema="define person owns email;"
-)
-
-# Add complex migration
-migration_manager.add_migration(
-    name="add_company_entity",
-    schema="""
-    define
-    entity company,
-        owns name @key,
-        owns industry;
-
-    attribute industry, value string;
-    """
-)
-
-# Add migration with data transformation
-migration_manager.add_migration(
-    name="split_name_field",
-    schema="""
-    define
-    person owns first-name,
-        owns last-name;
-
-    attribute first-name, value string;
-    attribute last-name, value string;
-    """,
-    data_script="""
-    # TypeQL to transform data
-    match
-    $p isa person, has name $n;
-    # ... split logic
-    """
-)
-```
-
-### Apply Migrations
-
-```python
-# Apply all pending migrations in order
-migration_manager.apply_migrations()
-
-# Apply specific migration
-migration_manager.apply_migration("add_email_to_person")
-
-# Check migration status
-status = migration_manager.get_migration_status()
-print(f"Applied: {status.applied}")
-print(f"Pending: {status.pending}")
-```
+For production schema history, use the dedicated migration system documented in
+[Migrations](migrations.md). It covers generated schema migrations,
+`ops.RunPython` data migrations that can use `User.manager(db)`, historical
+snapshot bindings, rollback, sidecar drift checks, and migration state stored in
+TypeDB.
 
 ## Complete Schema Workflow
 

--- a/examples/advanced/toml_migration/README.md
+++ b/examples/advanced/toml_migration/README.md
@@ -24,9 +24,12 @@ python -m type_bridge.migration migrate \
   --database support
 ```
 
-The generated `0001_initial.py` uses typed operations:
+The generated `0001_initial.py` uses typed operations imported from the
+historical snapshot for that migration:
 
 ```python
+from migrations.snapshots.v0001 import Customer, CustomerName
+
 operations = [
     ops.AddAttribute(CustomerName),
     ops.AddEntity(Customer),
@@ -34,7 +37,10 @@ operations = [
 ```
 
 The JSON sidecar beside the `.py` file keeps the same typed Rust
-`OperationSpec` shape, for example `add_attribute` and `add_entity`.
+`OperationSpec` shape, for example `add_attribute` and `add_entity`. The
+snapshot import matters because `generated_models` is the current application
+API, while `migrations.snapshots.v0001` is the schema state after migration
+`0001`.
 
 For the next change, copy `schema.v2.toml` over `schema.toml`, regenerate
 bindings, and make the second migration:
@@ -54,9 +60,12 @@ python -m type_bridge.migration migrate \
   --database support
 ```
 
-The generated `0002_add_email.py` should use typed operations for the delta:
+The generated `0002_add_email.py` should use typed operations from the next
+snapshot for the delta:
 
 ```python
+from migrations.snapshots.v0002 import Customer, Email
+
 operations = [
     ops.AddAttribute(Email),
     ops.AddOwnership(Customer, Email, optional=True),
@@ -66,4 +75,7 @@ operations = [
 `ops.RunTypeQL` is still supported for hand-authored escape hatches, but it is
 not the default output for schema diffs. Existing files in `--migrations-dir`
 set the next number and dependency; the current diff source is the live TypeDB
-schema after the previous migrations have been applied.
+schema after the previous migrations have been applied. See
+`docs/guide/migrations.md` for the full workflow, including why snapshots are
+required for replayable migration history and how to use `ops.RunPython` for
+ORM-backed data migrations.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ nav:
     - CRUD Operations: guide/crud.md
     - Queries & Expressions: guide/queries.md
     - Schema Management: guide/schema.md
+    - Migrations: guide/migrations.md
     - Code Generator: guide/generator.md
     - TOML Schema DSL: guide/toml.md
     - API DTOs: guide/dto.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "type-bridge"
-version = "1.5.2"
+version = "1.5.3"
 description = "A modern, Pythonic ORM for TypeDB with an Attribute-based API"
 readme = "README.md"
 requires-python = ">=3.12,<3.14"
@@ -28,7 +28,7 @@ dependencies = [
     "isodate==0.7.2",
     "jinja2>=3.1.0",
     "typer>=0.15.0",
-    "type-bridge-core>=1.5.2",
+    "type-bridge-core>=1.5.3",
 ]
 
 [project.urls]

--- a/tests/integration/migration/test_autogenerate.py
+++ b/tests/integration/migration/test_autogenerate.py
@@ -21,6 +21,7 @@ from type_bridge.migration import (
     SchemaIntrospector,
 )
 from type_bridge.migration.executor import MigrationError
+from type_bridge.migration.loader import MigrationLoadError
 
 
 # Test fixtures - Version 1: Basic schema
@@ -154,7 +155,7 @@ class DriftProbeMigration(Migration):
 """.lstrip()
     )
 
-    with pytest.raises(MigrationError, match="checksum drift"):
+    with pytest.raises((MigrationError, MigrationLoadError), match=r"sidecar drift|checksum drift"):
         executor.migrate()
 
     schema = SchemaIntrospector(clean_db).introspect()
@@ -185,9 +186,9 @@ def test_incremental_migration_detects_new_attribute(clean_db, tmp_path: Path):
     assert "0002_add_age.py" in str(path)
 
     content = path.read_text()
-    # Should have typed operations for adding the attribute and ownership.
+    assert "from migrations.snapshots.v0002 import Age, Person" in content
     assert "ops.AddAttribute(Age)" in content
-    assert "ops.AddOwnership(PersonV2, Age, optional=True)" in content
+    assert "ops.AddOwnership(Person, Age, optional=True)" in content
 
 
 @pytest.mark.integration
@@ -212,7 +213,8 @@ def test_incremental_migration_detects_new_entity(clean_db, tmp_path: Path):
     # Assert
     assert path is not None
     content = path.read_text()
-    assert "ops.AddEntity(CompanyV1)" in content
+    assert "from migrations.snapshots.v0002 import Company" in content
+    assert "ops.AddEntity(Company)" in content
 
 
 @pytest.mark.integration
@@ -237,7 +239,8 @@ def test_incremental_migration_detects_new_relation(clean_db, tmp_path: Path):
     # Assert
     assert path is not None
     content = path.read_text()
-    assert "ops.AddRelation(EmploymentV3)" in content
+    assert "from migrations.snapshots.v0002 import Employment" in content
+    assert "ops.AddRelation(Employment)" in content
 
 
 @pytest.mark.integration

--- a/tests/integration/migration/test_run_python_user_scenario.py
+++ b/tests/integration/migration/test_run_python_user_scenario.py
@@ -1,0 +1,537 @@
+"""Live integration tests for the #158 manager-based run-python user scenario."""
+
+import importlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from type_bridge.migration import MigrationExecutor, MigrationGenerator, MigrationStateManager
+from type_bridge.migration.executor import MigrationError
+from type_bridge.session import Database
+
+_PACKAGE_NAME = "scenario_app"
+_MIGRATIONS_DIR_NAME = "scenario_migrations"
+_TEAM_COUNT = 10
+_USER_COUNT = 1000
+_SEEDED_USER_EMAIL = "seeded@scenario-local.test"
+_SEEDED_USER_NAME = "Seeded Scenario User"
+_LOADED_USER_EMAIL_PREFIX = "user-"
+_TEAM_SLUG_PREFIX = "team-"
+
+
+def _scenario_package_source() -> str:
+    return """\
+from type_bridge import AttributeFlags, Entity, Flag, Key, Relation, Role, String, TypeFlags
+
+
+class ScenarioUserEmail(String):
+    flags = AttributeFlags(name="scenario158-user-email")
+
+
+class ScenarioUserName(String):
+    flags = AttributeFlags(name="scenario158-user-name")
+
+
+class ScenarioTeamSlug(String):
+    flags = AttributeFlags(name="scenario158-team-slug")
+
+
+class ScenarioMembershipRole(String):
+    flags = AttributeFlags(name="scenario158-membership-role")
+
+
+class ScenarioUser(Entity):
+    flags = TypeFlags(name="scenario158-user")
+    email: ScenarioUserEmail = Flag(Key)
+    name: ScenarioUserName
+
+
+class ScenarioTeam(Entity):
+    flags = TypeFlags(name="scenario158-team")
+    slug: ScenarioTeamSlug = Flag(Key)
+
+
+class ScenarioMembership(Relation):
+    flags = TypeFlags(name="scenario158-membership")
+    user: Role[ScenarioUser] = Role("member", ScenarioUser)
+    team: Role[ScenarioTeam] = Role("team", ScenarioTeam)
+    role: ScenarioMembershipRole
+"""
+
+
+def _build_teams_payload() -> str:
+    lines: list[str] = []
+    for index in range(_TEAM_COUNT):
+        slug = f"{_TEAM_SLUG_PREFIX}{index:02d}"
+        name = f"Scenario Team {index:02d}"
+        lines.append("[[teams]]")
+        lines.append(f'slug = "{slug}"')
+        lines.append(f'name = "{name}"')
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _build_user_payload() -> list[dict[str, str]]:
+    return [
+        {
+            "email": f"{_LOADED_USER_EMAIL_PREFIX}{index:04d}@scenario-local.test",
+            "name": f"Loaded User {index:04d}",
+            "team_slug": f"{_TEAM_SLUG_PREFIX}{index % _TEAM_COUNT:02d}",
+            "role": "member",
+        }
+        for index in range(_USER_COUNT)
+    ]
+
+
+def _clear_scenario_modules() -> None:
+    for module_name in list(sys.modules):
+        if module_name == _PACKAGE_NAME or module_name.startswith(f"{_PACKAGE_NAME}."):
+            del sys.modules[module_name]
+
+
+def _write_scenario_package(tmp_path: Path) -> None:
+    package_dir = tmp_path / _PACKAGE_NAME
+    package_dir.mkdir(exist_ok=True)
+    (package_dir / "__init__.py").write_text("")
+    (package_dir / "models.py").write_text(_scenario_package_source())
+
+
+def _write_data_resources(migrations_dir: Path) -> tuple[Path, Path]:
+    resources_dir = migrations_dir / "data"
+    resources_dir.mkdir(parents=True, exist_ok=True)
+
+    teams_toml = resources_dir / "teams.toml"
+    teams_toml.write_text(_build_teams_payload())
+
+    users_json = resources_dir / "users.json"
+    users_json.write_text(json.dumps(_build_user_payload(), indent=2))
+
+    return teams_toml, users_json
+
+
+def _load_models(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    _clear_scenario_modules()
+    monkeypatch.syspath_prepend(str(tmp_path))
+    return importlib.import_module(f"{_PACKAGE_NAME}.models")
+
+
+def _migrations_dir(tmp_path: Path) -> Path:
+    return tmp_path / _MIGRATIONS_DIR_NAME
+
+
+def _ensure_initial_schema(
+    clean_db: Database,
+    models: Any,
+    migrations_dir: Path,
+) -> tuple[MigrationExecutor, str]:
+    generator = MigrationGenerator(clean_db, migrations_dir)
+    executor = MigrationExecutor(clean_db, migrations_dir)
+
+    initial_path = generator.generate(
+        models=[models.ScenarioUser, models.ScenarioTeam, models.ScenarioMembership],
+        name="initial",
+    )
+    assert initial_path is not None, "initial migration must be generated"
+
+    result = executor.migrate()
+    assert len(result) == 1
+    assert result[0].success, f"initial migration failed: {result[0].error}"
+
+    return executor, initial_path.stem
+
+
+def _seed_user(clean_db: Database, models: Any) -> None:
+    models.ScenarioUser.manager(clean_db).insert(
+        models.ScenarioUser(
+            email=models.ScenarioUserEmail(_SEEDED_USER_EMAIL),
+            name=models.ScenarioUserName(_SEEDED_USER_NAME),
+        )
+    )
+
+
+def _write_load_users_migration(migrations_dir: Path, dependency_name: str) -> None:
+    migration_path = migrations_dir / "0002_load_users.py"
+
+    migration_path.write_text(
+        f"""\
+from pathlib import Path
+from typing import ClassVar
+
+import json
+import tomllib
+
+from scenario_app.models import (
+    ScenarioMembership,
+    ScenarioMembershipRole,
+    ScenarioTeam,
+    ScenarioTeamSlug,
+    ScenarioUser,
+    ScenarioUserEmail,
+    ScenarioUserName,
+)
+from type_bridge.migration import Migration
+from type_bridge.migration import operations as ops
+from type_bridge.migration.operations import Operation
+
+_SEEDED_EMAIL = {_SEEDED_USER_EMAIL!r}
+_LOADED_EMAIL_PREFIX = {_LOADED_USER_EMAIL_PREFIX!r}
+_TEAM_SLUG_PREFIX = {_TEAM_SLUG_PREFIX!r}
+
+
+def _load_teams(migration_path: Path) -> list[dict[str, str]]:
+    path = migration_path / "data" / "teams.toml"
+    return tomllib.loads(path.read_text())["teams"]
+
+
+def _load_users(migration_path: Path) -> list[dict[str, str]]:
+    with (migration_path / "data" / "users.json").open("r", encoding="utf-8") as fp:
+        return json.load(fp)
+
+
+def forwards(db: object) -> None:
+    migration_dir = Path(__file__).parent
+    teams = _load_teams(migration_dir)
+    users = _load_users(migration_dir)
+
+    seeded_users = ScenarioUser.manager(db).filter(email=_SEEDED_EMAIL).execute()
+    if len(seeded_users) != 1:
+        raise RuntimeError(
+            "expected seeded user " + str(_SEEDED_EMAIL) + "; got " + str(len(seeded_users))
+        )
+    seeded = seeded_users[0]
+
+    # Query while migrating through the public manager API.
+    _ = ScenarioUser.manager(db).filter().limit(5).execute()
+    _ = ScenarioUser.manager(db).filter().count()
+
+    team_objects = [
+        ScenarioTeam(
+            slug=ScenarioTeamSlug(team_row["slug"]),
+        )
+        for team_row in teams
+    ]
+    ScenarioTeam.manager(db).insert_many(team_objects)
+    team_by_slug = dict(
+        (team_row["slug"], model)
+        for team_row, model in zip(teams, team_objects)
+    )
+
+    user_objects = [
+        ScenarioUser(
+            email=ScenarioUserEmail(user["email"]),
+            name=ScenarioUserName(user["name"]),
+        )
+        for user in users
+    ]
+    ScenarioUser.manager(db).insert_many(user_objects)
+
+    memberships = [
+        ScenarioMembership(
+            user=user,
+            team=team_by_slug[user_row["team_slug"]],
+            role=ScenarioMembershipRole(user_row["role"]),
+        )
+        for user, user_row in zip(user_objects, users)
+    ]
+    memberships.append(
+        ScenarioMembership(
+            user=seeded,
+            team=team_by_slug[teams[0]["slug"]],
+            role=ScenarioMembershipRole("owner"),
+        )
+    )
+    ScenarioMembership.manager(db).insert_many(memberships)
+
+    _ = ScenarioMembership.manager(db).filter(user=seeded).execute()
+
+
+def reverse(db: object) -> None:
+    seeded = ScenarioUser.manager(db).filter(email=_SEEDED_EMAIL).first()
+    if seeded is not None:
+        ScenarioMembership.manager(db).filter(user=seeded).delete()
+
+    loaded_users = ScenarioUser.manager(db).filter(email__startswith=_LOADED_EMAIL_PREFIX).execute()
+    for loaded_user in loaded_users:
+        ScenarioMembership.manager(db).filter(user=loaded_user).delete()
+        ScenarioUser.manager(db).filter(email=loaded_user.email.value).delete()
+
+    ScenarioTeam.manager(db).filter(slug__startswith=_TEAM_SLUG_PREFIX).delete()
+
+
+class LoadUsersMigration(Migration):
+    dependencies: ClassVar[list[tuple[str, str]]] = [
+        ({migrations_dir.name!r}, {dependency_name!r}),
+    ]
+    operations: ClassVar[list[Operation]] = [
+        ops.RunPython(
+            forwards,
+            reverse=reverse,
+            description="load scenario users and memberships",
+            resources=["data/teams.toml", "data/users.json"],
+            import_checks=["json", "tomllib"],
+        )
+    ]
+"""
+    )
+
+
+def _write_failure_migration(migrations_dir: Path, dependency_name: str) -> None:
+    migration_path = migrations_dir / "0003_missing_resource.py"
+    migration_path.write_text(
+        f"""\
+from typing import ClassVar
+
+from scenario_app.models import ScenarioUser
+from type_bridge.migration import Migration
+from type_bridge.migration import operations as ops
+from type_bridge.migration.operations import Operation
+
+
+def forwards(db: object) -> None:
+    raise RuntimeError("migration should not execute")
+
+
+class MissingResourceMigration(Migration):
+    dependencies: ClassVar[list[tuple[str, str]]] = [
+        ({migrations_dir.name!r}, {dependency_name!r}),
+    ]
+    operations: ClassVar[list[Operation]] = [
+        ops.RunPython(
+            forwards,
+            description="missing-resource python migration",
+            resources=["data/missing_users.json"],
+        )
+    ]
+"""
+    )
+
+
+def _write_irreversible_migration(migrations_dir: Path, dependency_name: str) -> None:
+    migration_path = migrations_dir / "0004_irreversible.py"
+    migration_path.write_text(
+        f"""\
+from typing import ClassVar
+
+from type_bridge.migration import Migration
+from type_bridge.migration import operations as ops
+from type_bridge.migration.operations import Operation
+
+
+def forwards(db: object) -> None:
+    pass
+
+
+class IrreversibleMigration(Migration):
+    dependencies: ClassVar[list[tuple[str, str]]] = [
+        ({migrations_dir.name!r}, {dependency_name!r}),
+    ]
+    operations: ClassVar[list[Operation]] = [
+        ops.RunPython(
+            forwards,
+            description="irreversible python migration",
+        )
+    ]
+"""
+    )
+
+
+def _typedb_rows(db: Database, query: str) -> list[dict[str, object]]:
+    result = db.execute_query(query, transaction_type="read")
+    return list(result) if result else []
+
+
+def _count_rows(db: Database, query: str) -> int:
+    return len(_typedb_rows(db, query))
+
+
+@pytest.mark.integration
+@pytest.mark.order(420)
+def test_run_python_user_scenario_full_cycle(
+    clean_db, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_scenario_package(tmp_path)
+    models = _load_models(monkeypatch, tmp_path)
+    migrations_dir = _migrations_dir(tmp_path)
+
+    executor, initial_name = _ensure_initial_schema(clean_db, models, migrations_dir)
+
+    _seed_user(clean_db, models)
+    _write_data_resources(migrations_dir)
+    _write_load_users_migration(migrations_dir, initial_name)
+
+    # sqlmigrate preview shows RunPython comments and resources.
+    preview = executor.sqlmigrate("0002_load_users")
+    assert "RunPython: load scenario users and memberships" in preview
+    assert "resources: data/teams.toml, data/users.json" in preview
+    assert "import checks: json, tomllib" in preview
+    assert "RunPython reverse: load scenario users and memberships" in executor.sqlmigrate(
+        "0002_load_users",
+        reverse=True,
+    )
+
+    results = executor.migrate()
+    assert len(results) == 1
+    assert results[0].name == "0002_load_users"
+    assert results[0].success
+
+    # Assertions from the manager API.
+    assert len(models.ScenarioUser.manager(clean_db).all()) == 1 + _USER_COUNT
+    assert len(models.ScenarioTeam.manager(clean_db).all()) == _TEAM_COUNT
+    assert models.ScenarioMembership.manager(clean_db).count() == 1 + _USER_COUNT
+
+    seeded_user = models.ScenarioUser.manager(clean_db).filter(email=_SEEDED_USER_EMAIL).first()
+    assert seeded_user is not None
+    assert models.ScenarioMembership.manager(clean_db).filter(user=seeded_user).count() == 1
+
+    # Assertions from TypeDB query execution.
+    assert (
+        _count_rows(
+            clean_db,
+            """\
+match
+  $u isa scenario158-user,
+    has scenario158-user-email $e;
+fetch { "e": $e };
+""",
+        )
+        == 1 + _USER_COUNT
+    )
+    assert (
+        _count_rows(
+            clean_db,
+            """\
+match
+  $t isa scenario158-team,
+    has scenario158-team-slug $slug;
+fetch { "slug": $slug };
+""",
+        )
+        == _TEAM_COUNT
+    )
+    assert (
+        _count_rows(
+            clean_db,
+            """\
+match
+  $m isa scenario158-membership,
+    has scenario158-membership-role $role;
+fetch { "role": $role };
+""",
+        )
+        == 1 + _USER_COUNT
+    )
+
+    state = MigrationStateManager(clean_db).load_state()
+    assert state.is_applied(_MIGRATIONS_DIR_NAME, "0002_load_users")
+
+    run_rows = MigrationStateManager(clean_db).load_runs()
+    run_rows_for_load = [
+        row
+        for row in run_rows
+        if row.app_label == _MIGRATIONS_DIR_NAME
+        and row.name == "0002_load_users"
+        and row.direction == "apply"
+    ]
+    succeeded_run_rows = [row for row in run_rows_for_load if row.status == "succeeded"]
+    assert succeeded_run_rows
+    run_row = succeeded_run_rows[-1]
+    assert run_row.name == "0002_load_users"
+    assert run_row.app_label == _MIGRATIONS_DIR_NAME
+    assert run_row.direction == "apply"
+    assert run_row.status == "succeeded"
+    assert run_row.run_id
+    assert run_row.checksum
+    assert run_row.started_at
+    assert run_row.finished_at
+    assert run_row.error is None
+
+    # Rollback restores the pre-migration state.
+    rollback = executor.migrate(target=initial_name)
+    assert len(rollback) == 1
+    assert rollback[0].success
+    assert rollback[0].action == "rolled_back"
+    assert (
+        not MigrationStateManager(clean_db)
+        .load_state()
+        .is_applied(
+            _MIGRATIONS_DIR_NAME,
+            "0002_load_users",
+        )
+    )
+
+    assert len(models.ScenarioUser.manager(clean_db).all()) == 1
+    assert len(models.ScenarioTeam.manager(clean_db).all()) == 0
+    assert models.ScenarioMembership.manager(clean_db).count() == 0
+
+    # Re-apply after rollback does not duplicate loaded entities.
+    reapply = executor.migrate()
+    assert len(reapply) == 1
+    assert reapply[0].success
+    assert len(models.ScenarioUser.manager(clean_db).all()) == 1 + _USER_COUNT
+    assert len(models.ScenarioTeam.manager(clean_db).all()) == _TEAM_COUNT
+    assert models.ScenarioMembership.manager(clean_db).count() == 1 + _USER_COUNT
+
+
+@pytest.mark.integration
+@pytest.mark.order(421)
+def test_run_python_missing_resource_does_not_mutate(
+    clean_db, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_scenario_package(tmp_path)
+    models = _load_models(monkeypatch, tmp_path)
+    migrations_dir = _migrations_dir(tmp_path)
+
+    executor, initial_name = _ensure_initial_schema(clean_db, models, migrations_dir)
+    _seed_user(clean_db, models)
+
+    before_rows = _count_rows(
+        clean_db,
+        """\
+match
+  $u isa scenario158-user,
+    has scenario158-user-email $e;
+fetch { "e": $e };
+""",
+    )
+
+    _write_failure_migration(migrations_dir, initial_name)
+
+    with pytest.raises(MigrationError, match="missing"):
+        executor.migrate()
+
+    state = MigrationStateManager(clean_db).load_state()
+    assert not state.is_applied(_MIGRATIONS_DIR_NAME, "0003_missing_resource")
+    assert not any(
+        row.name == "0003_missing_resource" for row in MigrationStateManager(clean_db).load_runs()
+    )
+    assert (
+        _count_rows(
+            clean_db,
+            """\
+match
+  $u isa scenario158-user,
+    has scenario158-user-email $e;
+fetch { "e": $e };
+""",
+        )
+        == before_rows
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.order(422)
+def test_sqlmigrate_irreversible_preview(
+    clean_db, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_scenario_package(tmp_path)
+    models = _load_models(monkeypatch, tmp_path)
+    migrations_dir = _migrations_dir(tmp_path)
+
+    executor, initial_name = _ensure_initial_schema(clean_db, models, migrations_dir)
+    _write_irreversible_migration(migrations_dir, initial_name)
+
+    with pytest.raises(MigrationError, match="not reversible"):
+        executor.sqlmigrate("0004_irreversible", reverse=True)

--- a/tests/integration/migration/test_snapshot_bindings.py
+++ b/tests/integration/migration/test_snapshot_bindings.py
@@ -1,0 +1,241 @@
+"""Live integration tests for snapshot bindings and temporal migrations."""
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+from type_bridge.migration import MigrationExecutor, MigrationGenerator
+from type_bridge.migration.loader import MigrationLoadError
+from type_bridge.session import Database
+
+_PACKAGE_NAME = "integration_scenario_app"
+_MIGRATIONS_DIR_NAME = "integration_scenario_migrations"
+
+
+def _clear_modules() -> None:
+    for module_name in list(sys.modules):
+        if module_name == _PACKAGE_NAME or module_name.startswith(f"{_PACKAGE_NAME}."):
+            del sys.modules[module_name]
+        if module_name == _MIGRATIONS_DIR_NAME or module_name.startswith(
+            f"{_MIGRATIONS_DIR_NAME}."
+        ):
+            del sys.modules[module_name]
+
+
+@pytest.mark.integration
+def test_temporal_data_migration_scenario(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    clean_db: Database,
+) -> None:
+    _clear_modules()
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    migrations_dir = tmp_path / _MIGRATIONS_DIR_NAME
+    migrations_dir.mkdir()
+
+    # Step 1: Pre-state models
+    # User owns email (key) and name
+    pre_source = """\
+from type_bridge import AttributeFlags, Entity, Flag, Key, String, TypeFlags
+
+class UserEmail(String):
+    flags = AttributeFlags(name="email")
+
+class UserName(String):
+    flags = AttributeFlags(name="name")
+
+class User(Entity):
+    flags = TypeFlags(name="user")
+    email: UserEmail = Flag(Key)
+    name: UserName
+"""
+    app_dir = tmp_path / _PACKAGE_NAME
+    app_dir.mkdir()
+    (app_dir / "__init__.py").write_text("")
+    (app_dir / "models.py").write_text(pre_source)
+
+    # Generate and apply migration 1 (Pre-state)
+    models_v1 = importlib.import_module(f"{_PACKAGE_NAME}.models")
+    generator = MigrationGenerator(clean_db, migrations_dir)
+    executor = MigrationExecutor(clean_db, migrations_dir)
+
+    initial_path = generator.generate(
+        models=[models_v1.User],
+        name="initial",
+    )
+    assert initial_path is not None
+    result = executor.migrate()
+    assert len(result) == 1
+    assert result[0].success
+
+    # Seed pre-state data
+    models_v1.User.manager(clean_db).insert(
+        models_v1.User(
+            email=models_v1.UserEmail("alice@test.com"),
+            name=models_v1.UserName("Alice Smith"),
+        )
+    )
+
+    # Step 2: Transition state (User owns email, name, full_name, user_id)
+    transition_source = """\
+from type_bridge import AttributeFlags, Entity, Flag, Key, String, TypeFlags
+
+class UserEmail(String):
+    flags = AttributeFlags(name="email")
+
+class UserName(String):
+    flags = AttributeFlags(name="name")
+
+class UserFullName(String):
+    flags = AttributeFlags(name="full_name")
+
+class UserId(String):
+    flags = AttributeFlags(name="user_id")
+
+class User(Entity):
+    flags = TypeFlags(name="user")
+    email: UserEmail = Flag(Key)
+    name: UserName | None = None
+    full_name: UserFullName | None = None
+    user_id: UserId | None = None
+"""
+    _clear_modules()
+    (app_dir / "models.py").write_text(transition_source)
+    models_v2 = importlib.import_module(f"{_PACKAGE_NAME}.models")
+
+    # Generate and apply migration 2 (Transition State)
+    # The generator will write snapshot v0002 first, then render operations
+    generator = MigrationGenerator(clean_db, migrations_dir)
+    transition_path = generator.generate(
+        models=[models_v2.User],
+        name="transition",
+    )
+    assert transition_path is not None
+
+    # Step 3: Inject custom Python backfill logic in migration 2
+    # We want to edit migration 2 to run a Python data migration that reads from v0001.User and writes to v0002.User
+    migration_2_content = transition_path.read_text()
+
+    # We want to replace operations = [...] with a RunPython backfill
+    snapshot_imports = f"""\
+from {_MIGRATIONS_DIR_NAME}.snapshots.v0001 import User as OldUser
+from {_MIGRATIONS_DIR_NAME}.snapshots.v0002 import Email, FullName, Name, User as NewUser, UserId
+"""
+
+    backfill_code = """
+def backfill_data(db):
+    for old_user in OldUser.manager(db).filter().execute():
+        # Get matching NewUser instance to write the values
+        NewUser.manager(db).update(
+            NewUser(
+                email=Email(str(old_user.email)),
+                name=Name(str(old_user.name)),
+                full_name=FullName(str(old_user.name)),
+                user_id=UserId("ID-" + str(old_user.email)),
+            )
+        )
+
+    # Delete the name attribute from all user instances so they can be contracted
+    db.execute_query(
+        "match $u isa user, has name $n; delete $n of $u;",
+        transaction_type="write",
+    )
+"""
+    # Find operations block in migration_2_content
+    op_start = migration_2_content.find("    operations: ClassVar[list[Operation]] = [")
+    op_end = migration_2_content.find("    ]", op_start) + 5
+    original_ops_decl = migration_2_content[op_start:op_end]
+
+    # Insert backfill_data function and add ops.RunPython to operations
+    modified_content = migration_2_content.replace(
+        "class TransitionMigration(Migration):",
+        backfill_code + "\nclass TransitionMigration(Migration):\n",
+    ).replace(
+        original_ops_decl,
+        original_ops_decl.replace("    ]", "        ops.RunPython(backfill_data),\n    ]"),
+    )
+
+    # Add RunPython import if not present
+    modified_content = modified_content.replace(
+        "from type_bridge.migration import operations as ops, ref",
+        "from type_bridge.migration import operations as ops, ref\n" + snapshot_imports,
+    )
+    transition_path.write_text(modified_content)
+
+    with pytest.raises(MigrationLoadError, match="sidecar drift"):
+        MigrationExecutor(clean_db, migrations_dir).migrate()
+
+    # This hand-authored Python runtime migration cannot use the stale generated
+    # sidecar. Deleting it exercises the trusted Python migration path after the
+    # drift gate above proves stale sidecars do not execute.
+    sidecar_path = transition_path.with_suffix(".json")
+    if sidecar_path.exists():
+        sidecar_path.unlink()
+
+    # Now apply the transition migration
+    executor = MigrationExecutor(clean_db, migrations_dir)
+    result = executor.migrate()
+    assert len(result) == 1
+    assert result[0].success
+
+    # Verify that Alice Smith has user_id="ID-alice@test.com" and full_name="Alice Smith" in the database
+    # Let's query using the transition model User
+    users = models_v2.User.manager(clean_db).filter(email="alice@test.com").execute()
+    assert len(users) == 1
+    assert str(users[0].full_name) == "Alice Smith"
+    assert str(users[0].user_id) == "ID-alice@test.com"
+
+    # Step 4: Contract state (User owns email, full_name, user_id; name is removed)
+    contract_source = """\
+from type_bridge import AttributeFlags, Entity, Flag, Key, String, TypeFlags
+
+class UserEmail(String):
+    flags = AttributeFlags(name="email")
+
+class UserFullName(String):
+    flags = AttributeFlags(name="full_name")
+
+class UserId(String):
+    flags = AttributeFlags(name="user_id")
+
+class User(Entity):
+    flags = TypeFlags(name="user")
+    email: UserEmail = Flag(Key)
+    full_name: UserFullName
+    user_id: UserId
+"""
+    _clear_modules()
+    (app_dir / "models.py").write_text(contract_source)
+    models_v3 = importlib.import_module(f"{_PACKAGE_NAME}.models")
+
+    # Generate and apply migration 3 (Contract State)
+    generator = MigrationGenerator(clean_db, migrations_dir)
+    contract_path = generator.generate(
+        models=[models_v3.User],
+        name="contract",
+    )
+    assert contract_path is not None
+
+    # Apply contract migration
+    executor = MigrationExecutor(clean_db, migrations_dir)
+    result = executor.migrate()
+    assert len(result) == 1
+    assert result[0].success
+
+    # Step 5: Verify that querying old field fails
+    # Active model User (v3) no longer owns name
+    assert not hasattr(models_v3.User, "name")
+
+    # Trying to query using old snapshot v0001 (which expects UserName to be owned by User)
+    # should fail at the TypeDB schema level or because it doesn't exist
+    from type_bridge.migration.snapshots import get_snapshot_class_map
+
+    class_map_v1 = get_snapshot_class_map(migrations_dir, "v0001")
+    OldUser = class_map_v1["user"]
+
+    # This should fail because the live DB schema no longer has "name" owned by "user"
+    with pytest.raises(Exception):
+        OldUser.manager(clean_db).filter(name="Alice Smith").execute()

--- a/tests/integration/migration/test_state.py
+++ b/tests/integration/migration/test_state.py
@@ -13,6 +13,8 @@ Lifecycle covered:
 - record_unapplied removes the record;
 - state is durable in TypeDB across a fresh ``MigrationStateManager`` (reloaded
   from the database, not a process-local cache).
+- migration run-log rows are durable and are updated from started to terminal
+  status by run_id.
 """
 
 # pyright: reportMissingImports=false
@@ -112,3 +114,32 @@ def test_state_durable_across_fresh_manager(clean_db):
     records = state.get_all_for_app("orders")
     assert {r.name for r in records} == {"0001_initial", "0002_add_index"}
     assert {r.checksum for r in records} == {"sum-1", "sum-2"}
+
+
+@pytest.mark.integration
+@pytest.mark.order(325)
+def test_run_log_records_start_and_finish(clean_db):
+    """Run-log rows persist execution attempts separately from applied state."""
+    manager = MigrationStateManager(clean_db)
+    manager.ensure_schema()
+
+    started = manager.record_run_started(
+        "orders",
+        "0003_backfill",
+        "sum-3",
+        "apply",
+    )
+    finished = manager.record_run_finished(started, "failed", "boom")
+
+    runs = MigrationStateManager(clean_db).load_runs()
+
+    assert len(runs) == 1
+    assert runs[0].run_id == started.run_id == finished.run_id
+    assert runs[0].app_label == "orders"
+    assert runs[0].name == "0003_backfill"
+    assert runs[0].checksum == "sum-3"
+    assert runs[0].direction == "apply"
+    assert runs[0].status == "failed"
+    assert runs[0].started_at
+    assert runs[0].finished_at
+    assert runs[0].error == "boom"

--- a/tests/unit/migration/test_file_loader.py
+++ b/tests/unit/migration/test_file_loader.py
@@ -3,7 +3,8 @@
 
 Covers:
 - Generator writes a JSON sidecar beside the .py
-- Sidecar loaded via load_migration_sidecar matches lowering the .py (anti-drift)
+- Sidecar-backed .py files are not executed during discovery
+- Sidecar checksum drift is rejected before Python import
 - Legacy .py with no sidecar → execution_spec is None, lowering falls back
 - .py still contains ops.RunTypeQL text after generation
 """
@@ -16,7 +17,7 @@ import pytest
 
 from type_bridge import _rust_runtime
 from type_bridge.migration._lower import lower_execution_migration
-from type_bridge.migration.loader import LoadedMigration, MigrationLoader
+from type_bridge.migration.loader import MigrationLoader, MigrationLoadError
 
 # ---------------------------------------------------------------------------
 # Shared fixture: require the Rust extension for all tests in this module.
@@ -157,17 +158,19 @@ def test_discover_populates_execution_spec_from_sidecar(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Test 4: sidecar path = lower_execution_migration (anti-drift equivalence)
+# Test 4: sidecar-backed discovery does not execute .py
 # ---------------------------------------------------------------------------
 
 
-def test_sidecar_spec_equals_lowered_py_spec(tmp_path: Path) -> None:
-    """The sidecar-loaded spec must be byte-identical to what lowering the .py produces.
-
-    This is the anti-drift equivalence: both paths derive from the same op list,
-    so the normalized execution MigrationSpec must agree.
-    """
-    py_path = _write_py(tmp_path, "0001_auto.py")
+def test_sidecar_backed_discovery_skips_python_execution(tmp_path: Path) -> None:
+    """A valid sidecar lets discovery succeed even if .py imports are stale."""
+    py_path = _write_py(
+        tmp_path,
+        "0001_auto.py",
+        """
+import generated_models_that_no_longer_exists
+""".lstrip(),
+    )
     _build_and_write_sidecar(
         py_path,
         forward="define attribute loader-name, value string;",
@@ -180,22 +183,29 @@ def test_sidecar_spec_equals_lowered_py_spec(tmp_path: Path) -> None:
     migrations = MigrationLoader(tmp_path).discover()
     loaded = migrations[0]
 
-    # Sidecar path: lower_execution_migration returns the normalized sidecar spec.
-    sidecar_spec = lower_execution_migration(loaded)
+    assert loaded.execution_spec is not None
+    assert loaded.migration.operations == []
+    assert lower_execution_migration(loaded)["operations"][0]["kind"] == "run_typeql"
 
-    # .py path: load the same migration without the sidecar (clear execution_spec)
-    # and derive the spec via the to_typeql() fallback.
-    no_sidecar = LoadedMigration(
-        migration=loaded.migration,
-        path=loaded.path,
-        checksum=loaded.checksum,
-        execution_spec=None,
-    )
-    py_derived_spec = lower_execution_migration(no_sidecar)
 
-    assert sidecar_spec == py_derived_spec, (
-        "Sidecar-loaded spec must equal the spec derived from lowering the .py"
+def test_sidecar_drift_rejected_before_python_execution(tmp_path: Path) -> None:
+    py_path = _write_py(tmp_path, "0001_auto.py")
+    _build_and_write_sidecar(
+        py_path,
+        forward="define attribute loader-name, value string;",
+        reverse="undefine attribute loader-name;",
+        app_label=tmp_path.name,
+        migration_name="0001_auto",
+        dependencies=[],
     )
+    py_path.write_text(
+        """
+import generated_models_that_no_longer_exists
+""".lstrip()
+    )
+
+    with pytest.raises(MigrationLoadError, match="sidecar drift"):
+        MigrationLoader(tmp_path).discover()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/migration/test_lowering.py
+++ b/tests/unit/migration/test_lowering.py
@@ -37,6 +37,8 @@ from type_bridge.migration.introspection import (
     IntrospectedAttribute,
     IntrospectedEntity,
     IntrospectedOwnership,
+    IntrospectedRelation,
+    IntrospectedRole,
     IntrospectedSchema,
 )
 from type_bridge.migration.loader import LoadedMigration, MigrationLoader
@@ -182,9 +184,12 @@ def test_generator_renders_typed_operation_source() -> None:
         ]
     )
 
-    assert "ops.AddAttribute(LowerAge)" in rendered
-    assert "ops.AddEntity(LowerPerson)" in rendered
-    assert "ops.AddOwnership(LowerPerson, LowerAge, optional=True)" in rendered
+    assert "ops.AddAttribute(ref.attribute('lower-age'))" in rendered
+    assert "ops.AddEntity(ref.entity('lower-person'))" in rendered
+    assert (
+        "ops.AddOwnership(ref.entity('lower-person'), ref.attribute('lower-age'), optional=True)"
+        in rendered
+    )
     assert "ops.RunTypeQL(" in rendered
 
 
@@ -222,7 +227,7 @@ def test_generator_sidecar_preserves_typed_operation_specs(tmp_path: Path) -> No
     assert sidecar["operations"][2]["owner_type"] == "lower-person"
 
 
-def test_bindgen_package_can_render_importable_typed_migration(tmp_path: Path) -> None:
+def test_bindgen_package_renders_migration_refs_without_model_imports(tmp_path: Path) -> None:
     schema_path = tmp_path / "schema.toml"
     schema_path.write_text(
         """
@@ -256,6 +261,8 @@ owns = [
         operations = [ops.AddAttribute(email), ops.AddOwnership(customer, email, optional=True)]
         operations_code = generator._render_operations(operations)
         imports_code = generator._generate_operations_imports(operations)
+        assert "generated_models" not in imports_code
+        assert "ref" in imports_code
         migrations_dir = tmp_path / "migrations"
         migrations_dir.mkdir()
         migration_file = migrations_dir / "0001_add_email.py"
@@ -343,7 +350,51 @@ owns = [
 
     assert add_ownership.attribute.get_attribute_name() == "email"
     assert add_ownership.optional is True
-    assert "ops.AddOwnership(Customer, Email, optional=True)" in rendered
+    assert (
+        "ops.AddOwnership(ref.entity('customer'), ref.attribute('email'), optional=True)"
+        in rendered
+    )
+
+
+def test_generator_emits_ref_based_top_level_removals() -> None:
+    db_schema = IntrospectedSchema(
+        entities={"removed-user": IntrospectedEntity(name="removed-user")},
+        relations={
+            "removed-membership": IntrospectedRelation(
+                name="removed-membership",
+                roles={
+                    "member": IntrospectedRole(
+                        name="member",
+                        player_types=["removed-user"],
+                    )
+                },
+            )
+        },
+        attributes={
+            "removed-email": IntrospectedAttribute(
+                name="removed-email",
+                value_type="string",
+            )
+        },
+        ownerships=[
+            IntrospectedOwnership(
+                owner_name="removed-user",
+                attribute_name="removed-email",
+            )
+        ],
+    )
+    target = SchemaInfo()
+
+    generator = MigrationGenerator.__new__(MigrationGenerator)
+    operations = generator._introspected_to_operations(db_schema, target)
+    rendered = generator._render_operations(operations)
+
+    assert any(isinstance(operation, ops.RemoveRelation) for operation in operations)
+    assert any(isinstance(operation, ops.RemoveEntity) for operation in operations)
+    assert any(isinstance(operation, ops.RemoveAttribute) for operation in operations)
+    assert "ops.RemoveRelation(ref.relation('removed-membership'))" in rendered
+    assert "ops.RemoveEntity(ref.entity('removed-user'))" in rendered
+    assert "ops.RemoveAttribute(ref.attribute('removed-email'))" in rendered
 
 
 def test_model_based_migration_lowers_to_define_schema() -> None:

--- a/tests/unit/migration/test_planner.py
+++ b/tests/unit/migration/test_planner.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 # pyright: reportMissingImports=false
 from pathlib import Path
-from typing import Any, ClassVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import pytest
 
@@ -24,9 +24,13 @@ from type_bridge.migration.executor import MigrationError, MigrationExecutor
 from type_bridge.migration.loader import LoadedMigration
 from type_bridge.migration.state import (
     MigrationRecord,
+    MigrationRunRecord,
     MigrationState,
     MigrationStateManager,
 )
+
+if TYPE_CHECKING:
+    from type_bridge.session import Database
 
 
 class PlannerName(String):
@@ -140,6 +144,7 @@ class _RecordingStateManager:
 
     def __init__(self) -> None:
         self.calls: list[tuple[str, str, str]] = []
+        self.run_calls: list[tuple[str, str, str, str, str]] = []
         self.raise_on_apply: str | None = None
 
     def load_state(self) -> MigrationState:
@@ -152,6 +157,52 @@ class _RecordingStateManager:
 
     def record_unapplied(self, app_label: str, name: str) -> None:
         self.calls.append(("unapplied", app_label, name))
+
+    def record_run_started(
+        self,
+        app_label: str,
+        name: str,
+        checksum: str,
+        direction: str,
+    ) -> MigrationRunRecord:
+        record = MigrationRunRecord(
+            run_id=f"run-{name}",
+            app_label=app_label,
+            name=name,
+            checksum=checksum,
+            direction=direction,
+            status="started",
+            started_at="2026-06-23T00:00:00.000000",
+        )
+        self.run_calls.append(("started", app_label, name, checksum, direction))
+        return record
+
+    def record_run_finished(
+        self,
+        record: MigrationRunRecord,
+        status: str,
+        error: str | None = None,
+    ) -> MigrationRunRecord:
+        self.run_calls.append((status, record.app_label, record.name, record.checksum, error or ""))
+        return MigrationRunRecord(
+            run_id=record.run_id,
+            app_label=record.app_label,
+            name=record.name,
+            checksum=record.checksum,
+            direction=record.direction,
+            status=status,
+            started_at=record.started_at,
+            finished_at="2026-06-23T00:00:01.000000",
+            error=error,
+        )
+
+
+class _RecordingDb:
+    def __init__(self) -> None:
+        self.queries: list[tuple[str, str]] = []
+
+    def execute_query(self, query: str, *, transaction_type: str) -> None:
+        self.queries.append((query, transaction_type))
 
 
 def _executor_with(
@@ -325,6 +376,389 @@ def test_record_applied_failure_surfaces_migration_error(monkeypatch: pytest.Mon
         executor.migrate()
 
 
+# ── RunPython execution path ─────────────────────────────────────────────────
+
+
+def test_run_python_migration_receives_db_and_records_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RunPython executes in Python with the executor DB and records state."""
+    dummy_db: Any = object()
+    calls: list[Any] = []
+
+    def forwards(db: Any) -> None:
+        calls.append(db)
+
+    class PythonMigration(Migration):
+        operations: ClassVar[list[ops.Operation]] = [ops.RunPython(forwards)]
+
+    state_manager = _RecordingStateManager()
+    loaded = [_loaded(PythonMigration(), "app", "0001_python", "csum-py")]
+    executor = MigrationExecutor(db=dummy_db, migrations_dir=Path("migrations"))
+    executor.state_manager = cast(MigrationStateManager, state_manager)
+    monkeypatch.setattr(executor.loader, "discover", lambda: loaded)
+
+    def fail_if_called(_db: object) -> object:
+        pytest.fail("RunPython migrations must not be sent to the Rust TypeQL runner")
+
+    monkeypatch.setattr("type_bridge._rust_runtime.migration_runner_for", fail_if_called)
+
+    results = executor.migrate()
+
+    assert calls == [dummy_db]
+    assert [(result.name, result.action, result.success) for result in results] == [
+        ("0001_python", "applied", True)
+    ]
+    assert state_manager.calls == [("applied", "app", "0001_python")]
+    assert state_manager.run_calls == [
+        ("started", "app", "0001_python", "csum-py", "apply"),
+        ("succeeded", "app", "0001_python", "csum-py", ""),
+    ]
+
+
+def test_run_python_rollback_uses_reverse_callable_and_records_unapplied(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def forwards(db: Any) -> None:
+        calls.append("forwards")
+
+    def backwards(db: Any) -> None:
+        calls.append("backwards")
+
+    class BaseMigration(Migration):
+        operations: ClassVar[list[ops.Operation]] = []
+
+    class PythonMigration(Migration):
+        dependencies: ClassVar[list[tuple[str, str]]] = [("app", "0001_base")]
+        operations: ClassVar[list[ops.Operation]] = [ops.RunPython(forwards, reverse=backwards)]
+
+    state_manager = _RecordingStateManager()
+    state_manager.load_state = lambda: MigrationState(
+        applied=[
+            MigrationRecord("app", "0001_base", "2026-01-01T00:00:00", "csum-base"),
+            MigrationRecord("app", "0002_python", "2026-01-01T00:00:00", "csum-py"),
+        ]
+    )
+    loaded = [
+        _loaded(BaseMigration(), "app", "0001_base", "csum-base"),
+        _loaded(PythonMigration(), "app", "0002_python", "csum-py"),
+    ]
+    executor = MigrationExecutor(db=cast("Database", object()), migrations_dir=Path("migrations"))
+    executor.state_manager = cast(MigrationStateManager, state_manager)
+    monkeypatch.setattr(executor.loader, "discover", lambda: loaded)
+
+    results = executor.migrate(target="0001_base")
+
+    assert calls == ["backwards"]
+    assert [(result.name, result.action, result.success) for result in results] == [
+        ("0002_python", "rolled_back", True)
+    ]
+    assert state_manager.calls == [("unapplied", "app", "0002_python")]
+    assert state_manager.run_calls == [
+        ("started", "app", "0002_python", "csum-py", "rollback"),
+        ("succeeded", "app", "0002_python", "csum-py", ""),
+    ]
+
+
+def test_run_python_preflights_declared_resource_and_import(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    resource_dir = tmp_path / "data"
+    resource_dir.mkdir()
+    (resource_dir / "users.json").write_text("[]")
+    calls: list[Any] = []
+
+    def forwards(db: Any) -> None:
+        calls.append(db)
+
+    class PythonMigration(Migration):
+        operations: ClassVar[list[ops.Operation]] = [
+            ops.RunPython(
+                forwards,
+                resources=["data/users.json"],
+                import_checks=["json"],
+            )
+        ]
+
+    state_manager = _RecordingStateManager()
+    migration = PythonMigration()
+    migration.app_label = "app"
+    migration.name = "0001_python"
+    loaded = [
+        LoadedMigration(
+            migration=migration,
+            path=tmp_path / "0001_python.py",
+            checksum="csum-py",
+        )
+    ]
+    executor = MigrationExecutor(db=cast("Database", object()), migrations_dir=tmp_path)
+    executor.state_manager = cast(MigrationStateManager, state_manager)
+    monkeypatch.setattr(executor.loader, "discover", lambda: loaded)
+
+    results = executor.migrate()
+
+    assert calls
+    assert [(result.name, result.action, result.success) for result in results] == [
+        ("0001_python", "applied", True)
+    ]
+    assert state_manager.calls == [("applied", "app", "0001_python")]
+
+
+def test_run_python_missing_resource_preflight_blocks_entire_plan(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    calls: list[str] = []
+
+    def first(db: Any) -> None:
+        calls.append("first")
+
+    def second(db: Any) -> None:
+        calls.append("second")
+
+    class FirstMigration(Migration):
+        operations: ClassVar[list[ops.Operation]] = [ops.RunPython(first)]
+
+    class SecondMigration(Migration):
+        dependencies: ClassVar[list[tuple[str, str]]] = [("app", "0001_first")]
+        operations: ClassVar[list[ops.Operation]] = [
+            ops.RunPython(second, resources=["data/missing.json"])
+        ]
+
+    state_manager = _RecordingStateManager()
+    loaded = [
+        LoadedMigration(
+            migration=FirstMigration(),
+            path=tmp_path / "0001_first.py",
+            checksum="csum-first",
+        ),
+        LoadedMigration(
+            migration=SecondMigration(),
+            path=tmp_path / "0002_second.py",
+            checksum="csum-second",
+        ),
+    ]
+    for item in loaded:
+        item.migration.app_label = "app"
+        item.migration.name = item.path.stem
+
+    executor = MigrationExecutor(db=cast("Database", object()), migrations_dir=tmp_path)
+    executor.state_manager = cast(MigrationStateManager, state_manager)
+    monkeypatch.setattr(executor.loader, "discover", lambda: loaded)
+
+    with pytest.raises(MigrationError, match="missing resource"):
+        executor.migrate()
+
+    assert calls == []
+    assert state_manager.calls == []
+
+
+def test_run_python_missing_import_check_fails_before_user_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def forwards(db: Any) -> None:
+        calls.append("forwards")
+
+    class PythonMigration(Migration):
+        operations: ClassVar[list[ops.Operation]] = [
+            ops.RunPython(
+                forwards,
+                import_checks=["type_bridge_missing_test_module"],
+            )
+        ]
+
+    state_manager = _RecordingStateManager()
+    loaded = [_loaded(PythonMigration(), "app", "0001_python", "csum-py")]
+    executor = MigrationExecutor(db=cast("Database", object()), migrations_dir=Path("migrations"))
+    executor.state_manager = cast(MigrationStateManager, state_manager)
+    monkeypatch.setattr(executor.loader, "discover", lambda: loaded)
+
+    with pytest.raises(MigrationError, match="failed import check"):
+        executor.migrate()
+
+    assert calls == []
+    assert state_manager.calls == []
+
+
+def test_run_python_history_uses_python_path_for_later_typeql_migration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def forwards(db: Any) -> None:
+        pass
+
+    class PythonMigration(Migration):
+        operations: ClassVar[list[ops.Operation]] = [ops.RunPython(forwards)]
+
+    class TypeQLMigration(Migration):
+        dependencies: ClassVar[list[tuple[str, str]]] = [("app", "0001_python")]
+        operations: ClassVar[list[ops.Operation]] = [
+            ops.RunTypeQL("define attribute later-typeql, value string;")
+        ]
+
+    state_manager = _RecordingStateManager()
+    state_manager.load_state = lambda: MigrationState(
+        applied=[
+            MigrationRecord("app", "0001_python", "2026-01-01T00:00:00", "csum-py"),
+        ]
+    )
+    loaded = [
+        _loaded(PythonMigration(), "app", "0001_python", "csum-py"),
+        _loaded(TypeQLMigration(), "app", "0002_typeql", "csum-typeql"),
+    ]
+    db = _RecordingDb()
+    executor = MigrationExecutor(db=cast("Database", db), migrations_dir=Path("migrations"))
+    executor.state_manager = cast(MigrationStateManager, state_manager)
+    monkeypatch.setattr(executor.loader, "discover", lambda: loaded)
+
+    runner = _ScriptedRunner(
+        [
+            {
+                "app_label": "app",
+                "name": "0002_typeql",
+                "action": "apply",
+                "success": True,
+                "error": None,
+            },
+        ]
+    )
+
+    monkeypatch.setattr("type_bridge._rust_runtime.migration_runner_for", lambda db: runner)
+
+    results = executor.migrate()
+
+    assert [(result.name, result.action, result.success) for result in results] == [
+        ("0002_typeql", "applied", True)
+    ]
+    assert len(runner.apply_calls) == 1
+    assert runner.apply_calls[0][2] == "0002_typeql"
+    assert len(runner.apply_calls[0][0]["migrations"]) == 2
+    assert db.queries == []
+    assert state_manager.calls == [("applied", "app", "0002_typeql")]
+
+
+def test_run_python_plan_executes_sidecar_migration_via_rust(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    calls: list[Any] = []
+
+    def forwards(db: Any) -> None:
+        calls.append("run_python")
+
+    class PythonMigration(Migration):
+        dependencies: ClassVar[list[tuple[str, str]]] = [("app", "0001_initial")]
+        operations: ClassVar[list[ops.Operation]] = [ops.RunPython(forwards)]
+
+    sidecar_migration = _loaded(
+        _runtypeql_migration("unused"), "app", "0001_initial", "csum-initial"
+    )
+    sidecar_migration.migration.name = "0001_initial"
+    sidecar_migration.migration.app_label = "app"
+    sidecar_migration.execution_spec = {
+        "app_label": "app",
+        "name": "0001_initial",
+        "dependencies": [],
+        "operations": [
+            {
+                "kind": "run_typeql",
+                "forward": "define attribute sidecar-attr, value string;",
+                "reverse": "undefine attribute sidecar-attr;",
+            }
+        ],
+        "checksum": "csum-initial",
+        "reversible": True,
+    }
+
+    runner = _ScriptedRunner(
+        [
+            {
+                "app_label": "app",
+                "name": "0001_initial",
+                "action": "apply",
+                "success": True,
+                "error": None,
+            },
+        ]
+    )
+    loaded = [
+        sidecar_migration,
+        _loaded(PythonMigration(), "app", "0002_python", "csum-python"),
+    ]
+
+    state_manager = _RecordingStateManager()
+    dummy_db: Any = object()
+    executor = MigrationExecutor(db=dummy_db, migrations_dir=Path("migrations"))
+    executor.state_manager = cast(MigrationStateManager, state_manager)
+    monkeypatch.setattr(executor.loader, "discover", lambda: loaded)
+    monkeypatch.setattr("type_bridge._rust_runtime.migration_runner_for", lambda db: runner)
+
+    results = executor.migrate()
+
+    assert calls == ["run_python"]
+    assert [(result.name, result.action, result.success) for result in results] == [
+        ("0001_initial", "applied", True),
+        ("0002_python", "applied", True),
+    ]
+    assert state_manager.calls == [
+        ("applied", "app", "0001_initial"),
+        ("applied", "app", "0002_python"),
+    ]
+    assert len(runner.apply_calls) == 1
+    assert runner.apply_calls[0][2] == "0001_initial"
+
+
+def test_run_python_sqlmigrate_preview_is_comment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def forwards(db: Any) -> None:
+        pass
+
+    def backwards(db: Any) -> None:
+        pass
+
+    class PythonMigration(Migration):
+        operations: ClassVar[list[ops.Operation]] = [
+            ops.RunPython(
+                forwards,
+                reverse=backwards,
+                resources=["data/users.json"],
+                import_checks=["json"],
+            )
+        ]
+
+    loaded = _loaded(PythonMigration(), "app", "0001_python", "csum-py")
+    executor = MigrationExecutor(db=cast("Database", object()), migrations_dir=Path("migrations"))
+    monkeypatch.setattr(executor.loader, "get_by_name", lambda name: loaded)
+
+    preview = executor.sqlmigrate("0001_python")
+    assert "RunPython" in preview
+    assert "data/users.json" in preview
+    assert "json" in preview
+    assert "RunPython reverse" in executor.sqlmigrate("0001_python", reverse=True)
+
+
+def test_run_python_sqlmigrate_reverse_requires_reverse_callable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def forwards(db: Any) -> None:
+        pass
+
+    class PythonMigration(Migration):
+        operations: ClassVar[list[ops.Operation]] = [ops.RunPython(forwards)]
+
+    loaded = _loaded(PythonMigration(), "app", "0001_python", "csum-py")
+    executor = MigrationExecutor(db=cast("Database", object()), migrations_dir=Path("migrations"))
+    monkeypatch.setattr(executor.loader, "get_by_name", lambda name: loaded)
+
+    with pytest.raises(MigrationError, match="not reversible"):
+        executor.sqlmigrate("0001_python", reverse=True)
+
+
 # ── sqlmigrate preview parity ────────────────────────────────────────────────
 
 
@@ -384,4 +818,4 @@ def test_sqlmigrate_preview_uses_rust_planner_for_typed_ops(
     assert "owns planner-name @key;" in forward
 
     reverse = executor.sqlmigrate("0001_typed", reverse=True)
-    assert reverse == "undefine\nentity planner-person;\n\nundefine\nattribute planner-name;"
+    assert reverse == "undefine\nplanner-person;\n\nundefine\nplanner-name;"

--- a/tests/unit/migration/test_snapshot_bindings.py
+++ b/tests/unit/migration/test_snapshot_bindings.py
@@ -1,0 +1,385 @@
+import sys
+import uuid
+from typing import Any, cast
+
+import pytest
+
+from type_bridge import Entity, TypeFlags
+from type_bridge.migration import operations as ops
+from type_bridge.migration.generator import MigrationGenerator
+from type_bridge.migration.snapshots import (
+    generate_snapshot,
+    get_snapshot_metadata,
+)
+from type_bridge.models.registry import ModelRegistry
+
+
+@pytest.fixture
+def temp_migrations_dir(tmp_path):
+    # Use a unique directory name for each test to avoid Python module import caching collisions
+    unique_name = f"migrations_{uuid.uuid4().hex[:8]}"
+    migrations_dir = tmp_path / unique_name
+    migrations_dir.mkdir()
+    yield migrations_dir
+    # Clean up sys.modules to avoid polluting other tests
+    for key in list(sys.modules.keys()):
+        if key == unique_name or key.startswith(f"{unique_name}."):
+            del sys.modules[key]
+
+
+def test_generate_snapshot_and_metadata(temp_migrations_dir):
+    schema_text = """
+    define
+    entity person,
+        owns name @key;
+    attribute name, value string;
+    """
+
+    snapshot_dir = generate_snapshot(
+        migrations_dir=temp_migrations_dir,
+        version="v0001",
+        migration_name="0001_initial",
+        schema_text=schema_text,
+    )
+
+    assert snapshot_dir.exists()
+    assert (snapshot_dir / "__init__.py").exists()
+    assert (snapshot_dir / "attributes.py").exists()
+    assert (snapshot_dir / "entities.py").exists()
+    assert (snapshot_dir / "registry.py").exists()
+    assert (snapshot_dir / "schema.tql").exists()
+    assert (snapshot_dir / "snapshot.json").exists()
+    init_text = (snapshot_dir / "__init__.py").read_text()
+    assert "from .attributes import Name" in init_text
+    assert "from .entities import Person" in init_text
+
+    metadata = get_snapshot_metadata(snapshot_dir)
+    assert metadata is not None
+    assert metadata["version"] == "v0001"
+    assert metadata["source_migration"] == "0001_initial"
+    assert "schema_hash" in metadata
+    assert "file_hashes" in metadata
+    assert "attributes.py" in metadata["file_hashes"]
+    assert "entities.py" in metadata["file_hashes"]
+
+    sys.path.insert(0, str(temp_migrations_dir.parent))
+    try:
+        import importlib
+
+        snapshot_mod = importlib.import_module(f"{temp_migrations_dir.name}.snapshots.v0001")
+        assert getattr(snapshot_mod, "Person").get_type_name() == "person"
+        assert getattr(snapshot_mod, "Name").get_attribute_name() == "name"
+    finally:
+        try:
+            sys.path.remove(str(temp_migrations_dir.parent))
+        except ValueError:
+            pass
+
+
+def test_generate_snapshot_rejects_stale_existing_snapshot(temp_migrations_dir):
+    schema_text_1 = """
+    define
+    entity person,
+        owns name @key;
+    attribute name, value string;
+    """
+    schema_text_2 = """
+    define
+    entity company,
+        owns name @key;
+    attribute name, value string;
+    """
+
+    generate_snapshot(
+        migrations_dir=temp_migrations_dir,
+        version="v0001",
+        migration_name="0001_initial",
+        schema_text=schema_text_1,
+    )
+
+    with pytest.raises(ValueError, match="schema hash mismatch"):
+        generate_snapshot(
+            migrations_dir=temp_migrations_dir,
+            version="v0001",
+            migration_name="0001_initial",
+            schema_text=schema_text_2,
+        )
+
+
+def test_registry_isolation(temp_migrations_dir, monkeypatch):
+    # Enable import by putting the temp directory in sys.path
+    monkeypatch.syspath_prepend(temp_migrations_dir.parent)
+
+    schema_text = """
+    define
+    entity isolating_person,
+        owns name @key;
+    attribute name, value string;
+    """
+
+    generate_snapshot(
+        migrations_dir=temp_migrations_dir,
+        version="v0001",
+        migration_name="0001_initial",
+        schema_text=schema_text,
+    )
+
+    # Clean resolution cache and registry to check isolation
+    ModelRegistry.clear()
+
+    # Import the snapshot class
+    import importlib
+
+    app_name = temp_migrations_dir.name
+    entities_mod = importlib.import_module(f"{app_name}.snapshots.v0001.entities")
+
+    # Check that it did NOT register in the global ModelRegistry
+    assert ModelRegistry.get("isolating_person") is None
+
+    # But it is a valid type-bridge Entity subclass
+    PersonCls = getattr(entities_mod, "IsolatingPerson")
+    assert issubclass(PersonCls, Entity)
+    assert PersonCls.get_type_name() == "isolating_person"
+
+
+def test_resolve_subclasses_isolated(temp_migrations_dir, monkeypatch):
+    monkeypatch.syspath_prepend(temp_migrations_dir.parent)
+
+    schema_text = """
+    define
+    entity employee sub person;
+    entity person,
+        owns name @key;
+    attribute name, value string;
+    """
+
+    generate_snapshot(
+        migrations_dir=temp_migrations_dir,
+        version="v0001",
+        migration_name="0001_initial",
+        schema_text=schema_text,
+    )
+
+    # Load snapshot classes
+    import importlib
+
+    app_name = temp_migrations_dir.name
+    entities_mod = importlib.import_module(f"{app_name}.snapshots.v0001.entities")
+    SnapshotPerson = getattr(entities_mod, "Person")
+    SnapshotEmployee = getattr(entities_mod, "Employee")
+
+    # Define an active app model class Person with the same TypeDB name but NOT a snapshot
+    class ActivePerson(Entity):
+        flags = TypeFlags(name="person")
+        name: str
+
+    class ActiveEmployee(ActivePerson):
+        flags = TypeFlags(name="employee")
+
+    # The active class register themselves in ModelRegistry
+    assert ModelRegistry.get("person") == ActivePerson
+    assert ModelRegistry.get("employee") == ActiveEmployee
+
+    # Polymorphic resolution from ActivePerson should only resolve ActiveEmployee, NOT SnapshotEmployee
+    res_active = ModelRegistry.resolve("employee", (ActivePerson,))
+    assert res_active == ActiveEmployee
+
+    # Polymorphic resolution from SnapshotPerson should only resolve SnapshotEmployee, NOT ActiveEmployee
+    res_snap = ModelRegistry.resolve("employee", (SnapshotPerson,))
+    assert res_snap == SnapshotEmployee
+
+
+def test_generator_uses_snapshots(temp_migrations_dir, monkeypatch):
+    monkeypatch.syspath_prepend(temp_migrations_dir.parent)
+
+    # Pre-populate snapshot v0001
+    schema_text_1 = """
+    define
+    entity person,
+        owns name @key;
+    attribute name, value string;
+    """
+    generate_snapshot(
+        migrations_dir=temp_migrations_dir,
+        version="v0001",
+        migration_name="0001_initial",
+        schema_text=schema_text_1,
+    )
+
+    # Target state has modified schema (added company, removed person)
+    schema_text_2 = """
+    define
+    entity company,
+        owns name @key;
+    attribute name, value string;
+    """
+    generate_snapshot(
+        migrations_dir=temp_migrations_dir,
+        version="v0002",
+        migration_name="0002_add_company",
+        schema_text=schema_text_2,
+    )
+
+    # Let's instantiate generator
+    class DummyDB:
+        def database_exists(self):
+            return True
+
+        def transaction(self, mode):
+            class DummyTx:
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *args):
+                    pass
+
+                def execute(self, q):
+                    return []
+
+                def commit(self):
+                    pass
+
+            return DummyTx()
+
+    generator = MigrationGenerator(cast(Any, DummyDB()), temp_migrations_dir)
+    generator._pre_version = "v0001"
+    generator._post_version = "v0002"
+
+    # Define operations representing the changes
+    from type_bridge.migration.ref import EntityRef
+
+    remove_person = ops.RemoveEntity(EntityRef("person"))
+    add_company = ops.AddEntity(EntityRef("company"))
+
+    # Render operations
+    generator._collect_imports_and_aliases([remove_person, add_company])
+    rendered_ops = generator._render_operations([remove_person, add_company])
+    rendered_imports = generator._generate_operations_imports([remove_person, add_company])
+
+    # Check generated imports
+    assert f"from {temp_migrations_dir.name}.snapshots.v0001 import Person" in rendered_imports
+    assert f"from {temp_migrations_dir.name}.snapshots.v0002 import Company" in rendered_imports
+
+    # Check rendered operations use class symbols
+    assert "ops.RemoveEntity(Person)" in rendered_ops
+    assert "ops.AddEntity(Company)" in rendered_ops
+
+
+def test_generator_aliases_colliding_symbols(temp_migrations_dir, monkeypatch):
+    monkeypatch.syspath_prepend(temp_migrations_dir.parent)
+
+    # Pre-populate v0001: person owns name
+    schema_text_1 = """
+    define
+    entity person,
+        owns name @key;
+    attribute name, value string;
+    """
+    generate_snapshot(
+        migrations_dir=temp_migrations_dir,
+        version="v0001",
+        migration_name="0001_initial",
+        schema_text=schema_text_1,
+    )
+
+    # Pre-populate v0002: person owns name and age
+    schema_text_2 = """
+    define
+    entity person,
+        owns name @key,
+        owns age;
+    attribute name, value string;
+    attribute age, value integer;
+    """
+    generate_snapshot(
+        migrations_dir=temp_migrations_dir,
+        version="v0002",
+        migration_name="0002_add_age",
+        schema_text=schema_text_2,
+    )
+
+    # Generator setup
+    class DummyDB:
+        def database_exists(self):
+            return True
+
+    generator = MigrationGenerator(cast(Any, DummyDB()), temp_migrations_dir)
+    generator._pre_version = "v0001"
+    generator._post_version = "v0002"
+
+    from type_bridge.migration.ref import AttributeRef, EntityRef
+
+    # We remove age from person of v0001, and add age to person of v0002
+    op_remove = ops.RemoveOwnership(EntityRef("person"), AttributeRef("name"))
+    op_add = ops.AddOwnership(EntityRef("person"), AttributeRef("age"))
+
+    # Render
+    generator._collect_imports_and_aliases([op_remove, op_add])
+    rendered_ops = generator._render_operations([op_remove, op_add])
+    rendered_imports = generator._generate_operations_imports([op_remove, op_add])
+
+    # v0001.Person should be aliased (e.g. PersonV0001) because both v0001 and v0002 define Person
+    # and v0002 is the latest version so it gets the unaliased Person symbol.
+    assert "Person as PersonV0001" in rendered_imports
+    assert f"from {temp_migrations_dir.name}.snapshots.v0002 import Age, Person" in rendered_imports
+    assert "ops.RemoveOwnership(PersonV0001" in rendered_ops
+    assert "ops.AddOwnership(Person" in rendered_ops
+
+
+def test_generator_aliases_copy_attribute_owner(temp_migrations_dir, monkeypatch):
+    monkeypatch.syspath_prepend(temp_migrations_dir.parent)
+
+    schema_text_1 = """
+    define
+    entity person,
+        owns name @key;
+    attribute name, value string;
+    """
+    schema_text_2 = """
+    define
+    entity person,
+        owns name @key,
+        owns age;
+    attribute name, value string;
+    attribute age, value integer;
+    """
+    generate_snapshot(
+        migrations_dir=temp_migrations_dir,
+        version="v0001",
+        migration_name="0001_initial",
+        schema_text=schema_text_1,
+    )
+    generate_snapshot(
+        migrations_dir=temp_migrations_dir,
+        version="v0002",
+        migration_name="0002_add_age",
+        schema_text=schema_text_2,
+    )
+
+    class DummyDB:
+        def database_exists(self):
+            return True
+
+    generator = MigrationGenerator(cast(Any, DummyDB()), temp_migrations_dir)
+    generator._pre_version = "v0001"
+    generator._post_version = "v0002"
+
+    from type_bridge.migration.ref import AttributeRef, EntityRef
+
+    operations = [
+        ops.CopyAttribute(owner=EntityRef("person"), source="name", dest="age"),
+        ops.AddOwnership(EntityRef("person"), AttributeRef("age")),
+    ]
+
+    generator._collect_imports_and_aliases(operations)
+    rendered_ops = generator._render_operations(operations)
+    rendered_imports = generator._generate_operations_imports(operations)
+
+    assert f"from {temp_migrations_dir.name}.snapshots.v0001 import Person as PersonV0001" in (
+        rendered_imports
+    )
+    assert f"from {temp_migrations_dir.name}.snapshots.v0002 import Age, Person" in (
+        rendered_imports
+    )
+    assert "ops.CopyAttribute(owner=PersonV0001" in rendered_ops
+    assert "ops.AddOwnership(Person, Age)" in rendered_ops

--- a/tests/unit/migration/test_validation.py
+++ b/tests/unit/migration/test_validation.py
@@ -104,6 +104,26 @@ def test_loader_validate_dependencies_preserves_list_of_strings(tmp_path: Path) 
     assert "depends on missing.0001_initial which does not exist" in errors[0]
 
 
+def test_loader_validate_dependencies_accepts_run_python(tmp_path: Path) -> None:
+    (tmp_path / "0001_python.py").write_text(
+        """
+from typing import ClassVar
+from type_bridge.migration import Migration, operations as ops
+from type_bridge.migration.operations import Operation
+
+
+def forwards(db):
+    pass
+
+
+class TestMigration(Migration):
+    operations: ClassVar[list[Operation]] = [ops.RunPython(forwards)]
+""".lstrip()
+    )
+
+    assert MigrationLoader(tmp_path).validate_dependencies() == []
+
+
 def test_valid_graph_with_applied_records_passes() -> None:
     graph = _graph(
         _spec("0001_initial", checksum="aaa"),

--- a/type-bridge-core/Cargo.lock
+++ b/type-bridge-core/Cargo.lock
@@ -2522,7 +2522,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "type-bridge-core"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "pyo3",
  "pythonize",
@@ -2537,7 +2537,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-core-lib"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "criterion",
  "once_cell",
@@ -2554,7 +2554,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-migration"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "anstream 0.6.21",
  "anstyle",
@@ -2567,11 +2567,12 @@ dependencies = [
  "thiserror",
  "tokio",
  "type-bridge-orm",
+ "uuid",
 ]
 
 [[package]]
 name = "type-bridge-node"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "napi",
  "napi-derive",
@@ -2584,7 +2585,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-orm"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "criterion",
  "serde",
@@ -2599,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-orm-derive"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2609,7 +2610,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-server"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "axum 0.8.8",
  "chrono",
@@ -2633,7 +2634,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-toml-transpiler"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "indexmap 2.13.1",
  "serde",
@@ -2676,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-typedb-runtime"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "futures",
  "serde",

--- a/type-bridge-core/Cargo.lock
+++ b/type-bridge-core/Cargo.lock
@@ -1371,6 +1371,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "network-interface"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddcb8865ad3d9950f22f42ffa0ef0aecbfbf191867b3122413602b0a360b2a6"
+dependencies = [
+ "cc",
+ "libc",
+ "thiserror",
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2560,6 +2572,7 @@ dependencies = [
  "anstyle",
  "chrono",
  "clap",
+ "network-interface",
  "serde",
  "serde_json",
  "sha2",
@@ -2985,6 +2998,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2992,6 +3021,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/type-bridge-core/crates/core/Cargo.toml
+++ b/type-bridge-core/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-core-lib"
-version = "1.5.2"
+version = "1.5.3"
 edition = "2024"
 description = "TypeQL AST, schema parser, query compiler, and validation engine for type-bridge"
 license.workspace = true

--- a/type-bridge-core/crates/core/src/parser.rs
+++ b/type-bridge-core/crates/core/src/parser.rs
@@ -56,6 +56,7 @@ fn parse_schema(input: &mut &str) -> PResult<TypeSchema> {
         return Err(ContextError::new());
     }
 
+    let mut standalone_plays = Vec::new();
     let mut schema = TypeSchema::new();
     for block in blocks {
         for stmt in block {
@@ -132,9 +133,36 @@ fn parse_schema(input: &mut &str) -> PResult<TypeSchema> {
                 Statement::Struct(struct_type) => {
                     schema.structs.insert(struct_type.name.clone(), struct_type);
                 }
+                Statement::Plays(plays) => {
+                    standalone_plays.push(plays);
+                }
             }
         }
     }
+
+    for plays in standalone_plays {
+        if let Some(entity) = schema.entities.get_mut(&plays.player) {
+            if !entity.plays.iter().any(|p| p.role_ref == plays.played.role_ref) {
+                entity.plays.push(plays.played);
+            }
+        } else if let Some(relation) = schema.relations.get_mut(&plays.player) {
+            if !relation.plays.iter().any(|p| p.role_ref == plays.played.role_ref) {
+                relation.plays.push(plays.played);
+            }
+        } else {
+            // Player type is not explicitly defined yet. Create a shell entity.
+            let entity = EntityType {
+                name: plays.player.clone(),
+                parent: None,
+                is_abstract: false,
+                owns: Vec::new(),
+                owns_order: Vec::new(),
+                plays: vec![plays.played],
+            };
+            schema.entities.insert(plays.player, entity);
+        }
+    }
+
     Ok(schema)
 }
 
@@ -150,12 +178,18 @@ fn parse_define_block(input: &mut &str) -> PResult<Vec<Statement>> {
 // Statement dispatch
 // ---------------------------------------------------------------------------
 
+struct StandalonePlays {
+    player: String,
+    played: PlayedRole,
+}
+
 enum Statement {
     Attribute(AttributeType),
     Entity(EntityType),
     Relation(RelationType),
     Function(FunctionType),
     Struct(StructType),
+    Plays(StandalonePlays),
 }
 
 fn parse_statement(input: &mut &str) -> PResult<Option<Statement>> {
@@ -166,8 +200,21 @@ fn parse_statement(input: &mut &str) -> PResult<Option<Statement>> {
         parse_relation_def.map(|r| Some(Statement::Relation(r))),
         parse_function_def.map(|f| Some(Statement::Function(f))),
         parse_struct_def.map(|s| Some(Statement::Struct(s))),
+        parse_standalone_plays.map(|p| Some(Statement::Plays(p))),
     ))
     .parse_next(input)
+}
+
+fn parse_standalone_plays(input: &mut &str) -> PResult<StandalonePlays> {
+    let player = identifier(input)?;
+    ws_comments_required(input)?;
+    let played = parse_plays_statement(input)?;
+    ws_comments(input);
+    literal(";").parse_next(input)?;
+    Ok(StandalonePlays {
+        player: player.to_string(),
+        played,
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -1889,5 +1936,13 @@ entity person
         let attr = schema.attributes.get("age").unwrap();
         assert!(attr.range_min.is_none());
         assert_eq!(attr.range_max.as_deref(), Some("150"));
+    }
+
+    #[test]
+    fn test_parse_standalone_plays() {
+        let schema = parse_typeql("define\nentity person;\nperson plays friendship:friend;\n").unwrap();
+        let person = schema.entities.get("person").unwrap();
+        assert_eq!(person.plays.len(), 1);
+        assert_eq!(person.plays[0].role_ref, "friendship:friend");
     }
 }

--- a/type-bridge-core/crates/migration/Cargo.toml
+++ b/type-bridge-core/crates/migration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-migration"
-version = "1.5.2"
+version = "1.5.3"
 edition = "2024"
 description = "Migration IR and planning substrate for type-bridge"
 license.workspace = true
@@ -20,7 +20,7 @@ name = "type-bridge-migration"
 path = "src/bin/type_bridge_migration.rs"
 
 [dependencies]
-type-bridge-orm = { path = "../orm", version = "1.5.2", default-features = false, features = ["band7", "band8"] }
+type-bridge-orm = { path = "../orm", version = "1.5.3", default-features = false, features = ["band7", "band8"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -30,6 +30,7 @@ thiserror = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 anstyle = "1"
 anstream = "0.6"
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/type-bridge-core/crates/migration/Cargo.toml
+++ b/type-bridge-core/crates/migration/Cargo.toml
@@ -23,6 +23,7 @@ path = "src/bin/type_bridge_migration.rs"
 type-bridge-orm = { path = "../orm", version = "1.5.3", default-features = false, features = ["band7", "band8"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4.5", features = ["derive"] }
+network-interface = "2.0.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"

--- a/type-bridge-core/crates/migration/src/bin/type_bridge_migration.rs
+++ b/type-bridge-core/crates/migration/src/bin/type_bridge_migration.rs
@@ -11,7 +11,7 @@
 //! Pure verbs (`plan`, `sqlmigrate`) run entirely from the sidecar files on
 //! disk via [`load_dir_checked`].  The three connected verbs open their own
 //! `Database::connect` + Tokio runtime; the shared `TypeDbStateStore` and
-//! `execute_plan` from `crates/migration` are reused without re-implementation
+//! logged executor from `crates/migration` are reused without re-implementation
 //! (invariant 2: one engine, two bootstraps).
 
 mod display;
@@ -25,7 +25,7 @@ use thiserror::Error;
 use tokio::runtime::Runtime;
 use type_bridge_migration::{
     AppliedMigrationRecord, MigrationAction, MigrationError, MigrationStateStore, TypeDbStateStore,
-    execute_plan, load_dir, load_dir_checked, plan,
+    collect_executor_info, execute_plan_with_run_log, load_dir, load_dir_checked, plan,
 };
 use type_bridge_orm::Database;
 
@@ -323,6 +323,21 @@ fn resolve_address(flag: Option<String>) -> String {
         .unwrap_or_else(|| DEFAULT_ADDRESS.to_string())
 }
 
+fn migration_checksums(
+    graph: &type_bridge_migration::MigrationGraph,
+) -> std::collections::BTreeMap<(String, String), String> {
+    graph
+        .migrations
+        .iter()
+        .map(|migration| {
+            (
+                (migration.app_label.clone(), migration.name.clone()),
+                migration.checksum.clone().unwrap_or_default(),
+            )
+        })
+        .collect()
+}
+
 /// `plan` — load sidecars, plan with empty applied state, print per-step info.
 fn cmd_plan(migrations_dir: &Path, target: Option<&str>) -> CliResult<()> {
     let graph = load_dir_checked(migrations_dir)?;
@@ -406,7 +421,7 @@ fn connect(
 /// `migrate` — connect, load state, plan, execute, record state.
 ///
 /// Mirrors the Python `executor.py` coordination:
-///   load_applied → plan (filters out applied) → execute_plan
+///   load_applied → plan (filters out applied) → logged execution
 ///   → for each successful to_apply: record_applied
 ///   → for each to_rollback: record_unapplied
 #[allow(clippy::too_many_arguments)]
@@ -433,7 +448,15 @@ fn cmd_migrate(
         return Ok(());
     }
 
-    let results = runtime.block_on(execute_plan(&db, execution_plan));
+    let checksums = migration_checksums(&graph);
+    let executor = collect_executor_info();
+    let results = runtime.block_on(execute_plan_with_run_log(
+        &db,
+        &store,
+        execution_plan,
+        &checksums,
+        &executor,
+    ))?;
 
     let mut any_failure = false;
     for result in &results {

--- a/type-bridge-core/crates/migration/src/executor.rs
+++ b/type-bridge-core/crates/migration/src/executor.rs
@@ -15,10 +15,14 @@
 //! documented contract for this boundary.
 
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use type_bridge_orm::Database;
 
 use crate::backfill::{BackfillResult, execute_backfill};
 use crate::plan::{ExecutionPlan, MigrationAction, MigrationExecution, StepKind};
+use crate::state::{
+    MigrationExecutorInfo, MigrationStateStore, finished_run_record, started_run_record,
+};
 
 /// Result of executing a single migration (one entry per attempted migration).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -53,16 +57,20 @@ pub async fn execute_plan(db: &Database, plan: ExecutionPlan) -> Vec<MigrationRe
 
     // Process rollbacks before applies (planner already reverse-ordered them).
     for migration in plan.to_rollback {
-        let halting = execute_migration(db, &migration, &mut results).await;
-        if halting {
+        let result = execute_migration(db, &migration).await;
+        let should_halt = !result.success;
+        results.push(result);
+        if should_halt {
             return results;
         }
     }
 
     // Process applies.
     for migration in plan.to_apply {
-        let halting = execute_migration(db, &migration, &mut results).await;
-        if halting {
+        let result = execute_migration(db, &migration).await;
+        let should_halt = !result.success;
+        results.push(result);
+        if should_halt {
             return results;
         }
     }
@@ -70,26 +78,76 @@ pub async fn execute_plan(db: &Database, plan: ExecutionPlan) -> Vec<MigrationRe
     results
 }
 
+/// Execute a plan while writing one DB-backed run-log row per attempted migration.
+pub async fn execute_plan_with_run_log<S: MigrationStateStore>(
+    db: &Database,
+    store: &S,
+    plan: ExecutionPlan,
+    checksums: &BTreeMap<(String, String), String>,
+    executor: &MigrationExecutorInfo,
+) -> crate::Result<Vec<MigrationResult>> {
+    let mut results: Vec<MigrationResult> = Vec::new();
+
+    for migration in plan.to_rollback {
+        let result = execute_logged_migration(db, store, &migration, checksums, executor).await?;
+        let should_halt = !result.success;
+        results.push(result);
+        if should_halt {
+            return Ok(results);
+        }
+    }
+
+    for migration in plan.to_apply {
+        let result = execute_logged_migration(db, store, &migration, checksums, executor).await?;
+        let should_halt = !result.success;
+        results.push(result);
+        if should_halt {
+            return Ok(results);
+        }
+    }
+
+    Ok(results)
+}
+
+async fn execute_logged_migration<S: MigrationStateStore>(
+    db: &Database,
+    store: &S,
+    migration: &MigrationExecution,
+    checksums: &BTreeMap<(String, String), String>,
+    executor: &MigrationExecutorInfo,
+) -> crate::Result<MigrationResult> {
+    let checksum = checksums
+        .get(&(migration.app_label.clone(), migration.name.clone()))
+        .cloned()
+        .unwrap_or_default();
+    let run = started_run_record(migration, checksum, executor);
+    store.record_run(run.clone()).await?;
+
+    let result = execute_migration(db, migration).await;
+    let status = if result.success {
+        "succeeded"
+    } else {
+        "failed"
+    };
+    let finished = finished_run_record(run, status, result.error.clone());
+    store.record_run(finished).await?;
+    Ok(result)
+}
+
 /// Execute a single [`MigrationExecution`].
 ///
-/// Pushes a [`MigrationResult`] onto `results` and returns `true` when the
-/// run should halt (i.e. a failure occurred).
-async fn execute_migration(
-    db: &Database,
-    migration: &MigrationExecution,
-    results: &mut Vec<MigrationResult>,
-) -> bool {
+/// Returns one [`MigrationResult`] for this attempted migration.
+pub async fn execute_migration(db: &Database, migration: &MigrationExecution) -> MigrationResult {
     // Non-reversible rollback: fail immediately without opening a transaction.
     if migration.action == MigrationAction::Rollback && !migration.reversible {
-        results.push(MigrationResult {
+        return MigrationResult {
             app_label: migration.app_label.clone(),
             name: migration.name.clone(),
             action: migration.action,
             success: false,
             error: Some(format!("{} is not reversible", migration.name)),
             backfill: None,
-        });
-        return true; // halt
+        };
     }
 
     let mut backfill_results: Vec<BackfillResult> = Vec::new();
@@ -104,15 +162,14 @@ async fn execute_migration(
                     continue;
                 }
                 Err(e) => {
-                    results.push(MigrationResult {
+                    return MigrationResult {
                         app_label: migration.app_label.clone(),
                         name: migration.name.clone(),
                         action: migration.action,
                         success: false,
                         error: Some(format!("backfill step {step_index} failed: {e}")),
                         backfill: None,
-                    });
-                    return true; // halt
+                    };
                 }
             }
         }
@@ -132,15 +189,14 @@ async fn execute_migration(
         let ctx = match db.transaction_context(step.tx_type).await {
             Ok(ctx) => ctx,
             Err(e) => {
-                results.push(MigrationResult {
+                return MigrationResult {
                     app_label: migration.app_label.clone(),
                     name: migration.name.clone(),
                     action: migration.action,
                     success: false,
                     error: Some(format!("failed to open transaction: {e}")),
                     backfill: None,
-                });
-                return true; // halt
+                };
             }
         };
 
@@ -148,28 +204,26 @@ async fn execute_migration(
         if let Err(e) = ctx.query(typeql).await {
             // Best-effort rollback; ignore its error.
             let _ = ctx.rollback().await;
-            results.push(MigrationResult {
+            return MigrationResult {
                 app_label: migration.app_label.clone(),
                 name: migration.name.clone(),
                 action: migration.action,
                 success: false,
                 error: Some(format!("query failed: {e}")),
                 backfill: None,
-            });
-            return true; // halt
+            };
         }
 
         // Commit the step.
         if let Err(e) = ctx.commit().await {
-            results.push(MigrationResult {
+            return MigrationResult {
                 app_label: migration.app_label.clone(),
                 name: migration.name.clone(),
                 action: migration.action,
                 success: false,
                 error: Some(format!("commit failed: {e}")),
                 backfill: None,
-            });
-            return true; // halt
+            };
         }
     }
 
@@ -179,21 +233,21 @@ async fn execute_migration(
     } else {
         Some(backfill_results)
     };
-    results.push(MigrationResult {
+    MigrationResult {
         app_label: migration.app_label.clone(),
         name: migration.name.clone(),
         action: migration.action,
         success: true,
         error: None,
         backfill,
-    });
-    false // continue
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::plan::ExecutionStep;
+    use crate::state::InMemoryStateStore;
     use crate::testing::{MockEvent, MockMigrationBackend};
     use type_bridge_orm::{Database, TxType};
 
@@ -285,6 +339,45 @@ mod tests {
                 MockEvent::Commit,
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn execute_plan_with_run_log_records_started_and_finished_rows() {
+        let (backend, _log) = MockMigrationBackend::new(None);
+        let db = Database::with_backend(Box::new(backend), "test");
+        let store = InMemoryStateStore::new();
+        let mut checksums = BTreeMap::new();
+        checksums.insert(
+            ("app".to_string(), "0001_initial".to_string()),
+            "checksum-1".to_string(),
+        );
+        let executor = MigrationExecutorInfo {
+            ip: Some("127.0.0.1".to_string()),
+            mac: Some("00:11:22:33:44:55".to_string()),
+        };
+        let plan = ExecutionPlan {
+            to_apply: vec![apply_migration(
+                "0001_initial",
+                vec![schema_step("define attribute a, value string;", None)],
+            )],
+            to_rollback: Vec::new(),
+        };
+
+        let results = execute_plan_with_run_log(&db, &store, plan, &checksums, &executor)
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert!(results[0].success);
+        let runs = store.load_runs().await.unwrap();
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].name, "0001_initial");
+        assert_eq!(runs[0].checksum, "checksum-1");
+        assert_eq!(runs[0].direction, "apply");
+        assert_eq!(runs[0].status, "succeeded");
+        assert!(runs[0].finished_at.is_some());
+        assert_eq!(runs[0].executor_ip.as_deref(), Some("127.0.0.1"));
+        assert_eq!(runs[0].executor_mac.as_deref(), Some("00:11:22:33:44:55"));
     }
 
     // ── test: rollback path ───────────────────────────────────────────────────

--- a/type-bridge-core/crates/migration/src/lib.rs
+++ b/type-bridge-core/crates/migration/src/lib.rs
@@ -24,9 +24,13 @@ pub use checksum::{
     ChecksumDrift, check_checksum_drift, checksum_drift_errors, migration_file_checksum,
 };
 pub use error::{MigrationError, Result};
-pub use executor::{MigrationResult, execute_plan};
+pub use executor::{MigrationResult, execute_migration, execute_plan, execute_plan_with_run_log};
 pub use graph::{AppliedMigrationRecord, MigrationValidationError, ValidationCode, validate_graph};
 pub use loader::{load_dir, load_dir_checked, load_sidecar};
 pub use plan::{ExecutionPlan, ExecutionStep, MigrationAction, MigrationExecution, StepKind, plan};
 pub use spec::{MigrationDependencySpec, MigrationGraph, MigrationSpec, OperationSpec};
-pub use state::{InMemoryStateStore, MigrationStateStore, TypeDbStateStore};
+pub use state::{
+    InMemoryStateStore, MigrationExecutorInfo, MigrationRunRecord, MigrationStateStore,
+    TypeDbStateStore, collect_executor_info, finished_run_record, migration_timestamp_now,
+    started_run_record,
+};

--- a/type-bridge-core/crates/migration/src/plan.rs
+++ b/type-bridge-core/crates/migration/src/plan.rs
@@ -381,7 +381,7 @@ fn define_attribute(attribute: &AttributeSchemaEntry) -> crate::Result<String> {
 }
 
 fn undefine_attribute(attr_name: &str) -> String {
-    format!("undefine\nattribute {attr_name};")
+    format!("undefine\n{attr_name};")
 }
 
 fn define_entity(entity: &EntitySchemaEntry) -> crate::Result<String> {
@@ -393,7 +393,7 @@ fn define_entity(entity: &EntitySchemaEntry) -> crate::Result<String> {
 }
 
 fn undefine_entity(type_name: &str) -> String {
-    format!("undefine\nentity {type_name};")
+    format!("undefine\n{type_name};")
 }
 
 fn define_relation(relation: &RelationSchemaEntry) -> crate::Result<String> {
@@ -405,7 +405,7 @@ fn define_relation(relation: &RelationSchemaEntry) -> crate::Result<String> {
 }
 
 fn undefine_relation(type_name: &str) -> String {
-    format!("undefine\nrelation {type_name};")
+    format!("undefine\n{type_name};")
 }
 
 fn undefine_relation_with_players(relation: &RelationSchemaEntry) -> String {
@@ -413,12 +413,12 @@ fn undefine_relation_with_players(relation: &RelationSchemaEntry) -> String {
     for role in &relation.roles {
         for player_type_name in &role.player_type_names {
             statements.push(format!(
-                "{player_type_name} plays {}:{};",
+                "plays {}:{} from {player_type_name};",
                 relation.type_name, role.role_name
             ));
         }
     }
-    statements.push(format!("relation {};", relation.type_name));
+    statements.push(format!("{};", relation.type_name));
     typeql_block("undefine", statements)
 }
 
@@ -432,7 +432,10 @@ fn define_ownership(owner_type: &str, attribute: &OwnedAttributeEntry) -> String
 }
 
 fn undefine_ownership(owner_type: &str, attr_name: &str) -> String {
-    typeql_block("undefine", vec![format!("{owner_type} owns {attr_name};")])
+    typeql_block(
+        "undefine",
+        vec![format!("owns {attr_name} from {owner_type};")],
+    )
 }
 
 fn redefine_ownership(owner_type: &str, attr_name: &str, annotations: &str) -> String {
@@ -468,7 +471,7 @@ fn define_role(relation_type: &str, role: &RoleEntry) -> String {
 fn undefine_role(relation_type: &str, role_name: &str) -> String {
     typeql_block(
         "undefine",
-        vec![format!("{relation_type} relates {role_name};")],
+        vec![format!("relates {role_name} from {relation_type};")],
     )
 }
 
@@ -476,11 +479,14 @@ fn undefine_role_with_players(relation_type: &str, role: &RoleEntry) -> String {
     let mut statements = Vec::new();
     for player_type_name in &role.player_type_names {
         statements.push(format!(
-            "{player_type_name} plays {relation_type}:{};",
+            "plays {relation_type}:{} from {player_type_name};",
             role.role_name
         ));
     }
-    statements.push(format!("{relation_type} relates {};", role_type_ref(role)));
+    statements.push(format!(
+        "relates {} from {relation_type};",
+        role_type_ref(role)
+    ));
     typeql_block("undefine", statements)
 }
 
@@ -497,7 +503,7 @@ fn undefine_role_player(relation_type: &str, role_name: &str, player_type_name: 
     typeql_block(
         "undefine",
         vec![format!(
-            "{player_type_name} plays {relation_type}:{role_name};"
+            "plays {relation_type}:{role_name} from {player_type_name};"
         )],
     )
 }
@@ -952,11 +958,8 @@ delete $a has email "ops@example.com";"#,
 
         assert_eq!(steps.len(), 2);
         assert!(steps[0].forward.contains("attribute score, value integer;"));
-        assert_eq!(
-            steps[0].reverse.as_deref(),
-            Some("undefine\nattribute score;")
-        );
-        assert_eq!(steps[1].forward, "undefine\nattribute legacy-score;");
+        assert_eq!(steps[0].reverse.as_deref(), Some("undefine\nscore;"));
+        assert_eq!(steps[1].forward, "undefine\nlegacy-score;");
         assert!(steps[1].reverse.is_none());
         assert!(!result.to_apply[0].reversible);
     }
@@ -981,10 +984,7 @@ delete $a has email "ops@example.com";"#,
 
         assert!(steps[0].forward.contains("entity person,"));
         assert!(steps[0].forward.contains("owns name @key;"));
-        assert_eq!(
-            steps[0].reverse.as_deref(),
-            Some("undefine\nentity person;")
-        );
+        assert_eq!(steps[0].reverse.as_deref(), Some("undefine\nperson;"));
         assert!(steps[1].forward.contains("relation employment,"));
         assert!(steps[1].forward.contains("relates employee;"));
         assert!(
@@ -997,15 +997,9 @@ delete $a has email "ops@example.com";"#,
                 .reverse
                 .as_deref()
                 .unwrap()
-                .contains("person plays employment:employee;")
+                .contains("plays employment:employee from person;")
         );
-        assert!(
-            steps[1]
-                .reverse
-                .as_deref()
-                .unwrap()
-                .contains("relation employment;")
-        );
+        assert!(steps[1].reverse.as_deref().unwrap().contains("employment;"));
     }
 
     #[test]
@@ -1037,9 +1031,9 @@ delete $a has email "ops@example.com";"#,
         assert_eq!(steps[0].forward, "define\nperson owns email @key;");
         assert_eq!(
             steps[0].reverse.as_deref(),
-            Some("undefine\nperson owns email;")
+            Some("undefine\nowns email from person;")
         );
-        assert_eq!(steps[1].forward, "undefine\nperson owns legacy-email;");
+        assert_eq!(steps[1].forward, "undefine\nowns legacy-email from person;");
         assert!(steps[1].reverse.is_none());
         assert_eq!(
             steps[2].forward,
@@ -1096,9 +1090,14 @@ delete $a has email "ops@example.com";"#,
         );
         assert_eq!(
             steps[0].reverse.as_deref(),
-            Some("undefine\nperson plays employment:reviewer;\nemployment relates reviewer;")
+            Some(
+                "undefine\nplays employment:reviewer from person;\nrelates reviewer from employment;"
+            )
         );
-        assert_eq!(steps[1].forward, "undefine\nemployment relates legacy;");
+        assert_eq!(
+            steps[1].forward,
+            "undefine\nrelates legacy from employment;"
+        );
         assert!(steps[1].reverse.is_none());
         assert_eq!(
             steps[2].forward,
@@ -1106,11 +1105,11 @@ delete $a has email "ops@example.com";"#,
         );
         assert_eq!(
             steps[2].reverse.as_deref(),
-            Some("undefine\ncontractor plays employment:employee;")
+            Some("undefine\nplays employment:employee from contractor;")
         );
         assert_eq!(
             steps[3].forward,
-            "undefine\ncompany plays employment:employee;"
+            "undefine\nplays employment:employee from company;"
         );
         assert_eq!(
             steps[3].reverse.as_deref(),

--- a/type-bridge-core/crates/migration/src/state/memory.rs
+++ b/type-bridge-core/crates/migration/src/state/memory.rs
@@ -14,7 +14,7 @@ use std::sync::Mutex;
 use type_bridge_orm::session::backend::BoxFuture;
 
 use crate::state::MigrationStateStore;
-use crate::{AppliedMigrationRecord, Result};
+use crate::{AppliedMigrationRecord, MigrationRunRecord, Result};
 
 /// In-memory migration state store backed by a `Mutex<Vec<AppliedMigrationRecord>>`.
 ///
@@ -23,6 +23,7 @@ use crate::{AppliedMigrationRecord, Result};
 /// replaces the first entry rather than appending a duplicate.
 pub struct InMemoryStateStore {
     records: Mutex<Vec<AppliedMigrationRecord>>,
+    runs: Mutex<Vec<MigrationRunRecord>>,
 }
 
 impl InMemoryStateStore {
@@ -30,6 +31,7 @@ impl InMemoryStateStore {
     pub fn new() -> Self {
         Self {
             records: Mutex::new(Vec::new()),
+            runs: Mutex::new(Vec::new()),
         }
     }
 }
@@ -49,6 +51,12 @@ impl MigrationStateStore for InMemoryStateStore {
     /// Return a clone of all stored records in stable insertion order.
     fn load_applied(&self) -> BoxFuture<'_, Result<Vec<AppliedMigrationRecord>>> {
         let snapshot = self.records.lock().unwrap().clone();
+        Box::pin(async move { Ok(snapshot) })
+    }
+
+    /// Return a clone of all stored run-log records in stable insertion order.
+    fn load_runs(&self) -> BoxFuture<'_, Result<Vec<MigrationRunRecord>>> {
+        let snapshot = self.runs.lock().unwrap().clone();
         Box::pin(async move { Ok(snapshot) })
     }
 
@@ -86,6 +94,19 @@ impl MigrationStateStore for InMemoryStateStore {
         }
         Box::pin(async { Ok(()) })
     }
+
+    /// Insert or replace a run-log record by `run_id`.
+    fn record_run(&self, record: MigrationRunRecord) -> BoxFuture<'_, Result<()>> {
+        {
+            let mut runs = self.runs.lock().unwrap();
+            if let Some(existing) = runs.iter_mut().find(|r| r.run_id == record.run_id) {
+                *existing = record;
+            } else {
+                runs.push(record);
+            }
+        }
+        Box::pin(async { Ok(()) })
+    }
 }
 
 #[cfg(test)]
@@ -99,6 +120,22 @@ mod tests {
             name: name.to_string(),
             checksum: format!("{app}-{name}-checksum"),
             applied_at: Some("2026-06-05T00:00:00.000000".to_string()),
+        }
+    }
+
+    fn run_record(run_id: &str, status: &str) -> MigrationRunRecord {
+        MigrationRunRecord {
+            run_id: run_id.to_string(),
+            app_label: "app".to_string(),
+            name: "0001_initial".to_string(),
+            checksum: "checksum".to_string(),
+            direction: "apply".to_string(),
+            status: status.to_string(),
+            started_at: "2026-06-05T00:00:00.000000".to_string(),
+            finished_at: None,
+            error: None,
+            executor_ip: None,
+            executor_mac: None,
         }
     }
 
@@ -123,6 +160,13 @@ mod tests {
         assert!(applied.is_empty());
     }
 
+    #[tokio::test]
+    async fn load_runs_on_empty_store_returns_empty_vec() {
+        let store = InMemoryStateStore::new();
+        let runs = store.load_runs().await.unwrap();
+        assert!(runs.is_empty());
+    }
+
     // ── record then load ───────────────────────────────────────────────────────
 
     #[tokio::test]
@@ -135,6 +179,17 @@ mod tests {
         let applied = store.load_applied().await.unwrap();
         assert_eq!(applied.len(), 1);
         assert_eq!(applied[0], rec);
+    }
+
+    #[tokio::test]
+    async fn record_run_then_load_returns_the_record() {
+        let store = InMemoryStateStore::new();
+        let rec = run_record("run-1", "started");
+
+        store.record_run(rec.clone()).await.unwrap();
+
+        let runs = store.load_runs().await.unwrap();
+        assert_eq!(runs, vec![rec]);
     }
 
     // ── idempotent re-record ───────────────────────────────────────────────────
@@ -155,6 +210,23 @@ mod tests {
         let applied = store.load_applied().await.unwrap();
         assert_eq!(applied.len(), 1, "must not duplicate on re-record");
         assert_eq!(applied[0].checksum, "updated-checksum");
+    }
+
+    #[tokio::test]
+    async fn record_run_twice_replaces_existing_run() {
+        let store = InMemoryStateStore::new();
+        let rec = run_record("run-1", "started");
+        let finished = MigrationRunRecord {
+            status: "succeeded".to_string(),
+            finished_at: Some("2026-06-05T00:00:01.000000".to_string()),
+            ..rec.clone()
+        };
+
+        store.record_run(rec).await.unwrap();
+        store.record_run(finished.clone()).await.unwrap();
+
+        let runs = store.load_runs().await.unwrap();
+        assert_eq!(runs, vec![finished]);
     }
 
     // ── record unapplied removes the entry ─────────────────────────────────────

--- a/type-bridge-core/crates/migration/src/state/mod.rs
+++ b/type-bridge-core/crates/migration/src/state/mod.rs
@@ -14,10 +14,10 @@ pub mod typedb;
 pub use memory::InMemoryStateStore;
 pub use typedb::TypeDbStateStore;
 
-use std::fs;
 use std::net::UdpSocket;
 
 use chrono::Utc;
+use network_interface::{NetworkInterface, NetworkInterfaceConfig};
 use type_bridge_orm::session::backend::BoxFuture;
 use uuid::Uuid;
 
@@ -129,27 +129,39 @@ fn local_ip() -> Option<String> {
 }
 
 fn local_mac() -> Option<String> {
-    #[cfg(target_os = "linux")]
-    {
-        let entries = fs::read_dir("/sys/class/net").ok()?;
-        for entry in entries.flatten() {
-            let name = entry.file_name();
-            if name == "lo" {
-                continue;
-            }
-            let address_path = entry.path().join("address");
-            let address = fs::read_to_string(address_path).ok()?;
-            let address = address.trim().to_ascii_lowercase();
-            if address.len() == 17 && address != "00:00:00:00:00:00" {
-                return Some(address);
-            }
+    NetworkInterface::show()
+        .ok()?
+        .into_iter()
+        .filter(|interface| !interface.internal)
+        .find_map(|interface| {
+            interface
+                .mac_addr
+                .as_deref()
+                .and_then(normalize_mac_address)
+        })
+}
+
+fn normalize_mac_address(value: &str) -> Option<String> {
+    let mut bytes = [0_u8; 6];
+    let mut parts = value.split([':', '-']);
+    for byte in &mut bytes {
+        let part = parts.next()?;
+        if part.len() != 2 {
+            return None;
         }
-        None
+        *byte = u8::from_str_radix(part, 16).ok()?;
     }
-    #[cfg(not(target_os = "linux"))]
-    {
-        None
+    if parts.next().is_some() || bytes.iter().all(|byte| *byte == 0) {
+        return None;
     }
+    Some(format_mac_address(bytes))
+}
+
+fn format_mac_address(bytes: [u8; 6]) -> String {
+    format!(
+        "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+        bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5]
+    )
 }
 
 /// Seam trait for migration applied-state storage.
@@ -197,4 +209,36 @@ pub trait MigrationStateStore: Send + Sync {
 
     /// Insert or replace one migration execution run-log record by `run_id`.
     fn record_run(&self, record: MigrationRunRecord) -> BoxFuture<'_, Result<()>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{format_mac_address, normalize_mac_address};
+
+    #[test]
+    fn formats_mac_addresses_in_lowercase_colon_notation() {
+        assert_eq!(
+            format_mac_address([0x00, 0x11, 0xAB, 0xCD, 0xEF, 0x42]),
+            "00:11:ab:cd:ef:42"
+        );
+    }
+
+    #[test]
+    fn normalizes_supported_mac_address_strings() {
+        assert_eq!(
+            normalize_mac_address("00:11:AB:CD:EF:42").as_deref(),
+            Some("00:11:ab:cd:ef:42")
+        );
+        assert_eq!(
+            normalize_mac_address("00-11-ab-cd-ef-42").as_deref(),
+            Some("00:11:ab:cd:ef:42")
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_or_zero_mac_address_strings() {
+        assert_eq!(normalize_mac_address("00:00:00:00:00:00"), None);
+        assert_eq!(normalize_mac_address("00:11:22:33:44"), None);
+        assert_eq!(normalize_mac_address("00:11:22:33:44:zz"), None);
+    }
 }

--- a/type-bridge-core/crates/migration/src/state/mod.rs
+++ b/type-bridge-core/crates/migration/src/state/mod.rs
@@ -14,9 +14,143 @@ pub mod typedb;
 pub use memory::InMemoryStateStore;
 pub use typedb::TypeDbStateStore;
 
-use type_bridge_orm::session::backend::BoxFuture;
+use std::fs;
+use std::net::UdpSocket;
 
+use chrono::Utc;
+use type_bridge_orm::session::backend::BoxFuture;
+use uuid::Uuid;
+
+use crate::plan::{MigrationAction, MigrationExecution};
 use crate::{AppliedMigrationRecord, Result};
+
+const TIMESTAMP_FORMAT: &str = "%Y-%m-%dT%H:%M:%S.%6f";
+
+/// Best-effort executor identity stored with migration run-log rows.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]
+pub struct MigrationExecutorInfo {
+    /// Best-effort local IP address of the process that executed the migration.
+    #[serde(default)]
+    pub ip: Option<String>,
+    /// Best-effort MAC address of the process that executed the migration.
+    #[serde(default)]
+    pub mac: Option<String>,
+}
+
+/// Append/update record for one migration execution attempt.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct MigrationRunRecord {
+    /// Unique execution-attempt identifier.
+    pub run_id: String,
+    /// Application or migration package label.
+    pub app_label: String,
+    /// Migration file stem, such as `0001_initial`.
+    pub name: String,
+    /// Migration checksum observed when this run started.
+    pub checksum: String,
+    /// Execution direction: `apply` or `rollback`.
+    pub direction: String,
+    /// Execution status: `started`, `succeeded`, or `failed`.
+    pub status: String,
+    /// UTC timestamp when the run started.
+    pub started_at: String,
+    /// UTC timestamp when the run finished, when available.
+    #[serde(default)]
+    pub finished_at: Option<String>,
+    /// Error message captured for failed runs, when available.
+    #[serde(default)]
+    pub error: Option<String>,
+    /// Best-effort executor IP address, when available.
+    #[serde(default)]
+    pub executor_ip: Option<String>,
+    /// Best-effort executor MAC address, when available.
+    #[serde(default)]
+    pub executor_mac: Option<String>,
+}
+
+/// Return the current UTC timestamp in the TypeDB datetime literal format.
+pub fn migration_timestamp_now() -> String {
+    Utc::now().format(TIMESTAMP_FORMAT).to_string()
+}
+
+/// Collect best-effort executor identity for audit logging.
+pub fn collect_executor_info() -> MigrationExecutorInfo {
+    MigrationExecutorInfo {
+        ip: local_ip(),
+        mac: local_mac(),
+    }
+}
+
+/// Create a started run-log record for a planned migration execution.
+pub fn started_run_record(
+    migration: &MigrationExecution,
+    checksum: String,
+    executor: &MigrationExecutorInfo,
+) -> MigrationRunRecord {
+    MigrationRunRecord {
+        run_id: Uuid::new_v4().to_string(),
+        app_label: migration.app_label.clone(),
+        name: migration.name.clone(),
+        checksum,
+        direction: direction_label(migration.action).to_string(),
+        status: "started".to_string(),
+        started_at: migration_timestamp_now(),
+        finished_at: None,
+        error: None,
+        executor_ip: executor.ip.clone(),
+        executor_mac: executor.mac.clone(),
+    }
+}
+
+/// Return a finished copy of a migration run-log record.
+pub fn finished_run_record(
+    mut record: MigrationRunRecord,
+    status: &str,
+    error: Option<String>,
+) -> MigrationRunRecord {
+    record.status = status.to_string();
+    record.finished_at = Some(migration_timestamp_now());
+    record.error = error;
+    record
+}
+
+fn direction_label(action: MigrationAction) -> &'static str {
+    match action {
+        MigrationAction::Apply => "apply",
+        MigrationAction::Rollback => "rollback",
+    }
+}
+
+fn local_ip() -> Option<String> {
+    let socket = UdpSocket::bind("0.0.0.0:0").ok()?;
+    socket.connect("8.8.8.8:80").ok()?;
+    let addr = socket.local_addr().ok()?;
+    Some(addr.ip().to_string()).filter(|ip| ip != "0.0.0.0")
+}
+
+fn local_mac() -> Option<String> {
+    #[cfg(target_os = "linux")]
+    {
+        let entries = fs::read_dir("/sys/class/net").ok()?;
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            if name == "lo" {
+                continue;
+            }
+            let address_path = entry.path().join("address");
+            let address = fs::read_to_string(address_path).ok()?;
+            let address = address.trim().to_ascii_lowercase();
+            if address.len() == 17 && address != "00:00:00:00:00:00" {
+                return Some(address);
+            }
+        }
+        None
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
+    }
+}
 
 /// Seam trait for migration applied-state storage.
 ///
@@ -41,6 +175,9 @@ pub trait MigrationStateStore: Send + Sync {
     /// Load all applied migration records in stable insertion order.
     fn load_applied(&self) -> BoxFuture<'_, Result<Vec<AppliedMigrationRecord>>>;
 
+    /// Load all migration execution run-log records.
+    fn load_runs(&self) -> BoxFuture<'_, Result<Vec<MigrationRunRecord>>>;
+
     /// Record a migration as applied, inserting or replacing by `(app_label,
     /// name)` identity.
     ///
@@ -57,4 +194,7 @@ pub trait MigrationStateStore: Send + Sync {
         app_label: &'a str,
         name: &'a str,
     ) -> BoxFuture<'a, Result<()>>;
+
+    /// Insert or replace one migration execution run-log record by `run_id`.
+    fn record_run(&self, record: MigrationRunRecord) -> BoxFuture<'_, Result<()>>;
 }

--- a/type-bridge-core/crates/migration/src/state/typedb.rs
+++ b/type-bridge-core/crates/migration/src/state/typedb.rs
@@ -21,13 +21,16 @@ use type_bridge_orm::Database;
 use type_bridge_orm::OrmError;
 use type_bridge_orm::session::backend::{BoxFuture, QueryResult, TxType};
 
-use crate::state::MigrationStateStore;
+use crate::state::{MigrationRunRecord, MigrationStateStore};
 use crate::{AppliedMigrationRecord, MigrationError, Result};
 
 /// The migration-tracking entity type name.
 ///
 /// Mirrors `MigrationStateManager.ENTITY_NAME` (`state.py:111`).
 const ENTITY_NAME: &str = "type_bridge_migration";
+
+/// The append/update migration run-log entity type name.
+const RUN_ENTITY_NAME: &str = "type_bridge_migration_run";
 
 /// Timestamp format mirroring Python's `strftime("%Y-%m-%dT%H:%M:%S.%f")`.
 ///
@@ -55,6 +58,58 @@ impl TypeDbStateStore {
             schema_ensured: AtomicBool::new(false),
         }
     }
+
+    async fn type_exists(&self, type_name: &str) -> bool {
+        let check_query = format!(
+            "\n            match $t type {type_name};\n            fetch {{ \"exists\": true }};\n        "
+        );
+
+        match self.db.transaction_context(TxType::Read).await {
+            Ok(ctx) => match ctx.query(&check_query).await {
+                Ok(QueryResult::Documents(docs)) => !docs.is_empty(),
+                Ok(QueryResult::Rows(rows)) => !rows.is_empty(),
+                Ok(QueryResult::Ok) => false,
+                Err(_) => false,
+            },
+            Err(_) => false,
+        }
+    }
+
+    async fn ensure_type(&self, type_name: &str, define_typeql: &str) -> Result<()> {
+        if self.type_exists(type_name).await {
+            return Ok(());
+        }
+
+        let ctx = self
+            .db
+            .transaction_context(TxType::Schema)
+            .await
+            .map_err(map_orm_error)?;
+        match ctx.query(define_typeql).await {
+            Ok(_) => {
+                ctx.commit().await.map_err(map_orm_error)?;
+                Ok(())
+            }
+            Err(error) => {
+                let _ = ctx.rollback().await;
+                if self.type_exists(type_name).await {
+                    Ok(())
+                } else {
+                    Err(map_orm_error(error))
+                }
+            }
+        }
+    }
+
+    async fn query_documents(&self, query: &str) -> Result<Vec<serde_json::Value>> {
+        let ctx = self
+            .db
+            .transaction_context(TxType::Read)
+            .await
+            .map_err(map_orm_error)?;
+        let result = ctx.query(query).await.map_err(map_orm_error)?;
+        Ok(query_result_values(result))
+    }
 }
 
 /// Format the current UTC time as the Python-compatible applied-at string.
@@ -64,6 +119,24 @@ impl TypeDbStateStore {
 /// live clock or TypeDB.
 fn format_applied_at(now: chrono::DateTime<Utc>) -> String {
     now.format(APPLIED_AT_FORMAT).to_string()
+}
+
+fn query_result_values(result: QueryResult) -> Vec<serde_json::Value> {
+    match result {
+        QueryResult::Documents(docs) => docs,
+        QueryResult::Rows(rows) => rows,
+        QueryResult::Ok => Vec::new(),
+    }
+}
+
+fn typeql_string_literal(value: &str) -> String {
+    let escaped = value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+        .replace('\t', "\\t");
+    format!("\"{escaped}\"")
 }
 
 /// Map an ORM-layer error into the migration error hierarchy.
@@ -134,6 +207,135 @@ pub fn parse_applied_documents(
     Ok(records)
 }
 
+/// Parse TypeDB fetch documents into migration run-log records.
+pub fn parse_run_documents(values: &[serde_json::Value]) -> Result<Vec<MigrationRunRecord>> {
+    let mut records = Vec::with_capacity(values.len());
+    for doc in values {
+        let (
+            Some(run_id),
+            Some(app_label),
+            Some(name),
+            Some(checksum),
+            Some(direction),
+            Some(status),
+            Some(started_at),
+        ) = (
+            extract_value(doc, "run_id"),
+            extract_value(doc, "app"),
+            extract_value(doc, "name"),
+            extract_value(doc, "checksum"),
+            extract_value(doc, "direction"),
+            extract_value(doc, "status"),
+            extract_value(doc, "started"),
+        )
+        else {
+            continue;
+        };
+        records.push(MigrationRunRecord {
+            run_id,
+            app_label,
+            name,
+            checksum,
+            direction,
+            status,
+            started_at,
+            finished_at: None,
+            error: None,
+            executor_ip: None,
+            executor_mac: None,
+        });
+    }
+    Ok(records)
+}
+
+fn optional_run_field_query(attribute: &str, alias: &str) -> String {
+    format!(
+        "\nmatch\n$r isa {RUN_ENTITY_NAME},\n    has migration_run_id $run_id,\n    has {attribute} ${alias};\nfetch {{\n    \"run_id\": $run_id,\n    \"{alias}\": ${alias}\n}};\n"
+    )
+}
+
+fn merge_optional_run_field(
+    runs: &mut [MigrationRunRecord],
+    docs: &[serde_json::Value],
+    target: &str,
+    source: &str,
+) {
+    for doc in docs {
+        let (Some(run_id), Some(value)) =
+            (extract_value(doc, "run_id"), extract_value(doc, source))
+        else {
+            continue;
+        };
+        let Some(run) = runs.iter_mut().find(|run| run.run_id == run_id) else {
+            continue;
+        };
+        match target {
+            "finished_at" => run.finished_at = Some(value),
+            "error" => run.error = Some(value),
+            "executor_ip" => run.executor_ip = Some(value),
+            "executor_mac" => run.executor_mac = Some(value),
+            _ => {}
+        }
+    }
+}
+
+fn run_insert_query(record: &MigrationRunRecord) -> String {
+    let mut fields = vec![
+        format!(
+            "    has migration_run_id {}",
+            typeql_string_literal(&record.run_id)
+        ),
+        format!(
+            "    has migration_app_label {}",
+            typeql_string_literal(&record.app_label)
+        ),
+        format!(
+            "    has migration_name {}",
+            typeql_string_literal(&record.name)
+        ),
+        format!(
+            "    has migration_checksum {}",
+            typeql_string_literal(&record.checksum)
+        ),
+        format!(
+            "    has migration_direction {}",
+            typeql_string_literal(&record.direction)
+        ),
+        format!(
+            "    has migration_status {}",
+            typeql_string_literal(&record.status)
+        ),
+        format!("    has migration_started_at {}", record.started_at),
+    ];
+
+    if let Some(finished_at) = &record.finished_at {
+        fields.push(format!("    has migration_finished_at {finished_at}"));
+    }
+    if let Some(error) = &record.error {
+        fields.push(format!(
+            "    has migration_error {}",
+            typeql_string_literal(error)
+        ));
+    }
+    if let Some(executor_ip) = &record.executor_ip {
+        fields.push(format!(
+            "    has migration_executor_ip {}",
+            typeql_string_literal(executor_ip)
+        ));
+    }
+    if let Some(executor_mac) = &record.executor_mac {
+        fields.push(format!(
+            "    has migration_executor_mac {}",
+            typeql_string_literal(executor_mac)
+        ));
+    }
+
+    format!(
+        "\ninsert $r isa {RUN_ENTITY_NAME},\n{};\n",
+        fields.join(",\n")
+    )
+}
+
 impl MigrationStateStore for TypeDbStateStore {
     fn ensure_schema(&self) -> BoxFuture<'_, Result<()>> {
         Box::pin(async move {
@@ -141,45 +343,34 @@ impl MigrationStateStore for TypeDbStateStore {
                 return Ok(());
             }
 
-            // Check whether the entity type already exists. Ported from
-            // state.py:132-135 (read tx + fetch).
-            let check_query = format!(
-                "\n            match $t type {ENTITY_NAME};\n            fetch {{ \"exists\": true }};\n        "
-            );
-
-            let exists = match self.db.transaction_context(TxType::Read).await {
-                Ok(ctx) => match ctx.query(&check_query).await {
-                    // A non-empty document set means the type is defined.
-                    Ok(QueryResult::Documents(docs)) => !docs.is_empty(),
-                    Ok(QueryResult::Rows(rows)) => !rows.is_empty(),
-                    Ok(QueryResult::Ok) => false,
-                    // Type absent → the check query errors; fall through to
-                    // define, matching the Python bare `except` (state.py:143).
-                    Err(_) => false,
-                },
-                // Opening the read tx failed the same way the Python `except`
-                // swallows it: proceed to define.
-                Err(_) => false,
-            };
-
-            if exists {
-                self.schema_ensured.store(true, Ordering::Release);
-                return Ok(());
+            for (name, value_type) in [
+                ("migration_id", "string"),
+                ("migration_app_label", "string"),
+                ("migration_name", "string"),
+                ("migration_applied_at", "datetime"),
+                ("migration_checksum", "string"),
+                ("migration_run_id", "string"),
+                ("migration_direction", "string"),
+                ("migration_status", "string"),
+                ("migration_started_at", "datetime"),
+                ("migration_finished_at", "datetime"),
+                ("migration_error", "string"),
+                ("migration_executor_ip", "string"),
+                ("migration_executor_mac", "string"),
+            ] {
+                let define = format!("define\nattribute {name}, value {value_type};\n");
+                self.ensure_type(name, &define).await?;
             }
 
-            // Create the migration tracking schema. Ported verbatim from
-            // state.py:149-162 (composite-key entity + five attributes).
-            let schema = format!(
-                "define\nattribute migration_id, value string;\nattribute migration_app_label, value string;\nattribute migration_name, value string;\nattribute migration_applied_at, value datetime;\nattribute migration_checksum, value string;\n\nentity {ENTITY_NAME},\n    owns migration_id @key,\n    owns migration_app_label,\n    owns migration_name,\n    owns migration_applied_at,\n    owns migration_checksum;\n"
+            let applied_entity = format!(
+                "define\nentity {ENTITY_NAME},\n    owns migration_id @key,\n    owns migration_app_label,\n    owns migration_name,\n    owns migration_applied_at,\n    owns migration_checksum;\n"
             );
+            self.ensure_type(ENTITY_NAME, &applied_entity).await?;
 
-            let ctx = self
-                .db
-                .transaction_context(TxType::Schema)
-                .await
-                .map_err(map_orm_error)?;
-            ctx.query(&schema).await.map_err(map_orm_error)?;
-            ctx.commit().await.map_err(map_orm_error)?;
+            let run_entity = format!(
+                "define\nentity {RUN_ENTITY_NAME},\n    owns migration_run_id @key,\n    owns migration_app_label,\n    owns migration_name,\n    owns migration_checksum,\n    owns migration_direction,\n    owns migration_status,\n    owns migration_started_at,\n    owns migration_finished_at,\n    owns migration_error,\n    owns migration_executor_ip,\n    owns migration_executor_mac;\n"
+            );
+            self.ensure_type(RUN_ENTITY_NAME, &run_entity).await?;
 
             self.schema_ensured.store(true, Ordering::Release);
             Ok(())
@@ -202,12 +393,37 @@ impl MigrationStateStore for TypeDbStateStore {
                 .map_err(map_orm_error)?;
             let result = ctx.query(&query).await.map_err(map_orm_error)?;
 
-            let values = match result {
-                QueryResult::Documents(docs) => docs,
-                QueryResult::Rows(rows) => rows,
-                QueryResult::Ok => Vec::new(),
-            };
+            let values = query_result_values(result);
             parse_applied_documents(&values)
+        })
+    }
+
+    fn load_runs(&self) -> BoxFuture<'_, Result<Vec<MigrationRunRecord>>> {
+        Box::pin(async move {
+            self.ensure_schema().await?;
+
+            let query = format!(
+                "\nmatch\n$r isa {RUN_ENTITY_NAME},\n    has migration_run_id $run_id,\n    has migration_app_label $app,\n    has migration_name $name,\n    has migration_checksum $checksum,\n    has migration_direction $direction,\n    has migration_status $status,\n    has migration_started_at $started;\nfetch {{\n    \"run_id\": $run_id,\n    \"app\": $app,\n    \"name\": $name,\n    \"checksum\": $checksum,\n    \"direction\": $direction,\n    \"status\": $status,\n    \"started\": $started\n}};\n"
+            );
+            let mut runs = parse_run_documents(&self.query_documents(&query).await?)?;
+
+            let finished_query = optional_run_field_query("migration_finished_at", "finished");
+            let finished_docs = self.query_documents(&finished_query).await?;
+            merge_optional_run_field(&mut runs, &finished_docs, "finished_at", "finished");
+
+            let error_query = optional_run_field_query("migration_error", "error");
+            let error_docs = self.query_documents(&error_query).await?;
+            merge_optional_run_field(&mut runs, &error_docs, "error", "error");
+
+            let ip_query = optional_run_field_query("migration_executor_ip", "executor_ip");
+            let ip_docs = self.query_documents(&ip_query).await?;
+            merge_optional_run_field(&mut runs, &ip_docs, "executor_ip", "executor_ip");
+
+            let mac_query = optional_run_field_query("migration_executor_mac", "executor_mac");
+            let mac_docs = self.query_documents(&mac_query).await?;
+            merge_optional_run_field(&mut runs, &mac_docs, "executor_mac", "executor_mac");
+
+            Ok(runs)
         })
     }
 
@@ -223,6 +439,10 @@ impl MigrationStateStore for TypeDbStateStore {
                 .unwrap_or_else(|| format_applied_at(Utc::now()));
 
             let migration_id = format!("{}:{}", record.app_label, record.name);
+            let migration_id = typeql_string_literal(&migration_id);
+            let app = typeql_string_literal(&record.app_label);
+            let name = typeql_string_literal(&record.name);
+            let checksum = typeql_string_literal(&record.checksum);
 
             // Idempotent replace: delete any existing row for this migration_id
             // (the @key) before inserting, so re-recording an already-applied
@@ -230,16 +450,13 @@ impl MigrationStateStore for TypeDbStateStore {
             // This gives the TypeDB store the same dedup semantics the in-memory
             // store has behind the shared seam.
             let delete_existing = format!(
-                "\nmatch\n$m isa {ENTITY_NAME},\n    has migration_id \"{migration_id}\";\ndelete $m;\n"
+                "\nmatch\n$m isa {ENTITY_NAME},\n    has migration_id {migration_id};\ndelete $m;\n"
             );
 
             // Field set + storage schema match state.py:253-260. `applied_at` is
             // emitted unquoted (a TypeQL datetime literal); every other field quoted.
             let insert = format!(
-                "\ninsert $m isa {ENTITY_NAME},\n    has migration_id \"{migration_id}\",\n    has migration_app_label \"{app}\",\n    has migration_name \"{name}\",\n    has migration_applied_at {applied_at},\n    has migration_checksum \"{checksum}\";\n",
-                app = record.app_label,
-                name = record.name,
-                checksum = record.checksum,
+                "\ninsert $m isa {ENTITY_NAME},\n    has migration_id {migration_id},\n    has migration_app_label {app},\n    has migration_name {name},\n    has migration_applied_at {applied_at},\n    has migration_checksum {checksum};\n",
             );
 
             let ctx = self
@@ -265,8 +482,10 @@ impl MigrationStateStore for TypeDbStateStore {
             // Storage schema matches state.py:288-293; the delete clause uses the
             // TypeDB 3.x form `delete $m;` (the older `delete $m isa <type>;` that
             // the Python code carried is a parse error on TypeDB 3.x).
+            let app_label = typeql_string_literal(app_label);
+            let name = typeql_string_literal(name);
             let query = format!(
-                "\nmatch\n$m isa {ENTITY_NAME},\n    has migration_app_label \"{app_label}\",\n    has migration_name \"{name}\";\ndelete $m;\n"
+                "\nmatch\n$m isa {ENTITY_NAME},\n    has migration_app_label {app_label},\n    has migration_name {name};\ndelete $m;\n"
             );
 
             let ctx = self
@@ -275,6 +494,28 @@ impl MigrationStateStore for TypeDbStateStore {
                 .await
                 .map_err(map_orm_error)?;
             ctx.query(&query).await.map_err(map_orm_error)?;
+            ctx.commit().await.map_err(map_orm_error)?;
+            Ok(())
+        })
+    }
+
+    fn record_run(&self, record: MigrationRunRecord) -> BoxFuture<'_, Result<()>> {
+        Box::pin(async move {
+            self.ensure_schema().await?;
+
+            let run_id = typeql_string_literal(&record.run_id);
+            let delete_existing = format!(
+                "\nmatch\n$r isa {RUN_ENTITY_NAME},\n    has migration_run_id {run_id};\ndelete $r;\n"
+            );
+            let insert = run_insert_query(&record);
+
+            let ctx = self
+                .db
+                .transaction_context(TxType::Write)
+                .await
+                .map_err(map_orm_error)?;
+            ctx.query(&delete_existing).await.map_err(map_orm_error)?;
+            ctx.query(&insert).await.map_err(map_orm_error)?;
             ctx.commit().await.map_err(map_orm_error)?;
             Ok(())
         })
@@ -374,6 +615,85 @@ mod tests {
         let records = parse_applied_documents(&docs).unwrap();
         assert_eq!(records.len(), 1);
         assert!(records[0].applied_at.is_none());
+    }
+
+    #[test]
+    fn parse_run_documents_extracts_required_fields() {
+        let docs = vec![serde_json::json!({
+            "run_id": "run-1",
+            "app": "app",
+            "name": "0001_initial",
+            "checksum": "abc123",
+            "direction": "apply",
+            "status": "started",
+            "started": "2026-06-05T00:00:00.000000"
+        })];
+
+        let records = parse_run_documents(&docs).unwrap();
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].run_id, "run-1");
+        assert_eq!(records[0].direction, "apply");
+        assert_eq!(records[0].status, "started");
+        assert_eq!(records[0].finished_at, None);
+    }
+
+    #[test]
+    fn merge_optional_run_field_updates_matching_record_only() {
+        let mut records = vec![MigrationRunRecord {
+            run_id: "run-1".to_string(),
+            app_label: "app".to_string(),
+            name: "0001_initial".to_string(),
+            checksum: "abc123".to_string(),
+            direction: "apply".to_string(),
+            status: "started".to_string(),
+            started_at: "2026-06-05T00:00:00.000000".to_string(),
+            finished_at: None,
+            error: None,
+            executor_ip: None,
+            executor_mac: None,
+        }];
+        let docs = vec![serde_json::json!({
+            "run_id": "run-1",
+            "finished": "2026-06-05T00:00:01.000000"
+        })];
+
+        merge_optional_run_field(&mut records, &docs, "finished_at", "finished");
+
+        assert_eq!(
+            records[0].finished_at.as_deref(),
+            Some("2026-06-05T00:00:01.000000")
+        );
+    }
+
+    #[test]
+    fn typeql_string_literal_escapes_user_controlled_text() {
+        assert_eq!(typeql_string_literal("a\"b\\c\n"), "\"a\\\"b\\\\c\\n\"");
+    }
+
+    #[test]
+    fn run_insert_query_includes_optional_fields_when_present() {
+        let record = MigrationRunRecord {
+            run_id: "run-1".to_string(),
+            app_label: "app".to_string(),
+            name: "0001_initial".to_string(),
+            checksum: "abc123".to_string(),
+            direction: "apply".to_string(),
+            status: "failed".to_string(),
+            started_at: "2026-06-05T00:00:00.000000".to_string(),
+            finished_at: Some("2026-06-05T00:00:01.000000".to_string()),
+            error: Some("quote: \"boom\"".to_string()),
+            executor_ip: Some("127.0.0.1".to_string()),
+            executor_mac: Some("00:11:22:33:44:55".to_string()),
+        };
+
+        let query = run_insert_query(&record);
+
+        assert!(query.contains("has migration_run_id \"run-1\""));
+        assert!(query.contains("has migration_finished_at 2026-06-05T00:00:01.000000"));
+        assert!(query.contains("has migration_error \"quote: \\\"boom\\\"\""));
+        assert!(query.contains("has migration_executor_ip \"127.0.0.1\""));
+        assert!(query.contains("has migration_executor_mac \"00:11:22:33:44:55\""));
     }
 
     // ── timestamp parity (no TypeDB) ────────────────────────────────────────

--- a/type-bridge-core/crates/node/Cargo.toml
+++ b/type-bridge-core/crates/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-node"
-version = "1.5.2"
+version = "1.5.3"
 edition = "2024"
 description = "NAPI bindings exposing the type-bridge Rust ORM runtime to Node.js"
 license.workspace = true
@@ -12,8 +12,8 @@ name = "type_bridge_node"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-type-bridge-core-lib = { path = "../core", version = "1.5.2" }
-type-bridge-orm = { path = "../orm", version = "1.5.2", default-features = false, features = ["band7", "band8"] }
+type-bridge-core-lib = { path = "../core", version = "1.5.3" }
+type-bridge-orm = { path = "../orm", version = "1.5.3", default-features = false, features = ["band7", "band8"] }
 napi = { version = "2", features = ["napi4"] }
 napi-derive = "2"
 serde = { version = "1.0", features = ["derive"] }

--- a/type-bridge-core/crates/node/package-lock.json
+++ b/type-bridge-core/crates/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@type-bridge/node",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@type-bridge/node",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",

--- a/type-bridge-core/crates/node/package.json
+++ b/type-bridge-core/crates/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@type-bridge/node",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Node.js NAPI facade for the type-bridge Rust ORM runtime",
   "license": "MIT",
   "main": "dist/index.js",

--- a/type-bridge-core/crates/orm-derive/Cargo.toml
+++ b/type-bridge-core/crates/orm-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-orm-derive"
-version = "1.5.2"
+version = "1.5.3"
 edition = "2024"
 description = "Derive macros for type-bridge-orm: TypeBridgeEntity, TypeBridgeAttribute, TypeBridgeRelation"
 license.workspace = true
@@ -14,7 +14,7 @@ proc-macro = true
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full", "extra-traits"] }
-type-bridge-core-lib = { path = "../core", version = "1.5.2" }
+type-bridge-core-lib = { path = "../core", version = "1.5.3" }
 
 [lints]
 workspace = true

--- a/type-bridge-core/crates/orm/Cargo.toml
+++ b/type-bridge-core/crates/orm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-orm"
-version = "1.5.2"
+version = "1.5.3"
 edition = "2024"
 description = "Async ORM for TypeDB built on type-bridge-core-lib"
 license.workspace = true
@@ -24,14 +24,14 @@ derive = ["dep:type-bridge-orm-derive"]
 integration-tests = ["derive", "band7", "band8"]
 
 [dependencies]
-type-bridge-core-lib = { path = "../core", version = "1.5.2" }
-type-bridge-typedb-runtime = { path = "../typedb-runtime", version = "1.5.2", default-features = false, optional = true }
+type-bridge-core-lib = { path = "../core", version = "1.5.3" }
+type-bridge-typedb-runtime = { path = "../typedb-runtime", version = "1.5.3", default-features = false, optional = true }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2"
 tracing = "0.1"
-type-bridge-orm-derive = { path = "../orm-derive", version = "1.5.2", optional = true }
+type-bridge-orm-derive = { path = "../orm-derive", version = "1.5.3", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/type-bridge-core/crates/python/Cargo.toml
+++ b/type-bridge-core/crates/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-core"
-version = "1.5.2"
+version = "1.5.3"
 edition = "2024"
 description = "PyO3 bindings exposing the type-bridge Rust core to Python"
 license.workspace = true
@@ -12,10 +12,10 @@ name = "type_bridge_core"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-type-bridge-core-lib = { path = "../core", version = "1.5.2" }
-type-bridge-migration = { path = "../migration", version = "1.5.2" }
-type-bridge-orm = { path = "../orm", version = "1.5.2" }
-type-bridge-toml-transpiler = { path = "../toml-transpiler", version = "1.5.2" }
+type-bridge-core-lib = { path = "../core", version = "1.5.3" }
+type-bridge-migration = { path = "../migration", version = "1.5.3" }
+type-bridge-orm = { path = "../orm", version = "1.5.3" }
+type-bridge-toml-transpiler = { path = "../toml-transpiler", version = "1.5.3" }
 pyo3 = { version = "0.23", features = ["extension-module", "abi3-py312"] }
 pythonize = "0.23"
 serde = { version = "1.0", features = ["derive"] }

--- a/type-bridge-core/crates/python/src/migration_runtime.rs
+++ b/type-bridge-core/crates/python/src/migration_runtime.rs
@@ -5,6 +5,7 @@
 //! checks over it. They open no transactions and execute no TypeQL — migration
 //! execution is owned by a later sub-plan.
 
+use std::collections::BTreeMap;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -12,9 +13,9 @@ use pyo3::prelude::*;
 use pythonize::{depythonize, pythonize};
 use tokio::runtime::Runtime;
 use type_bridge_migration::{
-    AppliedMigrationRecord, MigrationGraph, MigrationSpec, MigrationStateStore, TypeDbStateStore,
-    check_checksum_drift, execute_plan, load_sidecar, migration_file_checksum, plan,
-    validate_graph,
+    AppliedMigrationRecord, MigrationGraph, MigrationRunRecord, MigrationSpec, MigrationStateStore,
+    TypeDbStateStore, check_checksum_drift, collect_executor_info, execute_plan_with_run_log,
+    load_sidecar, migration_file_checksum, plan, validate_graph,
 };
 
 use crate::orm_runtime::PyRustDatabase;
@@ -195,9 +196,19 @@ impl PyMigrationRunner {
         let execution_plan =
             plan(&graph, &applied, target).map_err(|error| py_value_error(error.to_string()))?;
 
+        let store = TypeDbStateStore::new(Arc::clone(&self.db));
+        let checksums = migration_checksums(&graph);
+        let executor = collect_executor_info();
         let results = self
             .runtime
-            .block_on(execute_plan(&self.db, execution_plan));
+            .block_on(execute_plan_with_run_log(
+                &self.db,
+                &store,
+                execution_plan,
+                &checksums,
+                &executor,
+            ))
+            .map_err(|error| py_value_error(error.to_string()))?;
 
         pythonize(py, &results)
             .map(|obj| obj.unbind())
@@ -256,6 +267,17 @@ impl PyMigrationStateManager {
             .map_err(|error| py_value_error(error.to_string()))
     }
 
+    /// Load all migration run-log records as a list of dicts.
+    fn load_runs(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let records = self
+            .runtime
+            .block_on(self.store.load_runs())
+            .map_err(|error| py_value_error(error.to_string()))?;
+        pythonize(py, &records)
+            .map(|obj| obj.unbind())
+            .map_err(|error| py_value_error(error.to_string()))
+    }
+
     /// Record a migration as applied.
     ///
     /// Accepts a serialized `AppliedMigrationRecord` dict. When `applied_at` is
@@ -274,6 +296,15 @@ impl PyMigrationStateManager {
     fn record_unapplied(&self, app_label: &str, name: &str) -> PyResult<()> {
         self.runtime
             .block_on(self.store.record_unapplied(app_label, name))
+            .map_err(|error| py_value_error(error.to_string()))
+    }
+
+    /// Insert or replace one migration run-log record.
+    fn record_run(&self, record: Bound<'_, PyAny>) -> PyResult<()> {
+        let record: MigrationRunRecord = depythonize(&record)
+            .map_err(|error| py_value_error(format!("Invalid migration run record: {error}")))?;
+        self.runtime
+            .block_on(self.store.record_run(record))
             .map_err(|error| py_value_error(error.to_string()))
     }
 }
@@ -299,6 +330,19 @@ fn depythonize_applied_records(
     }
     depythonize(&applied_records)
         .map_err(|error| py_value_error(format!("Invalid applied migration records: {error}")))
+}
+
+fn migration_checksums(graph: &MigrationGraph) -> BTreeMap<(String, String), String> {
+    graph
+        .migrations
+        .iter()
+        .map(|migration| {
+            (
+                (migration.app_label.clone(), migration.name.clone()),
+                migration.checksum.clone().unwrap_or_default(),
+            )
+        })
+        .collect()
 }
 
 fn py_value_error(message: impl Into<String>) -> PyErr {

--- a/type-bridge-core/crates/server/Cargo.toml
+++ b/type-bridge-core/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-server"
-version = "1.5.2"
+version = "1.5.3"
 edition = "2024"
 description = "Query-intercepting proxy server for TypeDB with validation and audit logging"
 license.workspace = true
@@ -25,8 +25,8 @@ axum-transport = ["dep:axum", "dep:tower-http"]
 test-helpers = []
 
 [dependencies]
-type-bridge-core-lib = { path = "../core", version = "1.5.2" }
-type-bridge-typedb-runtime = { path = "../typedb-runtime", version = "1.5.2", default-features = false, optional = true }
+type-bridge-core-lib = { path = "../core", version = "1.5.3" }
+type-bridge-typedb-runtime = { path = "../typedb-runtime", version = "1.5.3", default-features = false, optional = true }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/type-bridge-core/crates/toml-transpiler/Cargo.toml
+++ b/type-bridge-core/crates/toml-transpiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-toml-transpiler"
-version = "1.5.2"
+version = "1.5.3"
 edition = "2024"
 description = "TOML schema DSL transpiler producing TypeQL define blocks for type-bridge"
 license.workspace = true

--- a/type-bridge-core/crates/typedb-runtime/Cargo.toml
+++ b/type-bridge-core/crates/typedb-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-typedb-runtime"
-version = "1.5.2"
+version = "1.5.3"
 edition = "2024"
 description = "Shared TypeDB runtime driver layer for type-bridge"
 license.workspace = true
@@ -17,7 +17,7 @@ band7 = ["dep:type-bridge-typedb-driver-b7"]
 band8 = ["dep:typedb-driver"]
 
 [dependencies]
-type-bridge-core-lib = { path = "../core", version = "1.5.2" }
+type-bridge-core-lib = { path = "../core", version = "1.5.3" }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/type-bridge-core/pyproject.toml
+++ b/type-bridge-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "type-bridge-core"
-version = "1.5.2"
+version = "1.5.3"
 description = "Rust core for type-bridge ORM"
 requires-python = ">=3.12,<3.14"
 classifiers = [

--- a/type_bridge/__init__.py
+++ b/type_bridge/__init__.py
@@ -53,7 +53,7 @@ from type_bridge.query import Query, QueryBuilder
 from type_bridge.session import Connection, Database, TransactionContext
 from type_bridge.typedb_driver import Credentials, TransactionType, TypeDB, create_driver_options
 
-__version__ = "1.5.2"
+__version__ = "1.5.3"
 
 __all__ = [
     # Database and session

--- a/type_bridge/migration/__init__.py
+++ b/type_bridge/migration/__init__.py
@@ -66,7 +66,7 @@ CLI Usage:
     python -m type_bridge.migration makemigrations --name add_phone --models myapp.models
 """
 
-from type_bridge.migration import operations
+from type_bridge.migration import operations, ref
 from type_bridge.migration.base import Migration, MigrationDependency
 from type_bridge.migration.breaking import (
     BreakingChangeAnalyzer,
@@ -104,7 +104,7 @@ from type_bridge.migration.loader import (
     MigrationLoader,
     MigrationLoadError,
 )
-from type_bridge.migration.operations import CopyAttribute
+from type_bridge.migration.operations import CopyAttribute, RunPython
 from type_bridge.migration.registry import ModelRegistry
 from type_bridge.migration.schema_manager import SchemaManager
 from type_bridge.migration.simple_migration import (
@@ -112,6 +112,7 @@ from type_bridge.migration.simple_migration import (
 )
 from type_bridge.migration.state import (
     MigrationRecord,
+    MigrationRunRecord,
     MigrationState,
     MigrationStateManager,
 )
@@ -144,6 +145,7 @@ __all__ = [
     "MigrationState",
     "MigrationStateManager",
     "MigrationRecord",
+    "MigrationRunRecord",
     # Loader
     "MigrationLoader",
     "LoadedMigration",
@@ -169,6 +171,8 @@ __all__ = [
     "type_exists",
     # Operations module
     "operations",
+    "ref",
     # Ops shorthand
     "CopyAttribute",
+    "RunPython",
 ]

--- a/type_bridge/migration/_lower.py
+++ b/type_bridge/migration/_lower.py
@@ -69,6 +69,36 @@ def lower_migration_graph(loaded: Sequence[LoadedMigration]) -> dict[str, Any]:
     )
 
 
+def lower_validation_graph(loaded: Sequence[LoadedMigration]) -> dict[str, Any]:
+    """Lower loaded migrations into the graph shape needed for validation.
+
+    Dependency and checksum validation only needs migration metadata, not
+    executable operations. This keeps validation available for Python-only
+    operations such as ``ops.RunPython`` that cannot be serialized into Rust
+    ``OperationSpec`` values.
+    """
+    migrations: list[dict[str, Any]] = []
+    for item in loaded:
+        migration = item.migration
+        migrations.append(
+            {
+                "app_label": migration.app_label,
+                "name": migration.name,
+                "dependencies": [
+                    {
+                        "app_label": dependency.app_label,
+                        "migration_name": dependency.migration_name,
+                    }
+                    for dependency in migration.get_dependencies()
+                ],
+                "operations": [],
+                "checksum": item.checksum,
+                "reversible": migration.reversible,
+            }
+        )
+    return _rust_runtime.normalize_migration_graph({"migrations": migrations})
+
+
 def lower_execution_migration(loaded: LoadedMigration) -> dict[str, Any]:
     """Lower one loaded migration into the Rust migration IR used for execution.
 
@@ -96,31 +126,30 @@ def _operation_spec(operation: ops.Operation) -> dict[str, Any]:
     if isinstance(operation, ops.AddAttribute):
         return {
             "kind": "add_attribute",
-            "attribute": _attribute_entry(operation.attribute),
+            "attribute": _attribute_entry(_attribute_class(operation.attribute)),
         }
     if isinstance(operation, ops.RemoveAttribute):
         return {
             "kind": "remove_attribute",
-            "attr_name": operation.attribute.get_attribute_name(),
+            "attr_name": _attribute_name(operation.attribute),
         }
     if isinstance(operation, ops.AddEntity):
+        entity = _model_class(operation.entity)
         return {
             "kind": "add_entity",
-            "entity": _schema_info_for_models([operation.entity])["entities"][
-                operation.entity.get_type_name()
-            ],
+            "entity": _schema_info_for_models([entity])["entities"][entity.get_type_name()],
         }
     if isinstance(operation, ops.RemoveEntity):
         return {
             "kind": "remove_entity",
-            "type_name": operation.entity.get_type_name(),
+            "type_name": _type_name(operation.entity),
         }
     if isinstance(operation, ops.AddOwnership):
         return {
             "kind": "add_ownership",
             "owner_type": operation.owner.get_type_name(),
             "attribute": _owned_attribute_entry(
-                operation.attribute,
+                _attribute_class(operation.attribute),
                 optional=operation.optional,
                 key=operation.key,
                 unique=operation.unique,
@@ -131,33 +160,32 @@ def _operation_spec(operation: ops.Operation) -> dict[str, Any]:
     if isinstance(operation, ops.RemoveOwnership):
         return {
             "kind": "remove_ownership",
-            "owner_type": operation.owner.get_type_name(),
-            "attr_name": operation.attribute.get_attribute_name(),
+            "owner_type": _type_name(operation.owner),
+            "attr_name": _attribute_name(operation.attribute),
         }
     if isinstance(operation, ops.ModifyOwnership):
         return {
             "kind": "modify_ownership",
-            "owner_type": operation.owner.get_type_name(),
-            "attr_name": operation.attribute.get_attribute_name(),
+            "owner_type": _type_name(operation.owner),
+            "attr_name": _attribute_name(operation.attribute),
             "old_annotations": operation.old_annotations,
             "new_annotations": operation.new_annotations,
         }
     if isinstance(operation, ops.AddRelation):
+        relation = _model_class(operation.relation)
         return {
             "kind": "add_relation",
-            "relation": _schema_info_for_models([operation.relation])["relations"][
-                operation.relation.get_type_name()
-            ],
+            "relation": _schema_info_for_models([relation])["relations"][relation.get_type_name()],
         }
     if isinstance(operation, ops.RemoveRelation):
         return {
             "kind": "remove_relation",
-            "type_name": operation.relation.get_type_name(),
+            "type_name": _type_name(operation.relation),
         }
     if isinstance(operation, ops.AddRole):
         return {
             "kind": "add_role",
-            "relation_type": operation.relation.get_type_name(),
+            "relation_type": _type_name(operation.relation),
             "role": {
                 "role_name": operation.role_name,
                 "player_type_names": operation.player_types,
@@ -167,20 +195,20 @@ def _operation_spec(operation: ops.Operation) -> dict[str, Any]:
     if isinstance(operation, ops.RemoveRole):
         return {
             "kind": "remove_role",
-            "relation_type": operation.relation.get_type_name(),
+            "relation_type": _type_name(operation.relation),
             "role_name": operation.role_name,
         }
     if isinstance(operation, ops.AddRolePlayer):
         return {
             "kind": "add_role_player",
-            "relation_type": operation.relation.get_type_name(),
+            "relation_type": _type_name(operation.relation),
             "role_name": operation.role_name,
             "player_type_name": operation.player_type,
         }
     if isinstance(operation, ops.RemoveRolePlayer):
         return {
             "kind": "remove_role_player",
-            "relation_type": operation.relation.get_type_name(),
+            "relation_type": _type_name(operation.relation),
             "role_name": operation.role_name,
             "player_type_name": operation.player_type,
         }
@@ -221,6 +249,11 @@ def _schema_info_for_models(models: Sequence[type[Any]]) -> dict[str, Any]:
 
     registry = _rust_runtime.rust_core().PyDescriptorRegistry()
     for model in models:
+        if not isinstance(model, type):
+            raise TypeError(
+                "Schema-bearing migration operations require full model classes "
+                "when no sidecar execution spec is present"
+            )
         descriptor = _rust_runtime.descriptor_for_model(model)
         if issubclass(model, Relation):
             registry.register_relation(descriptor)
@@ -236,6 +269,38 @@ def _schema_info_for_models(models: Sequence[type[Any]]) -> dict[str, Any]:
 
 def _attribute_entry(attribute: type[Any]) -> dict[str, Any]:
     return _rust_runtime.attribute_schema_entry(attribute)
+
+
+def _model_class(value: object) -> type[Any]:
+    if not isinstance(value, type):
+        raise TypeError(
+            "Schema-bearing migration operations require full model classes "
+            "when no sidecar execution spec is present"
+        )
+    return value
+
+
+def _attribute_class(value: object) -> type[Any]:
+    if not isinstance(value, type):
+        raise TypeError(
+            "Schema-bearing migration operations require full attribute classes "
+            "when no sidecar execution spec is present"
+        )
+    return value
+
+
+def _type_name(value: object) -> str:
+    get_type_name = getattr(value, "get_type_name", None)
+    if get_type_name is None:
+        raise TypeError(f"{value!r} is not a TypeBridge type or migration type ref")
+    return str(get_type_name())
+
+
+def _attribute_name(value: object) -> str:
+    get_attribute_name = getattr(value, "get_attribute_name", None)
+    if get_attribute_name is None:
+        raise TypeError(f"{value!r} is not a TypeBridge attribute or migration attribute ref")
+    return str(get_attribute_name())
 
 
 def _owned_attribute_entry(

--- a/type_bridge/migration/executor.py
+++ b/type_bridge/migration/executor.py
@@ -2,15 +2,22 @@
 
 from __future__ import annotations
 
+import importlib
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from type_bridge import _rust_runtime
+from type_bridge.migration import operations as ops
 from type_bridge.migration.loader import LoadedMigration, MigrationLoader
-from type_bridge.migration.state import MigrationRecord, MigrationState, MigrationStateManager
+from type_bridge.migration.state import (
+    MigrationRecord,
+    MigrationRunRecord,
+    MigrationState,
+    MigrationStateManager,
+)
 
 if TYPE_CHECKING:
     from type_bridge.session import Database
@@ -136,6 +143,10 @@ class MigrationExecutor:
         if self.dry_run:
             return self._dry_run(plan)
 
+        if _loaded_contains_run_python(all_migrations):
+            self._preflight_python_plan(plan)
+            return self._migrate_with_python_operations(plan, all_migrations)
+
         graph = lower_execution_graph(all_migrations)
         applied_records = [_applied_record_dict(record) for record in state.applied]
 
@@ -157,6 +168,301 @@ class MigrationExecutor:
                 raise MigrationError(f"Migration failed: {result.error}")
 
         return results
+
+    def _migrate_with_python_operations(
+        self,
+        plan: MigrationPlan,
+        all_migrations: list[LoadedMigration],
+    ) -> list[MigrationResult]:
+        """Execute a plan that contains at least one ``ops.RunPython`` operation.
+
+        Rust remains the default executor for non-Python migrations (including
+        sidecar-backed migrations).  A plan containing ``RunPython`` needs
+        Python call boundaries only at those migration boundaries.
+        """
+        from type_bridge.migration._lower import lower_execution_migration
+
+        results: list[MigrationResult] = []
+        checksums = {
+            (loaded.migration.app_label, loaded.migration.name): loaded.checksum
+            for loaded in all_migrations
+        }
+        index_by_key = {
+            (loaded.migration.app_label, loaded.migration.name): i
+            for i, loaded in enumerate(all_migrations)
+        }
+
+        has_non_python = any(
+            not _migration_contains_run_python(loaded.migration)
+            for loaded in [*plan.to_rollback, *plan.to_apply]
+        )
+
+        runner = None
+        graph = None
+        if has_non_python:
+            runner = _rust_runtime.migration_runner_for(self.db)
+            graph = self._execution_graph_for_mixed_plan(
+                all_migrations,
+                lower_execution_migration=lower_execution_migration,
+            )
+
+        def run_rust_segment(target: str | None) -> list[MigrationResult]:
+            if runner is None or graph is None:
+                raise MigrationError("Mixed migration plan has no Rust runner configured")
+            state = self.state_manager.load_state()
+            applied_records = [_applied_record_dict(record) for record in state.applied]
+            rust_results = runner.apply(graph, applied_records, target)
+
+            mapped: list[MigrationResult] = []
+            for rust_result in rust_results:
+                result = self._record_result(rust_result, checksums)
+                mapped.append(result)
+                if not result.success:
+                    if result.action == "rolled_back":
+                        raise MigrationError(f"Rollback failed: {result.error}")
+                    raise MigrationError(f"Migration failed: {result.error}")
+            return mapped
+
+        non_python_segment: list[LoadedMigration] = []
+
+        for loaded in plan.to_rollback:
+            if _migration_contains_run_python(loaded.migration):
+                if non_python_segment:
+                    segment_target_idx = min(
+                        index_by_key[(segment.migration.app_label, segment.migration.name)]
+                        for segment in non_python_segment
+                    )
+                    target = (
+                        all_migrations[segment_target_idx - 1].migration.name
+                        if segment_target_idx > 0
+                        else None
+                    )
+                    results.extend(run_rust_segment(target))
+                    non_python_segment = []
+
+                result = self._execute_loaded_python_path(loaded, reverse=True)
+                results.append(result)
+                if not result.success:
+                    raise MigrationError(f"Rollback failed: {result.error}")
+            else:
+                non_python_segment.append(loaded)
+
+        if non_python_segment:
+            segment_target_idx = min(
+                index_by_key[(segment.migration.app_label, segment.migration.name)]
+                for segment in non_python_segment
+            )
+            target = (
+                all_migrations[segment_target_idx - 1].migration.name
+                if segment_target_idx > 0
+                else None
+            )
+            results.extend(run_rust_segment(target))
+
+        non_python_segment = []
+        for loaded in plan.to_apply:
+            if _migration_contains_run_python(loaded.migration):
+                if non_python_segment:
+                    target = non_python_segment[-1].migration.name
+                    results.extend(run_rust_segment(target))
+                    non_python_segment = []
+
+                result = self._execute_loaded_python_path(loaded, reverse=False)
+                results.append(result)
+                if not result.success:
+                    raise MigrationError(f"Migration failed: {result.error}")
+            else:
+                non_python_segment.append(loaded)
+
+        if non_python_segment:
+            target = non_python_segment[-1].migration.name
+            results.extend(run_rust_segment(target))
+
+        return results
+
+    def _execution_graph_for_mixed_plan(
+        self,
+        all_migrations: list[LoadedMigration],
+        *,
+        lower_execution_migration: Callable[[LoadedMigration], dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Lower all migrations into one executable graph for mixed plans.
+
+        ``ops.RunPython`` migrations cannot be lowered into Rust operation
+        specs, so they are represented as no-op placeholders in this mixed
+        graph. Other migrations keep their full executable lowering path.
+        """
+        specifications: list[dict[str, Any]] = []
+        for loaded in all_migrations:
+            if _migration_contains_run_python(loaded.migration):
+                migration = loaded.migration
+                specifications.append(
+                    {
+                        "app_label": migration.app_label,
+                        "name": migration.name,
+                        "dependencies": [
+                            {
+                                "app_label": dependency.app_label,
+                                "migration_name": dependency.migration_name,
+                            }
+                            for dependency in migration.get_dependencies()
+                        ],
+                        "operations": [],
+                        "checksum": loaded.checksum,
+                        "reversible": migration.reversible,
+                    }
+                )
+                continue
+
+            specifications.append(lower_execution_migration(loaded))
+
+        return _rust_runtime.normalize_migration_graph({"migrations": specifications})
+
+    def _preflight_python_plan(self, plan: MigrationPlan) -> None:
+        """Validate declared RunPython imports/resources before any step mutates data."""
+        for loaded in [*plan.to_rollback, *plan.to_apply]:
+            for operation in getattr(loaded.migration, "operations", []):
+                if isinstance(operation, ops.RunPython):
+                    self._preflight_run_python_operation(loaded, operation)
+
+    def _preflight_run_python_operation(
+        self,
+        loaded: LoadedMigration,
+        operation: ops.RunPython,
+    ) -> None:
+        operation_label = operation.description or operation._callable_name(operation.code)
+
+        for module_name in operation.import_checks:
+            if not module_name:
+                raise MigrationError(
+                    f"RunPython operation {operation_label} in {loaded.migration.name} "
+                    "declares an empty import check"
+                )
+            try:
+                importlib.import_module(module_name)
+            except (ImportError, AttributeError, ValueError) as exc:
+                raise MigrationError(
+                    f"RunPython operation {operation_label} in {loaded.migration.name} "
+                    f"failed import check {module_name!r}: {exc}"
+                ) from exc
+
+        for resource in operation.resources:
+            if not resource:
+                raise MigrationError(
+                    f"RunPython operation {operation_label} in {loaded.migration.name} "
+                    "declares an empty resource path"
+                )
+            path = _resolve_migration_resource(loaded.path, resource)
+            if not path.is_file():
+                raise MigrationError(
+                    f"RunPython operation {operation_label} in {loaded.migration.name} "
+                    f"requires missing resource {resource!r} at {path}"
+                )
+            try:
+                with path.open("rb"):
+                    pass
+            except OSError as exc:
+                raise MigrationError(
+                    f"RunPython operation {operation_label} in {loaded.migration.name} "
+                    f"cannot read resource {resource!r} at {path}: {exc}"
+                ) from exc
+
+    def _execute_loaded_python_path(
+        self,
+        loaded: LoadedMigration,
+        *,
+        reverse: bool,
+    ) -> MigrationResult:
+        migration = loaded.migration
+        action = "rolled_back" if reverse else "applied"
+        direction = "rollback" if reverse else "apply"
+        run = self.state_manager.record_run_started(
+            migration.app_label,
+            migration.name,
+            loaded.checksum,
+            direction,
+        )
+
+        try:
+            if reverse:
+                self._execute_migration_reverse(migration)
+                self._record_state(
+                    migration.name,
+                    action,
+                    lambda: self.state_manager.record_unapplied(
+                        migration.app_label,
+                        migration.name,
+                    ),
+                )
+            else:
+                self._execute_migration_forward(migration)
+                self._record_state(
+                    migration.name,
+                    action,
+                    lambda: self.state_manager.record_applied(
+                        migration.app_label,
+                        migration.name,
+                        loaded.checksum,
+                    ),
+                )
+        except Exception as exc:  # noqa: BLE001 - mapped to MigrationResult error
+            self._record_run_finished(run, "failed", str(exc))
+            return MigrationResult(
+                name=migration.name,
+                action=action,
+                success=False,
+                error=str(exc),
+            )
+
+        self._record_run_finished(run, "succeeded", None)
+        return MigrationResult(name=migration.name, action=action, success=True)
+
+    def _execute_migration_forward(self, migration: object) -> None:
+        models = getattr(migration, "models", [])
+        if models:
+            self._execute_typeql(_schema_typeql_for_models(models), "schema")
+
+        for operation in getattr(migration, "operations", []):
+            self._execute_operation_forward(operation)
+
+    def _execute_migration_reverse(self, migration: object) -> None:
+        models = getattr(migration, "models", [])
+        if models:
+            raise MigrationError(
+                f"Migration {getattr(migration, 'name', '<unknown>')} is not reversible"
+            )
+
+        operations = list(getattr(migration, "operations", []))
+        for operation in reversed(operations):
+            self._execute_operation_reverse(operation)
+
+    def _execute_operation_forward(self, operation: ops.Operation) -> None:
+        if isinstance(operation, ops.RunPython):
+            operation.run(self.db)
+            return
+
+        typeql = operation.to_typeql()
+        if typeql.strip():
+            self._execute_typeql(typeql, _typeql_transaction_type(typeql))
+
+    def _execute_operation_reverse(self, operation: ops.Operation) -> None:
+        if isinstance(operation, ops.RunPython):
+            operation.rollback(self.db)
+            return
+
+        typeql = operation.to_rollback_typeql()
+        if typeql is None:
+            raise MigrationError(f"Operation {type(operation).__name__} is not reversible")
+        if typeql.strip():
+            self._execute_typeql(typeql, _typeql_transaction_type(typeql))
+
+    def _execute_typeql(self, typeql: str, transaction_type: str) -> None:
+        execute_query = getattr(self.db, "execute_query", None)
+        if execute_query is None:
+            raise MigrationError(
+                "Cannot execute TypeQL migration operation: database object has no execute_query()"
+            )
+        execute_query(typeql, transaction_type=transaction_type)
 
     def _record_result(
         self,
@@ -215,6 +521,20 @@ class MigrationExecutor:
             verb = "apply" if action == "applied" else "rollback"
             raise MigrationError(
                 f"Migration {name} {verb} succeeded but recording its state failed: {exc}"
+            ) from exc
+
+    def _record_run_finished(
+        self,
+        run: MigrationRunRecord,
+        status: str,
+        error: str | None,
+    ) -> None:
+        try:
+            self.state_manager.record_run_finished(run, status, error)
+        except Exception as exc:  # noqa: BLE001 - re-raised as MigrationError below
+            raise MigrationError(
+                f"Migration {run.name} {run.direction} finished but recording its run log failed: "
+                f"{exc}"
             ) from exc
 
     def _dry_run(self, plan: MigrationPlan) -> list[MigrationResult]:
@@ -291,6 +611,9 @@ class MigrationExecutor:
         TypeQL in reverse step order when ``reverse`` is ``True``, or ``None``
         when any step is non-reversible.
         """
+        if _migration_contains_run_python(loaded.migration):
+            return _preview_python_migration(loaded, reverse=reverse)
+
         from type_bridge.migration._lower import lower_execution_migration
 
         spec = lower_execution_migration(loaded)
@@ -385,9 +708,14 @@ class MigrationExecutor:
         state: MigrationState,
     ) -> None:
         """Validate graph and checksum drift before any migration step runs."""
-        from type_bridge.migration._lower import lower_migration_graph
+        if _loaded_contains_run_python(all_migrations):
+            from type_bridge.migration._lower import lower_validation_graph
 
-        graph = lower_migration_graph(all_migrations)
+            graph = lower_validation_graph(all_migrations)
+        else:
+            from type_bridge.migration._lower import lower_migration_graph
+
+            graph = lower_migration_graph(all_migrations)
         applied_records = [_applied_record_dict(record) for record in state.applied]
         errors = _rust_runtime.validate_migration_graph(graph, applied_records)
         if errors:
@@ -425,3 +753,66 @@ def _applied_record_dict(record: MigrationRecord) -> dict[str, str]:
         "checksum": record.checksum,
         "applied_at": record.applied_at,
     }
+
+
+def _loaded_contains_run_python(loaded: list[LoadedMigration]) -> bool:
+    return any(_migration_contains_run_python(item.migration) for item in loaded)
+
+
+def _migration_contains_run_python(migration: object) -> bool:
+    return any(
+        isinstance(operation, ops.RunPython) for operation in getattr(migration, "operations", [])
+    )
+
+
+def _schema_typeql_for_models(models: list[type[object]]) -> str:
+    from type_bridge.migration._lower import _schema_info_for_models
+
+    return _rust_runtime.generate_define_block(_schema_info_for_models(models))
+
+
+def _resolve_migration_resource(migration_path: Path, resource: str) -> Path:
+    path = Path(resource)
+    if path.is_absolute():
+        return path
+    return migration_path.parent / path
+
+
+def _typeql_transaction_type(typeql: str) -> str:
+    first_statement = next(
+        (
+            line.strip().lower()
+            for line in typeql.splitlines()
+            if line.strip() and not line.strip().startswith(("#", "//"))
+        ),
+        "",
+    )
+    if first_statement.startswith(("define", "undefine", "redefine")):
+        return "schema"
+    return "write"
+
+
+def _preview_python_migration(loaded: LoadedMigration, *, reverse: bool) -> str | None:
+    operations = list(getattr(loaded.migration, "operations", []))
+    if reverse:
+        previews: list[str] = []
+        for operation in reversed(operations):
+            if isinstance(operation, ops.RunPython):
+                preview = operation.to_rollback_typeql()
+                if preview is None:
+                    return None
+                previews.append(preview)
+                continue
+            typeql = operation.to_rollback_typeql()
+            if typeql is None:
+                return None
+            previews.append(typeql)
+        return "\n\n".join(previews)
+
+    previews = []
+    models = getattr(loaded.migration, "models", [])
+    if models:
+        previews.append(_schema_typeql_for_models(models))
+    for operation in operations:
+        previews.append(operation.to_typeql())
+    return "\n\n".join(preview for preview in previews if preview.strip())

--- a/type_bridge/migration/generator.py
+++ b/type_bridge/migration/generator.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 from type_bridge import _rust_runtime
 from type_bridge.attribute.base import Attribute
 from type_bridge.migration import operations as ops
+from type_bridge.migration import ref
 from type_bridge.migration.info import SchemaInfo
 from type_bridge.migration.introspection import IntrospectedSchema, SchemaIntrospector
 from type_bridge.migration.loader import MigrationLoader
@@ -20,6 +21,26 @@ if TYPE_CHECKING:
     from type_bridge.session import Database
 
 logger = logging.getLogger(__name__)
+
+_MIGRATION_STATE_ENTITIES = {
+    "type_bridge_migration",
+    "type_bridge_migration_run",
+}
+_MIGRATION_STATE_ATTRIBUTES = {
+    "migration_id",
+    "migration_app_label",
+    "migration_name",
+    "migration_applied_at",
+    "migration_checksum",
+    "migration_run_id",
+    "migration_direction",
+    "migration_status",
+    "migration_started_at",
+    "migration_finished_at",
+    "migration_error",
+    "migration_executor_ip",
+    "migration_executor_mac",
+}
 
 
 def _add_ownership_operation(
@@ -98,9 +119,57 @@ def _attribute_type_change_keyword(changes: dict) -> str:
     return "define"
 
 
-def _class_ref(cls: type) -> str:
-    """Render a class reference for generated migration source."""
-    return cls.__name__
+def _type_label(value: Any) -> str:
+    return str(value.get_type_name())
+
+
+def _attribute_label(value: Any) -> str:
+    return str(value.get_attribute_name())
+
+
+def _player_type_label(value: object) -> str:
+    get_type_name = getattr(value, "get_type_name", None)
+    if callable(get_type_name):
+        return str(get_type_name())
+    return str(value)
+
+
+def _type_ref(value: object) -> str:
+    from type_bridge.models import Relation
+
+    label = _type_label(value)
+    if getattr(value, "kind", None) == "relation":
+        return f"ref.relation({label!r})"
+    if isinstance(value, type) and issubclass(value, Relation):
+        return f"ref.relation({label!r})"
+    return f"ref.entity({label!r})"
+
+
+def _attribute_ref(value: object) -> str:
+    return f"ref.attribute({_attribute_label(value)!r})"
+
+
+def _without_migration_state_schema(schema: IntrospectedSchema) -> IntrospectedSchema:
+    """Remove TypeBridge's migration ledger types from a live schema snapshot."""
+    return IntrospectedSchema(
+        entities={
+            name: entity
+            for name, entity in schema.entities.items()
+            if name not in _MIGRATION_STATE_ENTITIES
+        },
+        relations=dict(schema.relations),
+        attributes={
+            name: attribute
+            for name, attribute in schema.attributes.items()
+            if name not in _MIGRATION_STATE_ATTRIBUTES
+        },
+        ownerships=[
+            ownership
+            for ownership in schema.ownerships
+            if ownership.owner_name not in _MIGRATION_STATE_ENTITIES
+            and ownership.attribute_name not in _MIGRATION_STATE_ATTRIBUTES
+        ],
+    )
 
 
 class MigrationGenerator:
@@ -165,6 +234,10 @@ class MigrationGenerator:
             models_code = ""
             imports_code = self._generate_empty_imports()
             description = "empty migration"
+            self._pre_version = f"v{next_num - 1:04d}" if next_num > 1 else None
+            self._post_version = f"v{next_num:04d}"
+            self._import_records = {}
+            self._symbol_aliases = {}
         else:
             # Detect changes - now always returns operations
             operations, _ = self._detect_changes(models, existing)
@@ -173,7 +246,30 @@ class MigrationGenerator:
                 logger.info("No changes detected")
                 return None
 
-            # Always use operations-based migration.
+            # Phase 2: Generate snapshot first
+            from type_bridge.migration.snapshots import generate_snapshot
+
+            schema_mgr = SchemaManager(self.db)
+            schema_mgr.register(*models)
+            schema_text = schema_mgr.generate_schema()
+
+            migration_name = f"{next_num:04d}_{name}"
+            version_str = f"v{next_num:04d}"
+
+            generate_snapshot(
+                migrations_dir=self.migrations_dir,
+                version=version_str,
+                migration_name=migration_name,
+                schema_text=schema_text,
+            )
+
+            self._pre_version = f"v{next_num - 1:04d}" if next_num > 1 else None
+            self._post_version = f"v{next_num:04d}"
+            self._import_records = {}
+            self._symbol_aliases = {}
+
+            # Collect imports and render
+            self._collect_imports_and_aliases(operations)
             operations_code = self._render_operations(operations)
             models_code = ""
             imports_code = self._generate_operations_imports(operations)
@@ -235,9 +331,11 @@ class MigrationGenerator:
         schema_mgr.register(*models)
         new_info = schema_mgr.collect_schema_info()
 
-        # Introspect actual database schema using model-aware approach
+        # Introspect the full application schema so removed target types are
+        # still visible to the diff. TypeBridge's own migration state schema is
+        # filtered out because it is storage infrastructure, not app schema.
         introspector = SchemaIntrospector(self.db)
-        db_schema = introspector.introspect_for_models(models)
+        db_schema = _without_migration_state_schema(introspector.introspect())
 
         # Generate operations - this works for both initial and incremental migrations
         # For empty database, all model types will be "new" and get Add operations
@@ -310,8 +408,8 @@ class MigrationGenerator:
                     operations.append(operation)
                     logger.debug(f"Will add ownership: {entity_name} owns {attr_name}")
             for attr_name in changes.get("removed_attributes", []):
-                if attr := attributes.get(attr_name):
-                    operations.append(ops.RemoveOwnership(entity, attr))
+                attr = attributes.get(attr_name) or ref.attribute(attr_name)
+                operations.append(ops.RemoveOwnership(entity, attr))
             for attr_name, old_flags, new_flags in changes.get("modified_attributes", []):
                 if attr := attributes.get(attr_name):
                     operations.append(ops.ModifyOwnership(entity, attr, old_flags, new_flags))
@@ -325,8 +423,8 @@ class MigrationGenerator:
                     operations.append(operation)
                     logger.debug(f"Will add ownership: {relation_name} owns {attr_name}")
             for attr_name in changes.get("removed_attributes", []):
-                if attr := attributes.get(attr_name):
-                    operations.append(ops.RemoveOwnership(relation, attr))
+                attr = attributes.get(attr_name) or ref.attribute(attr_name)
+                operations.append(ops.RemoveOwnership(relation, attr))
             for attr_name, old_flags, new_flags in changes.get("modified_attributes", []):
                 if attr := attributes.get(attr_name):
                     operations.append(ops.ModifyOwnership(relation, attr, old_flags, new_flags))
@@ -343,6 +441,45 @@ class MigrationGenerator:
                     operations.append(ops.AddRolePlayer(relation, role_name, player_type))
                 for player_type in player_change.get("removed_player_types", []):
                     operations.append(ops.RemoveRolePlayer(relation, role_name, player_type))
+
+        for relation_name in rust_diff.get("removed_relations", []):
+            relation_ref = ref.relation(relation_name)
+            if relation := db_schema.relations.get(relation_name):
+                for role in relation.roles.values():
+                    for player_type in role.player_types:
+                        operations.append(
+                            ops.RemoveRolePlayer(
+                                relation_ref,
+                                role.name,
+                                _player_type_label(player_type),
+                            )
+                        )
+                    operations.append(ops.RemoveRole(relation_ref, role.name))
+                for ownership in db_schema.get_ownerships_for(relation_name):
+                    operations.append(
+                        ops.RemoveOwnership(
+                            relation_ref,
+                            ref.attribute(ownership.attribute_name),
+                        )
+                    )
+            operations.append(ops.RemoveRelation(ref.relation(relation_name)))
+            logger.debug(f"Will remove relation: {relation_name}")
+
+        for entity_name in rust_diff.get("removed_entities", []):
+            entity_ref = ref.entity(entity_name)
+            for ownership in db_schema.get_ownerships_for(entity_name):
+                operations.append(
+                    ops.RemoveOwnership(
+                        entity_ref,
+                        ref.attribute(ownership.attribute_name),
+                    )
+                )
+            operations.append(ops.RemoveEntity(entity_ref))
+            logger.debug(f"Will remove entity: {entity_name}")
+
+        for attr_name in rust_diff.get("removed_attributes", []):
+            operations.append(ops.RemoveAttribute(ref.attribute(attr_name)))
+            logger.debug(f"Will remove attribute: {attr_name}")
 
         return operations
 
@@ -369,60 +506,237 @@ class MigrationGenerator:
         lines.append("    ]")
         return "\n".join(lines)
 
+    def _collect_imports_and_aliases(self, operations: list[ops.Operation]) -> None:
+        """Scan operations to collect all needed snapshot imports and compute aliases."""
+        self._import_records = {}
+        self._symbol_aliases = {}
+
+        # 1. Collect imports by scanning each operation
+        for op in operations:
+            self._collect_op_imports(op)
+
+        # 2. Compute aliases for colliding symbol names
+        # Count occurrences of each symbol name across all versions
+        symbol_counts: dict[str, int] = {}
+        symbol_versions: dict[str, list[str]] = {}
+        for version, submodules in self._import_records.items():
+            for submodule, symbols in submodules.items():
+                for symbol in symbols:
+                    symbol_counts[symbol] = symbol_counts.get(symbol, 0) + 1
+                    symbol_versions.setdefault(symbol, []).append(version)
+
+        # For symbols with count > 1, latest version gets the unaliased symbol,
+        # and others get aliased to Symbol{Version}
+        for symbol, count in symbol_counts.items():
+            if count > 1:
+                versions = sorted(symbol_versions[symbol])
+                latest_version = versions[-1]
+                # Register aliases
+                for version in versions:
+                    if version != latest_version:
+                        alias = f"{symbol}{version.upper()}"
+                        self._symbol_aliases[(version, symbol)] = alias
+
+    def _collect_op_imports(self, op: ops.Operation) -> None:
+        # Determine the version (pre or post) for the operation
+        if isinstance(
+            op,
+            (
+                ops.AddEntity,
+                ops.AddRelation,
+                ops.AddAttribute,
+                ops.AddOwnership,
+                ops.AddRole,
+                ops.AddRolePlayer,
+            ),
+        ):
+            version = self._post_version
+        else:
+            version = self._pre_version
+
+        if not version:
+            return
+
+        # Helper to try to resolve type references
+        def record_ref(value: object):
+            if not isinstance(value, str):
+                self._resolve_snapshot_symbol(value, version)
+
+        if isinstance(op, (ops.AddEntity, ops.RemoveEntity)):
+            record_ref(op.entity)
+        elif isinstance(op, (ops.AddRelation, ops.RemoveRelation)):
+            record_ref(op.relation)
+        elif isinstance(op, (ops.AddAttribute, ops.RemoveAttribute)):
+            record_ref(op.attribute)
+        elif isinstance(op, (ops.AddOwnership, ops.RemoveOwnership)):
+            record_ref(op.owner)
+            record_ref(op.attribute)
+        elif isinstance(op, ops.ModifyOwnership):
+            record_ref(op.owner)
+            record_ref(op.attribute)
+        elif isinstance(op, (ops.AddRole, ops.RemoveRole)):
+            record_ref(op.relation)
+        elif isinstance(op, (ops.AddRolePlayer, ops.RemoveRolePlayer)):
+            record_ref(op.relation)
+        elif isinstance(op, ops.CopyAttribute):
+            record_ref(op.owner)
+
+    def _resolve_snapshot_symbol(self, value: Any, version: str) -> str | None:
+        if not version:
+            return None
+
+        # Extract label
+        from type_bridge.migration.snapshots import get_snapshot_class_map
+
+        # Get label and kind
+        try:
+            label, kind = self._get_label_and_kind(value)
+        except Exception:
+            return None
+
+        class_map = get_snapshot_class_map(self.migrations_dir, version)
+        if label not in class_map:
+            return None
+
+        cls = class_map[label]
+        class_name = cls.__name__
+
+        # Determine submodule
+        from type_bridge.attribute.base import Attribute
+        from type_bridge.models import Relation
+
+        if issubclass(cls, Relation):
+            submodule = "relations"
+        elif issubclass(cls, Attribute):
+            submodule = "attributes"
+        else:
+            submodule = "entities"
+
+        # Record the import
+        self._import_records.setdefault(version, {}).setdefault(submodule, set()).add(class_name)
+        return class_name
+
+    def _get_label_and_kind(self, value: Any) -> tuple[str, str]:
+        if isinstance(value, type):
+            from type_bridge.attribute.base import Attribute
+            from type_bridge.models import Relation
+
+            if issubclass(value, Relation):
+                return value.get_type_name(), "relation"
+            elif issubclass(value, Attribute):
+                return value.get_attribute_name(), "attribute"
+            else:
+                return value.get_type_name(), "entity"
+        elif hasattr(value, "get_type_name"):
+            kind = getattr(value, "kind", "entity")
+            return str(value.get_type_name()), kind
+        elif hasattr(value, "get_attribute_name"):
+            return str(value.get_attribute_name()), "attribute"
+        elif hasattr(value, "label"):
+            kind = getattr(value, "kind", "entity")
+            return str(value.label), kind
+        else:
+            raise ValueError(f"Cannot get label from {value}")
+
+    def _type_ref(self, value: Any, version: str | None) -> str:
+        if version:
+            symbol = self._resolve_snapshot_symbol(value, version)
+            if symbol:
+                resolved_symbol = self._symbol_aliases.get((version, symbol), symbol)
+                return resolved_symbol
+
+        # Fallback to old behavior
+        from type_bridge.models import Relation
+
+        try:
+            label, kind = self._get_label_and_kind(value)
+        except Exception:
+            label = getattr(value, "label", str(value))
+            kind = "entity"
+
+        if kind == "relation":
+            return f"ref.relation({label!r})"
+        if isinstance(value, type) and issubclass(value, Relation):
+            return f"ref.relation({label!r})"
+        return f"ref.entity({label!r})"
+
+    def _attribute_ref(self, value: Any, version: str | None) -> str:
+        if version:
+            symbol = self._resolve_snapshot_symbol(value, version)
+            if symbol:
+                resolved_symbol = self._symbol_aliases.get((version, symbol), symbol)
+                return resolved_symbol
+
+        # Fallback to old behavior
+        try:
+            label, _ = self._get_label_and_kind(value)
+        except Exception:
+            label = getattr(value, "label", str(value))
+        return f"ref.attribute({label!r})"
+
     def _render_operation(self, operation: ops.Operation) -> str:
         """Render one operation object as Python source."""
+        pre_version = getattr(self, "_pre_version", None)
+        post_version = getattr(self, "_post_version", None)
+
         if isinstance(operation, ops.AddAttribute):
-            return f"ops.AddAttribute({_class_ref(operation.attribute)})"
+            return f"ops.AddAttribute({self._attribute_ref(operation.attribute, post_version)})"
         if isinstance(operation, ops.RemoveAttribute):
-            return f"ops.RemoveAttribute({_class_ref(operation.attribute)})"
+            return f"ops.RemoveAttribute({self._attribute_ref(operation.attribute, pre_version)})"
         if isinstance(operation, ops.AddEntity):
-            return f"ops.AddEntity({_class_ref(operation.entity)})"
+            return f"ops.AddEntity({self._type_ref(operation.entity, post_version)})"
         if isinstance(operation, ops.RemoveEntity):
-            return f"ops.RemoveEntity({_class_ref(operation.entity)})"
+            return f"ops.RemoveEntity({self._type_ref(operation.entity, pre_version)})"
         if isinstance(operation, ops.AddOwnership):
-            args = [_class_ref(operation.owner), _class_ref(operation.attribute)]
+            args = [
+                self._type_ref(operation.owner, post_version),
+                self._attribute_ref(operation.attribute, post_version),
+            ]
             kwargs = self._render_add_ownership_kwargs(operation)
             return self._render_call("AddOwnership", args, kwargs)
         if isinstance(operation, ops.RemoveOwnership):
             return (
                 "ops.RemoveOwnership("
-                f"{_class_ref(operation.owner)}, {_class_ref(operation.attribute)})"
+                f"{self._type_ref(operation.owner, pre_version)}, {self._attribute_ref(operation.attribute, pre_version)})"
             )
         if isinstance(operation, ops.ModifyOwnership):
             return self._render_call(
                 "ModifyOwnership",
-                [_class_ref(operation.owner), _class_ref(operation.attribute)],
+                [
+                    self._type_ref(operation.owner, pre_version),
+                    self._attribute_ref(operation.attribute, pre_version),
+                ],
                 {
                     "old_annotations": repr(operation.old_annotations),
                     "new_annotations": repr(operation.new_annotations),
                 },
             )
         if isinstance(operation, ops.AddRelation):
-            return f"ops.AddRelation({_class_ref(operation.relation)})"
+            return f"ops.AddRelation({self._type_ref(operation.relation, post_version)})"
         if isinstance(operation, ops.RemoveRelation):
-            return f"ops.RemoveRelation({_class_ref(operation.relation)})"
+            return f"ops.RemoveRelation({self._type_ref(operation.relation, pre_version)})"
         if isinstance(operation, ops.AddRole):
             return self._render_call(
                 "AddRole",
                 [
-                    _class_ref(operation.relation),
+                    self._type_ref(operation.relation, post_version),
                     repr(operation.role_name),
                     repr(operation.player_types),
                 ],
                 {},
             )
         if isinstance(operation, ops.RemoveRole):
-            return f"ops.RemoveRole({_class_ref(operation.relation)}, {operation.role_name!r})"
+            return f"ops.RemoveRole({self._type_ref(operation.relation, pre_version)}, {operation.role_name!r})"
         if isinstance(operation, ops.AddRolePlayer):
             return (
                 "ops.AddRolePlayer("
-                f"{_class_ref(operation.relation)}, {operation.role_name!r}, "
+                f"{self._type_ref(operation.relation, post_version)}, {operation.role_name!r}, "
                 f"{operation.player_type!r})"
             )
         if isinstance(operation, ops.RemoveRolePlayer):
             return (
                 "ops.RemoveRolePlayer("
-                f"{_class_ref(operation.relation)}, {operation.role_name!r}, "
+                f"{self._type_ref(operation.relation, pre_version)}, {operation.role_name!r}, "
                 f"{operation.player_type!r})"
             )
         if isinstance(operation, ops.RunTypeQL):
@@ -438,7 +752,7 @@ class MigrationGenerator:
             )
         if isinstance(operation, ops.CopyAttribute):
             kwargs = {
-                "owner": _class_ref(operation.owner),
+                "owner": self._type_ref(operation.owner, pre_version),
                 "source": repr(operation.source),
                 "dest": repr(operation.dest),
             }
@@ -508,9 +822,10 @@ class MigrationGenerator:
     ) -> None:
         """Write the JSON sidecar for a generated migration alongside its .py file.
 
-        Builds the structured MigrationSpec from the same operations list that
-        _render_operations rendered into the .py.  Typed operations stay typed
-        in the sidecar; only explicit ops.RunTypeQL instances become run_typeql.
+        Builds the structured MigrationSpec from the original typed operation
+        list, while generated .py source renders stable snapshot bindings. Typed
+        operations stay typed in the sidecar; only explicit ops.RunTypeQL
+        instances become run_typeql.
         The checksum is computed over the .py text so the drift gate reads a
         consistent value regardless of which path (sidecar or exec_module) is
         used.
@@ -578,42 +893,26 @@ from type_bridge.migration import operations as ops"""
             "",
             "from type_bridge.migration import Migration",
             "from type_bridge.migration.operations import Operation",
-            "from type_bridge.migration import operations as ops",
+            "from type_bridge.migration import operations as ops, ref",
         ]
 
-        imports_by_module: dict[str, set[str]] = {}
-
-        def add_type(cls: type) -> None:
-            imports_by_module.setdefault(cls.__module__, set()).add(cls.__name__)
-
-        for op in operations:
-            if isinstance(op, (ops.AddAttribute, ops.RemoveAttribute)):
-                add_type(op.attribute)
-            elif isinstance(op, (ops.AddEntity, ops.RemoveEntity)):
-                add_type(op.entity)
-            elif isinstance(op, (ops.AddRelation, ops.RemoveRelation)):
-                add_type(op.relation)
-            elif isinstance(op, (ops.AddOwnership, ops.RemoveOwnership, ops.ModifyOwnership)):
-                add_type(op.owner)
-                add_type(op.attribute)
-            elif isinstance(
-                op,
-                (
-                    ops.AddRole,
-                    ops.RemoveRole,
-                    ops.AddRolePlayer,
-                    ops.RemoveRolePlayer,
-                ),
-            ):
-                add_type(op.relation)
-            elif isinstance(op, ops.CopyAttribute):
-                add_type(op.owner)
-
-        if imports_by_module:
+        if hasattr(self, "_import_records") and self._import_records:
             lines.append("")
-            for module in sorted(imports_by_module):
-                names = ", ".join(sorted(imports_by_module[module]))
-                lines.append(f"from {module} import {names}")
+            app_name = self.migrations_dir.name
+            for version in sorted(self._import_records.keys()):
+                submodules = self._import_records[version]
+                symbols = sorted({symbol for symbols in submodules.values() for symbol in symbols})
+                import_parts = []
+                for sym in symbols:
+                    alias = self._symbol_aliases.get((version, sym))
+                    if alias:
+                        import_parts.append(f"{sym} as {alias}")
+                    else:
+                        import_parts.append(sym)
+
+                lines.append(
+                    f"from {app_name}.snapshots.{version} import {', '.join(import_parts)}"
+                )
 
         return "\n".join(lines)
 

--- a/type_bridge/migration/loader.py
+++ b/type_bridge/migration/loader.py
@@ -140,6 +140,22 @@ class MigrationLoader:
         content = path.read_text()
         checksum = _rust_runtime.migration_file_checksum(content)
 
+        execution_spec = _rust_runtime.load_migration_sidecar(str(path))
+        if execution_spec is not None:
+            sidecar_checksum = execution_spec.get("checksum")
+            if sidecar_checksum is not None and sidecar_checksum != checksum:
+                raise MigrationLoadError(
+                    f"sidecar drift detected for {path}: sidecar checksum "
+                    f"{sidecar_checksum} does not match current .py checksum {checksum}"
+                )
+            migration = self._migration_from_sidecar(execution_spec, path)
+            return LoadedMigration(
+                migration=migration,
+                path=path,
+                checksum=checksum,
+                execution_spec=execution_spec,
+            )
+
         # Load module dynamically
         module_name = f"migration_{path.stem}"
         spec = importlib.util.spec_from_file_location(module_name, path)
@@ -150,10 +166,23 @@ class MigrationLoader:
         module = importlib.util.module_from_spec(spec)
 
         # Execute the module
+        import sys
+
+        parent_path = str(self.migrations_dir.parent.resolve())
+        added_to_path = False
+        if parent_path not in sys.path:
+            sys.path.insert(0, parent_path)
+            added_to_path = True
         try:
             spec.loader.exec_module(module)
         except Exception as e:
             raise MigrationLoadError(f"Error executing migration {path}: {e}") from e
+        finally:
+            if added_to_path:
+                try:
+                    sys.path.remove(parent_path)
+                except ValueError:
+                    pass
 
         # Find Migration subclass in module
         migration_cls = self._find_migration_class(module)
@@ -167,18 +196,33 @@ class MigrationLoader:
         migration.name = path.stem
         migration.app_label = self.migrations_dir.name
 
-        # Prefer the JSON sidecar as the pre-lowered execution spec when present.
-        # The sidecar is produced at generation time from the same op list the
-        # .py renders, so it is structurally identical to what lowering the .py
-        # would produce.  The .py text remains the sole checksum source (04 gate).
-        execution_spec = _rust_runtime.load_migration_sidecar(str(path))
-
         return LoadedMigration(
             migration=migration,
             path=path,
             checksum=checksum,
-            execution_spec=execution_spec,
+            execution_spec=None,
         )
+
+    def _migration_from_sidecar(self, execution_spec: dict[str, Any], path: Path) -> Migration:
+        """Create lightweight migration metadata without executing sidecar-backed .py."""
+        dependencies = [
+            (str(dependency["app_label"]), str(dependency["migration_name"]))
+            for dependency in execution_spec.get("dependencies", [])
+        ]
+        migration_cls = type(
+            "SidecarMigration",
+            (Migration,),
+            {
+                "dependencies": dependencies,
+                "operations": [],
+                "models": [],
+                "reversible": bool(execution_spec.get("reversible", True)),
+            },
+        )
+        migration = migration_cls()
+        migration.name = str(execution_spec.get("name") or path.stem)
+        migration.app_label = str(execution_spec.get("app_label") or self.migrations_dir.name)
+        return migration
 
     def _find_migration_class(self, module: types.ModuleType) -> type[Migration] | None:
         """Find a Migration subclass in a module.
@@ -227,8 +271,8 @@ class MigrationLoader:
         Returns:
             List of error messages (empty if valid)
         """
-        from type_bridge.migration._lower import lower_migration_graph
+        from type_bridge.migration._lower import lower_validation_graph
 
-        graph = lower_migration_graph(self.discover())
+        graph = lower_validation_graph(self.discover())
         errors = _rust_runtime.validate_migration_graph(graph)
         return [str(error["message"]) for error in errors]

--- a/type_bridge/migration/operations.py
+++ b/type_bridge/migration/operations.py
@@ -19,12 +19,40 @@ Example:
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from type_bridge.attribute.base import Attribute
+    from type_bridge.migration.ref import AttributeRef, EntityRef, RelationRef
     from type_bridge.models import Entity, Relation
+
+    TypeLike = type[Entity | Relation] | EntityRef | RelationRef
+    AttributeLike = type[Attribute] | AttributeRef
+
+
+def _type_name(value: object) -> str:
+    get_type_name = getattr(value, "get_type_name", None)
+    if get_type_name is None:
+        raise TypeError(f"{value!r} is not a TypeBridge type or migration type ref")
+    return str(get_type_name())
+
+
+def _attribute_name(value: object) -> str:
+    get_attribute_name = getattr(value, "get_attribute_name", None)
+    if get_attribute_name is None:
+        raise TypeError(f"{value!r} is not a TypeBridge attribute or migration attribute ref")
+    return str(get_attribute_name())
+
+
+def _schema_definition(value: object, operation: str) -> str:
+    to_schema_definition = getattr(value, "to_schema_definition", None)
+    if to_schema_definition is None:
+        raise TypeError(
+            f"{operation} requires a full model class when no sidecar execution spec is present"
+        )
+    return str(to_schema_definition())
 
 
 class Operation(ABC):
@@ -74,14 +102,14 @@ class AddAttribute(Operation):
         ops.AddAttribute(Phone)  # Creates: define attribute phone, value string;
     """
 
-    attribute: type[Attribute]
+    attribute: AttributeLike
 
     def to_typeql(self) -> str:
-        return f"define\n{self.attribute.to_schema_definition()}"
+        return f"define\n{_schema_definition(self.attribute, 'AddAttribute')}"
 
     def to_rollback_typeql(self) -> str | None:
-        name = self.attribute.get_attribute_name()
-        return f"undefine\nattribute {name};"
+        name = _attribute_name(self.attribute)
+        return f"undefine\n{name};"
 
 
 @dataclass
@@ -92,11 +120,11 @@ class RemoveAttribute(Operation):
     and ownerships are removed first.
     """
 
-    attribute: type[Attribute]
+    attribute: AttributeLike
 
     def to_typeql(self) -> str:
-        name = self.attribute.get_attribute_name()
-        return f"undefine\nattribute {name};"
+        name = _attribute_name(self.attribute)
+        return f"undefine\n{name};"
 
     def to_rollback_typeql(self) -> str | None:
         # Cannot restore deleted data
@@ -114,17 +142,17 @@ class AddEntity(Operation):
         ops.AddEntity(Person)
     """
 
-    entity: type[Entity]
+    entity: TypeLike
 
     def to_typeql(self) -> str:
-        schema = self.entity.to_schema_definition()
+        schema = _schema_definition(self.entity, "AddEntity")
         if schema:
             return f"define\n{schema}"
         return ""
 
     def to_rollback_typeql(self) -> str | None:
-        name = self.entity.get_type_name()
-        return f"undefine\nentity {name};"
+        name = _type_name(self.entity)
+        return f"undefine\n{name};"
 
 
 @dataclass
@@ -135,11 +163,11 @@ class RemoveEntity(Operation):
     are deleted first.
     """
 
-    entity: type[Entity]
+    entity: TypeLike
 
     def to_typeql(self) -> str:
-        name = self.entity.get_type_name()
-        return f"undefine\nentity {name};"
+        name = _type_name(self.entity)
+        return f"undefine\n{name};"
 
     def to_rollback_typeql(self) -> str | None:
         # Cannot restore deleted data
@@ -161,8 +189,8 @@ class AddOwnership(Operation):
         # Creates: define person owns email @key;
     """
 
-    owner: type[Entity | Relation]
-    attribute: type[Attribute]
+    owner: TypeLike
+    attribute: AttributeLike
     optional: bool = False
     key: bool = False
     unique: bool = False
@@ -172,8 +200,8 @@ class AddOwnership(Operation):
     def to_typeql(self) -> str:
         from type_bridge.typeql.annotations import format_card_annotation
 
-        owner_name = self.owner.get_type_name()
-        attr_name = self.attribute.get_attribute_name()
+        owner_name = _type_name(self.owner)
+        attr_name = _attribute_name(self.attribute)
 
         annotations = []
         if self.key:
@@ -191,9 +219,9 @@ class AddOwnership(Operation):
         return f"define\n{owner_name} owns {attr_name}{ann_str};"
 
     def to_rollback_typeql(self) -> str | None:
-        owner_name = self.owner.get_type_name()
-        attr_name = self.attribute.get_attribute_name()
-        return f"undefine\n{owner_name} owns {attr_name};"
+        owner_name = _type_name(self.owner)
+        attr_name = _attribute_name(self.attribute)
+        return f"undefine\nowns {attr_name} from {owner_name};"
 
 
 @dataclass
@@ -204,13 +232,13 @@ class RemoveOwnership(Operation):
     are removed from instances first.
     """
 
-    owner: type[Entity | Relation]
-    attribute: type[Attribute]
+    owner: TypeLike
+    attribute: AttributeLike
 
     def to_typeql(self) -> str:
-        owner_name = self.owner.get_type_name()
-        attr_name = self.attribute.get_attribute_name()
-        return f"undefine\n{owner_name} owns {attr_name};"
+        owner_name = _type_name(self.owner)
+        attr_name = _attribute_name(self.attribute)
+        return f"undefine\nowns {attr_name} from {owner_name};"
 
     def to_rollback_typeql(self) -> str | None:
         # Would need to know original flags (key, unique, cardinality)
@@ -229,20 +257,20 @@ class ModifyOwnership(Operation):
         )
     """
 
-    owner: type[Entity | Relation]
-    attribute: type[Attribute]
+    owner: TypeLike
+    attribute: AttributeLike
     old_annotations: str
     new_annotations: str
 
     def to_typeql(self) -> str:
-        owner_name = self.owner.get_type_name()
-        attr_name = self.attribute.get_attribute_name()
+        owner_name = _type_name(self.owner)
+        attr_name = _attribute_name(self.attribute)
         # TypeDB 3.x uses redefine for modifications
         return f"redefine\n{owner_name} owns {attr_name} {self.new_annotations};"
 
     def to_rollback_typeql(self) -> str | None:
-        owner_name = self.owner.get_type_name()
-        attr_name = self.attribute.get_attribute_name()
+        owner_name = _type_name(self.owner)
+        attr_name = _attribute_name(self.attribute)
         return f"redefine\n{owner_name} owns {attr_name} {self.old_annotations};"
 
 
@@ -257,26 +285,24 @@ class AddRelation(Operation):
         ops.AddRelation(Employment)
     """
 
-    relation: type[Relation]
+    relation: TypeLike
 
     def to_typeql(self) -> str:
         lines = []
-        schema = self.relation.to_schema_definition()
+        schema = _schema_definition(self.relation, "AddRelation")
         if schema:
             lines.append(f"define\n{schema}")
 
             # Add role player definitions
-            for role_name, role in self.relation._roles.items():
+            for role_name, role in getattr(self.relation, "_roles", {}).items():
                 for player_type in role.player_types:
-                    lines.append(
-                        f"{player_type} plays {self.relation.get_type_name()}:{role.role_name};"
-                    )
+                    lines.append(f"{player_type} plays {_type_name(self.relation)}:{role_name};")
 
         return "\n".join(lines)
 
     def to_rollback_typeql(self) -> str | None:
-        name = self.relation.get_type_name()
-        return f"undefine\nrelation {name};"
+        name = _type_name(self.relation)
+        return f"undefine\n{name};"
 
 
 @dataclass
@@ -287,11 +313,11 @@ class RemoveRelation(Operation):
     are deleted first.
     """
 
-    relation: type[Relation]
+    relation: TypeLike
 
     def to_typeql(self) -> str:
-        name = self.relation.get_type_name()
-        return f"undefine\nrelation {name};"
+        name = _type_name(self.relation)
+        return f"undefine\n{name};"
 
     def to_rollback_typeql(self) -> str | None:
         # Cannot restore deleted data
@@ -309,20 +335,20 @@ class AddRole(Operation):
         ops.AddRole(Employment, "manager", ["person"])
     """
 
-    relation: type[Relation]
+    relation: TypeLike
     role_name: str
     player_types: list[str] = field(default_factory=list)
 
     def to_typeql(self) -> str:
-        rel_name = self.relation.get_type_name()
+        rel_name = _type_name(self.relation)
         lines = [f"define\n{rel_name} relates {self.role_name};"]
         for player in self.player_types:
             lines.append(f"{player} plays {rel_name}:{self.role_name};")
         return "\n".join(lines)
 
     def to_rollback_typeql(self) -> str | None:
-        rel_name = self.relation.get_type_name()
-        return f"undefine\n{rel_name} relates {self.role_name};"
+        rel_name = _type_name(self.relation)
+        return f"undefine\nrelates {self.role_name} from {rel_name};"
 
 
 @dataclass
@@ -333,12 +359,12 @@ class RemoveRole(Operation):
     have role players for this role.
     """
 
-    relation: type[Relation]
+    relation: TypeLike
     role_name: str
 
     def to_typeql(self) -> str:
-        rel_name = self.relation.get_type_name()
-        return f"undefine\n{rel_name} relates {self.role_name};"
+        rel_name = _type_name(self.relation)
+        return f"undefine\nrelates {self.role_name} from {rel_name};"
 
     def to_rollback_typeql(self) -> str | None:
         # Would need to know player types
@@ -354,17 +380,17 @@ class AddRolePlayer(Operation):
         # Allows Contractor entities to play the employee role
     """
 
-    relation: type[Relation]
+    relation: TypeLike
     role_name: str
     player_type: str
 
     def to_typeql(self) -> str:
-        rel_name = self.relation.get_type_name()
+        rel_name = _type_name(self.relation)
         return f"define\n{self.player_type} plays {rel_name}:{self.role_name};"
 
     def to_rollback_typeql(self) -> str | None:
-        rel_name = self.relation.get_type_name()
-        return f"undefine\n{self.player_type} plays {rel_name}:{self.role_name};"
+        rel_name = _type_name(self.relation)
+        return f"undefine\nplays {rel_name}:{self.role_name} from {self.player_type};"
 
 
 @dataclass
@@ -375,16 +401,16 @@ class RemoveRolePlayer(Operation):
     have this player type in this role.
     """
 
-    relation: type[Relation]
+    relation: TypeLike
     role_name: str
     player_type: str
 
     def to_typeql(self) -> str:
-        rel_name = self.relation.get_type_name()
-        return f"undefine\n{self.player_type} plays {rel_name}:{self.role_name};"
+        rel_name = _type_name(self.relation)
+        return f"undefine\nplays {rel_name}:{self.role_name} from {self.player_type};"
 
     def to_rollback_typeql(self) -> str | None:
-        rel_name = self.relation.get_type_name()
+        rel_name = _type_name(self.relation)
         return f"define\n{self.player_type} plays {rel_name}:{self.role_name};"
 
 
@@ -422,6 +448,72 @@ class RunTypeQL(Operation):
 
     def to_rollback_typeql(self) -> str | None:
         return self.reverse.strip() if self.reverse else None
+
+
+PythonMigrationCallable = Callable[[Any], None]
+
+
+@dataclass
+class RunPython(Operation):
+    """Run Python ORM code during migration execution.
+
+    ``RunPython`` is for migrations that need the normal TypeBridge ORM surface
+    rather than portable TypeQL, for example loading JSON/TOML data, creating
+    many entities/relations, or querying existing data before writing derived
+    values.  The callable receives the migration executor's database connection,
+    so existing code such as ``User.manager(db).filter(...).execute()`` works.
+
+    Example:
+        def forwards(db):
+            users = User.manager(db).filter(name__startswith="A").execute()
+            ...
+
+        operations = [ops.RunPython(forwards)]
+    """
+
+    code: PythonMigrationCallable
+    reverse: PythonMigrationCallable | None = None
+    description: str | None = None
+    resources: Sequence[str] = ()
+    import_checks: Sequence[str] = ()
+
+    def to_typeql(self) -> str:
+        name = self.description or self._callable_name(self.code)
+        return self._preview("RunPython", name)
+
+    def to_rollback_typeql(self) -> str | None:
+        if self.reverse is None:
+            return None
+        name = self.description or self._callable_name(self.reverse)
+        return self._preview("RunPython reverse", name)
+
+    @property
+    def reversible(self) -> bool:
+        return self.reverse is not None
+
+    def run(self, db: Any) -> None:
+        self.code(db)
+
+    def rollback(self, db: Any) -> None:
+        if self.reverse is None:
+            raise RuntimeError(
+                f"RunPython operation {self._callable_name(self.code)} is not reversible"
+            )
+        self.reverse(db)
+
+    @staticmethod
+    def _callable_name(func: PythonMigrationCallable) -> str:
+        module = getattr(func, "__module__", "")
+        name = getattr(func, "__qualname__", getattr(func, "__name__", repr(func)))
+        return f"{module}:{name}" if module else name
+
+    def _preview(self, prefix: str, name: str) -> str:
+        lines = [f"# {prefix}: {name}"]
+        if self.resources:
+            lines.append(f"# resources: {', '.join(self.resources)}")
+        if self.import_checks:
+            lines.append(f"# import checks: {', '.join(self.import_checks)}")
+        return "\n".join(lines)
 
 
 @dataclass
@@ -495,7 +587,7 @@ class CopyAttribute(Operation):
     Note: ``dest`` must already be owned by ``owner`` via a prior schema op.
     """
 
-    owner: type[Entity | Relation]
+    owner: TypeLike
     source: str
     dest: str
     filter: str | None = None
@@ -506,7 +598,7 @@ class CopyAttribute(Operation):
         Emits a match+insert that copies ``source`` values to ``dest`` for every
         owner instance that does not already have the destination attribute.
         """
-        owner_name = self.owner.get_type_name()
+        owner_name = _type_name(self.owner)
         filter_line = f"\n  {self.filter};" if self.filter else ""
         # `has <dest> == $v` assigns the *value* of the matched source attribute
         # to a new destination attribute. Writing `has <dest> $v` instead would
@@ -522,5 +614,5 @@ class CopyAttribute(Operation):
 
     def to_rollback_typeql(self) -> str | None:
         """Generate the inverse delete that removes all dest values added by this op."""
-        owner_name = self.owner.get_type_name()
+        owner_name = _type_name(self.owner)
         return f"match $x isa {owner_name}, has {self.dest} $v;\ndelete $v of $x;"

--- a/type_bridge/migration/ref.py
+++ b/type_bridge/migration/ref.py
@@ -1,0 +1,76 @@
+"""Stable schema-label references for generated migration source.
+
+Active application model classes can disappear when bindgen regenerates a
+package after a schema deletion.  Migration refs are the historical authoring
+surface for generated migrations: they carry only the TypeDB label needed to
+review or remove schema objects, while sidecars carry full executable payloads
+for schema-bearing add operations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+def _validate_label(label: str) -> str:
+    if not isinstance(label, str) or not label:
+        raise ValueError("Migration ref labels must be non-empty strings")
+    return label
+
+
+@dataclass(frozen=True)
+class EntityRef:
+    """Historical reference to an entity type label."""
+
+    label: str
+    kind: Literal["entity"] = "entity"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "label", _validate_label(self.label))
+
+    def get_type_name(self) -> str:
+        return self.label
+
+
+@dataclass(frozen=True)
+class RelationRef:
+    """Historical reference to a relation type label."""
+
+    label: str
+    kind: Literal["relation"] = "relation"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "label", _validate_label(self.label))
+
+    def get_type_name(self) -> str:
+        return self.label
+
+
+@dataclass(frozen=True)
+class AttributeRef:
+    """Historical reference to an attribute type label."""
+
+    label: str
+    kind: Literal["attribute"] = "attribute"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "label", _validate_label(self.label))
+
+    def get_attribute_name(self) -> str:
+        return self.label
+
+
+def entity(label: str) -> EntityRef:
+    """Return a stable migration reference to an entity label."""
+    return EntityRef(label)
+
+
+def relation(label: str) -> RelationRef:
+    """Return a stable migration reference to a relation label."""
+    return RelationRef(label)
+
+
+def attribute(label: str) -> AttributeRef:
+    """Return a stable migration reference to an attribute label."""
+    return AttributeRef(label)

--- a/type_bridge/migration/snapshots.py
+++ b/type_bridge/migration/snapshots.py
@@ -1,0 +1,313 @@
+"""Migration snapshot bindings and time-state package management."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from type_bridge import __version__ as type_bridge_version
+from type_bridge.generator import generate_models
+
+logger = logging.getLogger(__name__)
+
+
+class SnapshotError(ValueError):
+    """Raised when an existing migration snapshot is missing or stale."""
+
+
+def generate_snapshot(
+    migrations_dir: Path,
+    version: str,
+    migration_name: str,
+    schema_text: str,
+) -> Path:
+    """Generate a schema snapshot package in migrations/snapshots/vNNNN/.
+
+    Args:
+        migrations_dir: Directory containing migrations (e.g. Path("migrations"))
+        version: Snapshot version string, e.g. "v0001"
+        migration_name: The suffix name of the migration, e.g. "0001_initial"
+        schema_text: The canonical TypeQL schema text
+
+    Returns:
+        Path to the created snapshot directory
+    """
+    # 1. Establish directory layout
+    snapshots_dir = migrations_dir / "snapshots"
+    snapshots_dir.mkdir(parents=True, exist_ok=True)
+
+    # Write empty __init__.py in snapshots/ if not exists
+    init_file = snapshots_dir / "__init__.py"
+    if not init_file.exists():
+        init_file.write_text("# TypeBridge migration snapshots package\n")
+
+    schema_hash = _schema_hash(schema_text)
+    snapshot_dir = snapshots_dir / version
+    # If the snapshot already exists, we do NOT overwrite it (append-only contract)
+    if snapshot_dir.exists():
+        _validate_existing_snapshot(snapshot_dir, schema_hash)
+        return snapshot_dir
+
+    snapshot_dir.mkdir(parents=True, exist_ok=False)
+
+    try:
+        # 2. Render Python classes
+        generate_models(
+            schema=schema_text,
+            output_dir=snapshot_dir,
+            copy_schema=True,
+            schema_path="schema.tql",
+        )
+
+        _rewrite_snapshot_init(snapshot_dir)
+
+        # 3. Compute canonical schema hash
+        file_hashes = _file_hashes(snapshot_dir)
+
+        # 5. Core version info
+        try:
+            import type_bridge_core
+
+            core_version = getattr(type_bridge_core, "__version__", None) or getattr(
+                type_bridge_core, "VERSION", "unknown"
+            )
+        except ImportError:
+            core_version = "unknown"
+
+        # 6. Render snapshot.json metadata
+        metadata = {
+            "version": version,
+            "source_migration": migration_name,
+            "schema_hash": schema_hash,
+            "file_hashes": file_hashes,
+            "type_bridge_version": type_bridge_version,
+            "type_bridge_core_version": core_version,
+        }
+        (snapshot_dir / "snapshot.json").write_text(
+            json.dumps(metadata, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        logger.info(f"Successfully generated migration snapshot in {snapshot_dir}")
+        return snapshot_dir
+
+    except Exception as e:
+        # Clean up directory on failure so we don't leave corrupted state
+        import shutil
+
+        if snapshot_dir.exists():
+            try:
+                shutil.rmtree(snapshot_dir)
+            except Exception:
+                pass
+        raise e
+
+
+def _schema_hash(schema_text: str) -> str:
+    return hashlib.sha256(schema_text.encode("utf-8")).hexdigest()
+
+
+def _file_hashes(snapshot_dir: Path) -> dict[str, str]:
+    file_hashes: dict[str, str] = {}
+    for path in sorted(snapshot_dir.glob("*")):
+        if path.is_file() and path.name != "snapshot.json":
+            file_hashes[path.name] = hashlib.sha256(path.read_bytes()).hexdigest()
+    return file_hashes
+
+
+def _validate_existing_snapshot(snapshot_dir: Path, expected_schema_hash: str) -> None:
+    metadata = get_snapshot_metadata(snapshot_dir)
+    if metadata is None:
+        raise SnapshotError(
+            f"snapshot {snapshot_dir} already exists but has no readable snapshot.json"
+        )
+
+    actual_schema_hash = metadata.get("schema_hash")
+    if actual_schema_hash != expected_schema_hash:
+        raise SnapshotError(
+            f"snapshot {snapshot_dir} schema hash mismatch: "
+            f"expected {expected_schema_hash}, found {actual_schema_hash}"
+        )
+
+    expected_hashes = metadata.get("file_hashes")
+    if not isinstance(expected_hashes, dict):
+        raise SnapshotError(f"snapshot {snapshot_dir} has no file hash manifest")
+
+    current_hashes = _file_hashes(snapshot_dir)
+    for filename, expected_hash in expected_hashes.items():
+        actual_hash = current_hashes.get(str(filename))
+        if actual_hash != expected_hash:
+            raise SnapshotError(
+                f"snapshot {snapshot_dir} file hash mismatch for {filename}: "
+                f"expected {expected_hash}, found {actual_hash}"
+            )
+
+    init_exports = (snapshot_dir / "__init__.py").read_text(encoding="utf-8")
+    if (
+        "from .entities import" not in init_exports
+        and "from .attributes import" not in init_exports
+        and "from .relations import" not in init_exports
+    ):
+        raise SnapshotError(f"snapshot {snapshot_dir} does not expose top-level binding imports")
+
+
+def _rewrite_snapshot_init(snapshot_dir: Path) -> None:
+    attributes = _class_names(snapshot_dir / "attributes.py")
+    entities = _class_names(snapshot_dir / "entities.py")
+    relations = _class_names(snapshot_dir / "relations.py")
+
+    lines = [
+        '"""TypeBridge migration snapshot bindings generated from a TypeDB schema.',
+        "",
+        "AUTO-GENERATED FILE - DO NOT EDIT MANUALLY",
+        '"""',
+        "",
+        "from __future__ import annotations",
+        "",
+        "from importlib import resources",
+        "",
+        "from . import attributes, entities, registry, relations",
+    ]
+    for module, names in (
+        ("attributes", attributes),
+        ("entities", entities),
+        ("relations", relations),
+    ):
+        import_block = _render_class_import(module, names)
+        if import_block:
+            lines.extend(["", import_block])
+
+    lines.extend(
+        [
+            "",
+            'SCHEMA_VERSION = "1.0.0"',
+            "",
+            "",
+            "def schema_text() -> str:",
+            '    """Return the canonical TypeDB schema text bundled with the package."""',
+            "    return (",
+            "        resources.files(__package__)",
+            '        .joinpath("schema.tql")',
+            '        .read_text(encoding="utf-8")',
+            "    )",
+            "",
+            _render_class_list("ATTRIBUTES", attributes),
+            "",
+            _render_class_list("ENTITIES", entities),
+            "",
+            _render_class_list("RELATIONS", relations),
+            "",
+            _render_all([*attributes, *entities, *relations]),
+        ]
+    )
+    (snapshot_dir / "__init__.py").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _class_names(path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    return [node.name for node in tree.body if isinstance(node, ast.ClassDef)]
+
+
+def _render_class_import(module: str, names: list[str]) -> str:
+    if not names:
+        return ""
+    joined = ", ".join(names)
+    if len(f"from .{module} import {joined}") <= 88:
+        return f"from .{module} import {joined}"
+    lines = [f"from .{module} import ("]
+    lines.extend(f"    {name}," for name in names)
+    lines.append(")")
+    return "\n".join(lines)
+
+
+def _render_class_list(name: str, class_names: list[str]) -> str:
+    lines = [f"{name} = ["]
+    lines.extend(f"    {class_name}," for class_name in class_names)
+    lines.append("]")
+    return "\n".join(lines)
+
+
+def _render_all(class_names: list[str]) -> str:
+    exported = [
+        *class_names,
+        "ATTRIBUTES",
+        "ENTITIES",
+        "RELATIONS",
+        "SCHEMA_VERSION",
+        "attributes",
+        "entities",
+        "registry",
+        "relations",
+        "schema_text",
+    ]
+    lines = ["__all__ = ["]
+    lines.extend(f'    "{name}",' for name in exported)
+    lines.append("]")
+    return "\n".join(lines)
+
+
+def get_snapshot_metadata(snapshot_dir: Path) -> dict[str, Any] | None:
+    """Read metadata from a snapshot.json file."""
+    metadata_path = snapshot_dir / "snapshot.json"
+    if not metadata_path.exists():
+        return None
+    try:
+        return json.loads(metadata_path.read_text(encoding="utf-8"))
+    except Exception as e:
+        logger.warning(f"Failed to read snapshot metadata from {metadata_path}: {e}")
+        return None
+
+
+def get_snapshot_class_map(migrations_dir: Path, version: str) -> dict[str, type]:
+    """Return a mapping from TypeDB type label to class for a snapshot version.
+
+    For example, maps 'user' to migrations.snapshots.v0001.entities.User class.
+    """
+    import importlib
+    import sys
+
+    # Invalidate import caches so newly generated snapshot files are discoverable
+    importlib.invalidate_caches()
+
+    app_name = migrations_dir.name
+    module_name = f"{app_name}.snapshots.{version}.registry"
+
+    # Clean up sys.modules cache for the migrations package so Python imports it fresh from the new path
+    for key in list(sys.modules.keys()):
+        if key == app_name or key.startswith(f"{app_name}."):
+            try:
+                del sys.modules[key]
+            except KeyError:
+                pass
+
+    parent_path = str(migrations_dir.parent.resolve())
+    added_to_path = False
+    if parent_path not in sys.path:
+        sys.path.insert(0, parent_path)
+        added_to_path = True
+    try:
+        reg_mod = importlib.import_module(module_name)
+    except Exception as e:
+        logger.warning(f"Could not load registry for snapshot {version}: {e}")
+        return {}
+    finally:
+        if added_to_path:
+            try:
+                sys.path.remove(parent_path)
+            except ValueError:
+                pass
+
+    class_map = {}
+    if hasattr(reg_mod, "ENTITY_MAP"):
+        class_map.update(reg_mod.ENTITY_MAP)
+    if hasattr(reg_mod, "RELATION_MAP"):
+        class_map.update(reg_mod.RELATION_MAP)
+    if hasattr(reg_mod, "ATTRIBUTE_MAP"):
+        class_map.update(reg_mod.ATTRIBUTE_MAP)
+    return class_map

--- a/type_bridge/migration/state.py
+++ b/type_bridge/migration/state.py
@@ -6,6 +6,8 @@ Tracks applied migrations in TypeDB as the sole source of truth.
 from __future__ import annotations
 
 import logging
+import socket
+import uuid
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
@@ -29,6 +31,23 @@ class MigrationRecord:
         if not isinstance(other, MigrationRecord):
             return NotImplemented
         return self.app_label == other.app_label and self.name == other.name
+
+
+@dataclass
+class MigrationRunRecord:
+    """Record of one migration execution attempt."""
+
+    run_id: str
+    app_label: str
+    name: str
+    checksum: str
+    direction: str
+    status: str
+    started_at: str
+    finished_at: str | None = None
+    error: str | None = None
+    executor_ip: str | None = None
+    executor_mac: str | None = None
 
 
 @dataclass
@@ -97,12 +116,12 @@ class MigrationState:
 class MigrationStateManager:
     """Manages migration state in TypeDB.
 
-    State is stored in TypeDB as type_bridge_migration entities. The storage
-    mechanism — schema bootstrap, the applied-state read, and the
-    record/unrecord writes — lives in Rust behind the ``MigrationStateStore``
-    seam; this class is a thin facade that delegates to a Rust-owned
-    ``PyMigrationStateManager`` and assembles the ``MigrationState`` /
-    ``MigrationRecord`` dataclasses Python callers consume.
+    Applied state is stored in TypeDB as ``type_bridge_migration`` entities, and
+    execution attempts are stored as ``type_bridge_migration_run`` entities. The
+    storage mechanism — schema bootstrap, reads, and writes — lives in Rust
+    behind the ``MigrationStateStore`` seam; this class is a thin facade that
+    delegates to a Rust-owned ``PyMigrationStateManager`` and assembles Python
+    dataclasses for callers.
 
     Example:
         manager = MigrationStateManager(db)
@@ -172,6 +191,29 @@ class MigrationStateManager:
         self._state = state
         return state
 
+    def load_runs(self) -> list[MigrationRunRecord]:
+        """Load the migration execution run log from TypeDB."""
+        self.ensure_schema()
+
+        runs: list[MigrationRunRecord] = []
+        for row in self._manager.load_runs():
+            runs.append(
+                MigrationRunRecord(
+                    run_id=str(row["run_id"]),
+                    app_label=str(row["app_label"]),
+                    name=str(row["name"]),
+                    checksum=str(row["checksum"]),
+                    direction=str(row["direction"]),
+                    status=str(row["status"]),
+                    started_at=str(row["started_at"]),
+                    finished_at=_optional_str(row.get("finished_at")),
+                    error=_optional_str(row.get("error")),
+                    executor_ip=_optional_str(row.get("executor_ip")),
+                    executor_mac=_optional_str(row.get("executor_mac")),
+                )
+            )
+        return runs
+
     def record_applied(self, app_label: str, name: str, checksum: str) -> None:
         """Record that a migration was applied.
 
@@ -223,3 +265,105 @@ class MigrationStateManager:
         # Update local state
         if self._state:
             self._state.remove(app_label, name)
+
+    def record_run_started(
+        self,
+        app_label: str,
+        name: str,
+        checksum: str,
+        direction: str,
+    ) -> MigrationRunRecord:
+        """Record that one migration execution attempt started."""
+        if direction not in {"apply", "rollback"}:
+            raise ValueError(f"Unsupported migration run direction: {direction}")
+
+        started_at = _timestamp_now()
+        executor_ip, executor_mac = _executor_info()
+        record = MigrationRunRecord(
+            run_id=str(uuid.uuid4()),
+            app_label=app_label,
+            name=name,
+            checksum=checksum,
+            direction=direction,
+            status="started",
+            started_at=started_at,
+            executor_ip=executor_ip,
+            executor_mac=executor_mac,
+        )
+        self._record_run(record)
+        return record
+
+    def record_run_finished(
+        self,
+        record: MigrationRunRecord,
+        status: str,
+        error: str | None = None,
+    ) -> MigrationRunRecord:
+        """Record that a migration execution attempt finished."""
+        if status not in {"succeeded", "failed"}:
+            raise ValueError(f"Unsupported migration run status: {status}")
+
+        finished = MigrationRunRecord(
+            run_id=record.run_id,
+            app_label=record.app_label,
+            name=record.name,
+            checksum=record.checksum,
+            direction=record.direction,
+            status=status,
+            started_at=record.started_at,
+            finished_at=_timestamp_now(),
+            error=error,
+            executor_ip=record.executor_ip,
+            executor_mac=record.executor_mac,
+        )
+        self._record_run(finished)
+        return finished
+
+    def _record_run(self, record: MigrationRunRecord) -> None:
+        self.ensure_schema()
+        self._manager.record_run(
+            {
+                "run_id": record.run_id,
+                "app_label": record.app_label,
+                "name": record.name,
+                "checksum": record.checksum,
+                "direction": record.direction,
+                "status": record.status,
+                "started_at": record.started_at,
+                "finished_at": record.finished_at,
+                "error": record.error,
+                "executor_ip": record.executor_ip,
+                "executor_mac": record.executor_mac,
+            }
+        )
+
+
+def _timestamp_now() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.%f")
+
+
+def _optional_str(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text or None
+
+
+def _executor_info() -> tuple[str | None, str | None]:
+    return _local_ip(), _local_mac()
+
+
+def _local_ip() -> str | None:
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            sock.connect(("8.8.8.8", 80))
+            return str(sock.getsockname()[0])
+    except OSError:
+        return None
+
+
+def _local_mac() -> str | None:
+    node = uuid.getnode()
+    if (node >> 40) & 1:
+        return None
+    return ":".join(f"{(node >> shift) & 0xFF:02x}" for shift in range(40, -1, -8))

--- a/type_bridge/models/registry.py
+++ b/type_bridge/models/registry.py
@@ -13,6 +13,20 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T", bound="TypeDBType")
 
 
+def _is_snapshot(model: type) -> bool:
+    """Helper to detect if a class is a snapshot class."""
+    if getattr(model, "_is_snapshot", False):
+        return True
+    module = getattr(model, "__module__", "") or ""
+    parts = module.split(".")
+    for i, part in enumerate(parts):
+        if part == "snapshots" and i + 1 < len(parts):
+            next_part = parts[i + 1]
+            if next_part.startswith("v") and next_part[1:].isdigit():
+                return True
+    return False
+
+
 class ModelRegistry:
     """Registry for TypeDB model classes.
 
@@ -34,6 +48,9 @@ class ModelRegistry:
         """
         # Skip base classes like Entity/Relation
         if model.is_base():
+            return
+
+        if _is_snapshot(model):
             return
 
         type_name = model.get_type_name()
@@ -108,6 +125,8 @@ class ModelRegistry:
         def find_in_subclasses(search_cls: type[T]) -> type[T] | None:
             """Recursively search subclasses for matching type name."""
             for subclass in search_cls.__subclasses__():
+                if _is_snapshot(subclass) != _is_snapshot(search_cls):
+                    continue
                 if subclass.get_type_name() == type_label:
                     return cast("type[T]", subclass)
                 found = find_in_subclasses(cast("type[T]", subclass))
@@ -134,6 +153,8 @@ class ModelRegistry:
         (i.e. after SchemaScanner runs in Entity/Relation ``__init_subclass__``).
         """
         if model.is_base():
+            return
+        if _is_snapshot(model):
             return
         for attr_info in model._owned_attrs.values():
             cls._attribute_owners.setdefault(attr_info.typ, set()).add(model)


### PR DESCRIPTION
- add RunPython migrations with normal manager APIs
- store migration state and run logs in TypeDB
- generate replay-safe historical snapshot bindings
- validate snapshot and sidecar drift before execution
- document migration workflow and snapshot rationale
- bump package versions to 1.5.3

Closes: #158
Closes: #160 