### PR TITLE
feat(generator): support case-insensitive overrides, PascalCase, and …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [master, develop]
 
 env:
-  CARGO_HOME: ${{ github.workspace }}/.cargo-home
+  CARGO_HOME: ${{ runner.temp }}/cargo-home
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
   RUST_STABLE_TOOLCHAIN: "1.94.1"
 
@@ -32,6 +32,7 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: ${{ env.RUST_STABLE_TOOLCHAIN }}
+          components: clippy
 
       - name: Cache cargo registry and build
         uses: actions/cache@v4
@@ -40,7 +41,7 @@ jobs:
             ${{ env.CARGO_HOME }}/registry
             ${{ env.CARGO_HOME }}/git
             type-bridge-core/target
-          key: ${{ runner.os }}-cargo-v2-${{ hashFiles('type-bridge-core/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-v3-${{ hashFiles('type-bridge-core/Cargo.lock') }}
 
       - name: cargo check
         working-directory: type-bridge-core
@@ -83,7 +84,7 @@ jobs:
             ${{ env.CARGO_HOME }}/registry
             ${{ env.CARGO_HOME }}/git
             type-bridge-core/target
-          key: ${{ runner.os }}-cargo-band-v2-${{ matrix.band }}-${{ hashFiles('type-bridge-core/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-band-v3-${{ matrix.band }}-${{ hashFiles('type-bridge-core/Cargo.lock') }}
 
       - name: cargo check (${{ matrix.band }})
         working-directory: type-bridge-core
@@ -116,7 +117,7 @@ jobs:
             ${{ env.CARGO_HOME }}/registry
             ${{ env.CARGO_HOME }}/git
             type-bridge-core/target
-          key: ${{ runner.os }}-cargo-nightly-v2-${{ hashFiles('type-bridge-core/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-nightly-v3-${{ hashFiles('type-bridge-core/Cargo.lock') }}
 
       - name: Generate LCOV report
         run: ./scripts/coverage.sh branch --lcov
@@ -214,7 +215,7 @@ jobs:
             ${{ env.CARGO_HOME }}/registry
             ${{ env.CARGO_HOME }}/git
             type-bridge-core/target
-          key: ${{ runner.os }}-cargo-node-v2-${{ hashFiles('type-bridge-core/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-node-v3-${{ hashFiles('type-bridge-core/Cargo.lock') }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master, develop]
 
+env:
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+
 jobs:
   # Rust crate: compile, test, lint (parallel with Python jobs)
   rust-check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [master, develop]
 
 env:
-  CARGO_HOME: ${{ runner.temp }}/cargo-home
+  CARGO_HOME: ${{ github.workspace }}/../.cargo-home
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
   RUST_STABLE_TOOLCHAIN: "1.94.1"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     branches: [master, develop]
 
 env:
+  CARGO_HOME: ${{ github.workspace }}/.cargo-home
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 jobs:
@@ -35,8 +36,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
+            ${{ env.CARGO_HOME }}/registry
+            ${{ env.CARGO_HOME }}/git
             type-bridge-core/target
           key: ${{ runner.os }}-cargo-v2-${{ hashFiles('type-bridge-core/Cargo.lock') }}
 
@@ -78,8 +79,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
+            ${{ env.CARGO_HOME }}/registry
+            ${{ env.CARGO_HOME }}/git
             type-bridge-core/target
           key: ${{ runner.os }}-cargo-band-v2-${{ matrix.band }}-${{ hashFiles('type-bridge-core/Cargo.lock') }}
 
@@ -111,8 +112,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
+            ${{ env.CARGO_HOME }}/registry
+            ${{ env.CARGO_HOME }}/git
             type-bridge-core/target
           key: ${{ runner.os }}-cargo-nightly-v2-${{ hashFiles('type-bridge-core/Cargo.lock') }}
 
@@ -208,8 +209,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
+            ${{ env.CARGO_HOME }}/registry
+            ${{ env.CARGO_HOME }}/git
             type-bridge-core/target
           key: ${{ runner.os }}-cargo-node-v2-${{ hashFiles('type-bridge-core/Cargo.lock') }}
 
@@ -508,8 +509,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
+            ${{ env.CARGO_HOME }}/registry
+            ${{ env.CARGO_HOME }}/git
             type-bridge-core/target
           key: ${{ runner.os }}-cargo-parity-v2-${{ hashFiles('type-bridge-core/Cargo.lock') }}
 
@@ -640,8 +641,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
+            ${{ env.CARGO_HOME }}/registry
+            ${{ env.CARGO_HOME }}/git
             type-bridge-core/target
           key: ${{ runner.os }}-cargo-node-v2-${{ hashFiles('type-bridge-core/Cargo.lock') }}
 
@@ -759,8 +760,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
+            ${{ env.CARGO_HOME }}/registry
+            ${{ env.CARGO_HOME }}/git
             type-bridge-core/target
           key: ${{ runner.os }}-cargo-gate-v2-${{ hashFiles('type-bridge-core/Cargo.lock') }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 env:
   CARGO_HOME: ${{ github.workspace }}/.cargo-home
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+  RUST_STABLE_TOOLCHAIN: "1.94.1"
 
 jobs:
   # Rust crate: compile, test, lint (parallel with Python jobs)
@@ -30,7 +31,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
-          toolchain: stable
+          toolchain: ${{ env.RUST_STABLE_TOOLCHAIN }}
 
       - name: Cache cargo registry and build
         uses: actions/cache@v4
@@ -73,7 +74,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
-          toolchain: stable
+          toolchain: ${{ env.RUST_STABLE_TOOLCHAIN }}
 
       - name: Cache cargo registry and build
         uses: actions/cache@v4
@@ -177,6 +178,7 @@ jobs:
           CFLAGS_aarch64_unknown_linux_gnu: ${{ matrix.target == 'aarch64-unknown-linux-gnu' && '-D__ARM_ARCH=8' || '' }}
         with:
           target: ${{ matrix.target }}
+          rust-toolchain: ${{ env.RUST_STABLE_TOOLCHAIN }}
           args: --release --out dist -i python3.13
           manylinux: auto
           working-directory: type-bridge-core
@@ -203,7 +205,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
-          toolchain: stable
+          toolchain: ${{ env.RUST_STABLE_TOOLCHAIN }}
 
       - name: Cache cargo registry and build
         uses: actions/cache@v4
@@ -261,7 +263,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
-          toolchain: stable
+          toolchain: ${{ env.RUST_STABLE_TOOLCHAIN }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
@@ -298,7 +300,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
-          toolchain: stable
+          toolchain: ${{ env.RUST_STABLE_TOOLCHAIN }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
@@ -339,7 +341,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
-          toolchain: stable
+          toolchain: ${{ env.RUST_STABLE_TOOLCHAIN }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
@@ -412,7 +414,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
-          toolchain: stable
+          toolchain: ${{ env.RUST_STABLE_TOOLCHAIN }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
@@ -503,7 +505,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
-          toolchain: stable
+          toolchain: ${{ env.RUST_STABLE_TOOLCHAIN }}
 
       - name: Cache cargo registry and build
         uses: actions/cache@v4
@@ -635,7 +637,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
-          toolchain: stable
+          toolchain: ${{ env.RUST_STABLE_TOOLCHAIN }}
 
       - name: Cache cargo registry and build
         uses: actions/cache@v4
@@ -754,7 +756,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
-          toolchain: stable
+          toolchain: ${{ env.RUST_STABLE_TOOLCHAIN }}
 
       - name: Cache cargo registry and build
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             type-bridge-core/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('type-bridge-core/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+          key: ${{ runner.os }}-cargo-v2-${{ hashFiles('type-bridge-core/Cargo.lock') }}
 
       - name: cargo check
         working-directory: type-bridge-core
@@ -80,10 +78,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             type-bridge-core/target
-          key: ${{ runner.os }}-cargo-band-${{ matrix.band }}-${{ hashFiles('type-bridge-core/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-band-${{ matrix.band }}-
-            ${{ runner.os }}-cargo-
+          key: ${{ runner.os }}-cargo-band-v2-${{ matrix.band }}-${{ hashFiles('type-bridge-core/Cargo.lock') }}
 
       - name: cargo check (${{ matrix.band }})
         working-directory: type-bridge-core
@@ -116,9 +111,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             type-bridge-core/target
-          key: ${{ runner.os }}-cargo-nightly-${{ hashFiles('type-bridge-core/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-nightly-
+          key: ${{ runner.os }}-cargo-nightly-v2-${{ hashFiles('type-bridge-core/Cargo.lock') }}
 
       - name: Generate LCOV report
         run: ./scripts/coverage.sh branch --lcov
@@ -215,10 +208,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             type-bridge-core/target
-          key: ${{ runner.os }}-cargo-node-${{ hashFiles('type-bridge-core/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-node-
-            ${{ runner.os }}-cargo-
+          key: ${{ runner.os }}-cargo-node-v2-${{ hashFiles('type-bridge-core/Cargo.lock') }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -518,10 +508,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             type-bridge-core/target
-          key: ${{ runner.os }}-cargo-parity-${{ hashFiles('type-bridge-core/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-parity-
-            ${{ runner.os }}-cargo-
+          key: ${{ runner.os }}-cargo-parity-v2-${{ hashFiles('type-bridge-core/Cargo.lock') }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
@@ -653,10 +640,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             type-bridge-core/target
-          key: ${{ runner.os }}-cargo-node-${{ hashFiles('type-bridge-core/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-node-
-            ${{ runner.os }}-cargo-
+          key: ${{ runner.os }}-cargo-node-v2-${{ hashFiles('type-bridge-core/Cargo.lock') }}
 
       # Node >= 22 is required here (unlike the other Node jobs): run-integration.js
       # executes the .test.ts files directly via node --test, relying on Node's
@@ -775,7 +759,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             type-bridge-core/target
-          key: ${{ runner.os }}-cargo-gate-${{ hashFiles('type-bridge-core/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-gate-v2-${{ hashFiles('type-bridge-core/Cargo.lock') }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,9 @@ permissions:
   pages: write
   id-token: write
 
+env:
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+
 jobs:
   build:
     name: Build docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,9 +53,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             type-bridge-core/target
-          key: ${{ runner.os }}-cargo-docs-${{ hashFiles('type-bridge-core/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-docs-
+          key: ${{ runner.os }}-cargo-docs-v2-${{ hashFiles('type-bridge-core/Cargo.lock') }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ permissions:
   id-token: write
 
 env:
-  CARGO_HOME: ${{ runner.temp }}/cargo-home
+  CARGO_HOME: ${{ github.workspace }}/../.cargo-home
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
   RUST_STABLE_TOOLCHAIN: "1.94.1"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ permissions:
   id-token: write
 
 env:
-  CARGO_HOME: ${{ github.workspace }}/.cargo-home
+  CARGO_HOME: ${{ runner.temp }}/cargo-home
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
   RUST_STABLE_TOOLCHAIN: "1.94.1"
 
@@ -58,7 +58,7 @@ jobs:
             ${{ env.CARGO_HOME }}/registry
             ${{ env.CARGO_HOME }}/git
             type-bridge-core/target
-          key: ${{ runner.os }}-cargo-docs-v2-${{ hashFiles('type-bridge-core/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-docs-v3-${{ hashFiles('type-bridge-core/Cargo.lock') }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,6 +31,7 @@ permissions:
 env:
   CARGO_HOME: ${{ github.workspace }}/.cargo-home
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+  RUST_STABLE_TOOLCHAIN: "1.94.1"
 
 jobs:
   build:
@@ -48,7 +49,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
-          toolchain: stable
+          toolchain: ${{ env.RUST_STABLE_TOOLCHAIN }}
 
       - name: Cache cargo registry and build
         uses: actions/cache@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,7 @@ permissions:
   id-token: write
 
 env:
+  CARGO_HOME: ${{ github.workspace }}/.cargo-home
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 jobs:
@@ -53,8 +54,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
+            ${{ env.CARGO_HOME }}/registry
+            ${{ env.CARGO_HOME }}/git
             type-bridge-core/target
           key: ${{ runner.os }}-cargo-docs-v2-${{ hashFiles('type-bridge-core/Cargo.lock') }}
 

--- a/docs/guide/generator.md
+++ b/docs/guide/generator.md
@@ -538,10 +538,30 @@ entity user,
 | --------------------- | ------------------------------------ |
 | `# @prefix(XXX)`      | Adds `prefix: ClassVar[str] = "XXX"` |
 | `# @internal`         | Sets `internal = True` on the spec   |
-| `# @case(SNAKE_CASE)` | Uses specified case for type name    |
 | `# @transform(xxx)`   | Adds `transform = "xxx"` attribute   |
 | `# @tags(a, b, c)`    | Adds list annotation                 |
 | `# Any other comment` | Becomes the class docstring          |
+
+### Automatic Type Name Case Inference
+
+When generating Python models, the generator automatically infers the correct `TypeNameCase` for each type based on its TypeDB name. You do not need to manually specify a case or use annotations, but you can override it if you want.
+
+To override the case, you can use the `@case` annotation. The argument is case-insensitive:
+```typeql
+# Applies to all languages
+# @case(PascalCase)
+entity forced_class_name;
+
+# Applies only to Python
+# @case(Python, SnakeCase)
+entity forced_python_snake;
+```
+
+
+- If the TypeDB name is `person_name`, the generator assigns `flags = TypeFlags(case=TypeNameCase.SNAKE_CASE)`.
+- If the TypeDB name is `PersonName`, it assigns `flags = TypeFlags(case=TypeNameCase.CLASS_NAME)`.
+- If the TypeDB name is `personname`, it assigns `flags = TypeFlags(case=TypeNameCase.LOWERCASE)`.
+- For names that don't fit these conventions (e.g., kebab-case `person-name`), the generator falls back to explicitly emitting `name="person-name"`.
 
 ## Functions
 

--- a/docs/guide/toml.md
+++ b/docs/guide/toml.md
@@ -51,6 +51,9 @@ A `.tql` file or raw TypeQL text continues to work exactly as before.
 value = "string"      # value type (see table below); required unless sub is set
 sub   = "parent"      # inherit from a parent attribute instead of declaring a value type
 abstract = true       # mark as abstract
+bindgen_case = "SnakeCase" # specify class name case explicitly for bindgen
+annotations = ["dto_name(MyDTO)"] # specify code generator annotations for bindgen
+
 
 # Annotation constraints (optional, combine as needed)
 regex  = "^active|inactive$"
@@ -103,6 +106,8 @@ sub = "id"     # inherits from id; no value key
 [entities.NAME]
 sub      = "parent"    # optional; inherit from another entity
 abstract = true        # optional; mark as abstract
+bindgen_case = "PascalCase" # optional; explicitly override class case naming
+annotations = ["dto_name(MyDTO)"] # optional; add custom generator annotations
 owns     = [...]       # list of owned attributes (see below)
 plays    = [...]       # list of roles the entity plays (see below)
 ```
@@ -146,12 +151,16 @@ value  = "string"
 values = ["beginner", "intermediate", "expert"]
 
 [entities.user]
+bindgen_case = "PascalCase"
+annotations = ["dto_name(UserDto)"]
 owns = [
     { attribute = "username", key = true },
     "score",
-    { attribute = "tag", card = "0..5" },
+    { attribute = "tag", card = "0..3" },
 ]
-plays = [{ relation = "membership", role = "member" }]
+plays = [
+    { relation = "membership", role = "member" }
+]
 ```
 
 ### Relations
@@ -160,6 +169,8 @@ plays = [{ relation = "membership", role = "member" }]
 [relations.NAME]
 sub      = "parent"    # optional; inherit from another relation
 abstract = true        # optional; mark as abstract
+bindgen_case = "PascalCase" # optional; explicitly override class case naming
+annotations = ["dto_name(MyDTO)"] # optional; add custom generator annotations
 roles    = [...]       # list of role definitions (see below)
 owns     = [...]       # list of owned attributes (same syntax as entities)
 plays    = [...]       # roles this relation itself plays

--- a/tests/unit/generator/test_generator.py
+++ b/tests/unit/generator/test_generator.py
@@ -41,6 +41,66 @@ class TestGenerateModels:
                 content = py_file.read_text()
                 compile(content, py_file.name, "exec")
 
+    def test_case_annotation_inference_and_overrides(self) -> None:
+        """Test that TypeNameCase inference and @case overrides work correctly."""
+        schema_text = """
+            define
+            attribute name, value string;
+
+            # @case(PascalCase)
+            entity forced_class_name, owns name @key;
+
+            # @case(Python, LowerCase)
+            entity forced_python_lower, owns name @key;
+
+            entity FirstPerson, owns name @key;
+
+            entity technology_company, owns name @key;
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = Path(tmpdir) / "models"
+            generate_models(schema_text, output)
+
+            entities_code = (output / "entities.py").read_text()
+
+            # forced_class_name should have CLASS_NAME (override)
+            assert "case=TypeNameCase.CLASS_NAME" in entities_code
+            assert "class ForcedClassName" in entities_code
+
+            # forced_python_lower should have LOWERCASE (override)
+            assert "case=TypeNameCase.LOWERCASE" in entities_code
+            assert "class ForcedPythonLower" in entities_code
+
+            # FirstPerson should automatically get CLASS_NAME
+            # wait, it might be implicitly inferred without any string because default is CLASS_NAME
+            assert "class Firstperson" not in entities_code
+            assert "class FirstPerson" in entities_code
+
+            # technology_company should automatically get SNAKE_CASE
+            assert "case=TypeNameCase.SNAKE_CASE" in entities_code
+            assert "class TechnologyCompany" in entities_code
+
+    def test_toml_transpiler_annotations(self) -> None:
+        """Test that annotations in TOML schemas are emitted correctly."""
+        schema_text = """
+        [attributes.name]
+        value = "string"
+
+        [entities.customer]
+        bindgen_case = "Python, PascalCase"
+        annotations = ["dto_name(CustomerDto)"]
+        owns = ["name"]
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = Path(tmpdir) / "models"
+            generate_models(schema_text, output, format="toml")
+
+            entities_code = (output / "entities.py").read_text()
+            assert "class Customer" in entities_code
+            assert "case=TypeNameCase.CLASS_NAME" in entities_code
+
     def test_generates_from_file(self) -> None:
         """Generate from a schema file path."""
         if not BOOKSTORE_SCHEMA.exists():

--- a/tests/unit/generator/test_naming.py
+++ b/tests/unit/generator/test_naming.py
@@ -1,8 +1,6 @@
-"""Tests for naming convention utilities."""
+"""Tests for generator naming helpers."""
 
 from __future__ import annotations
-
-import pytest
 
 from type_bridge.generator.naming import (
     build_class_name_map,
@@ -12,96 +10,44 @@ from type_bridge.generator.naming import (
 )
 
 
-class TestToClassName:
-    """Tests for to_class_name conversion."""
-
-    @pytest.mark.parametrize(
-        ("input_name", "expected"),
-        [
-            ("person", "Person"),
-            ("isbn-13", "Isbn13"),
-            ("order-line", "OrderLine"),
-            ("birth-date", "BirthDate"),
-            ("user-action-log", "UserActionLog"),
-            ("a", "A"),
-            ("ABC", "Abc"),
-        ],
-    )
-    def test_conversion(self, input_name: str, expected: str) -> None:
-        """Test various kebab-case to PascalCase conversions."""
-        assert to_class_name(input_name) == expected
+def test_to_class_name_preserves_mixed_case_segments() -> None:
+    """Mixed-case segments should preserve their internal casing."""
+    assert to_class_name("person-name") == "PersonName"
+    assert to_class_name("person_NAME") == "PersonName"
+    assert to_class_name("firstPerson") == "FirstPerson"
+    assert to_class_name("api_KEY") == "ApiKey"
 
 
-class TestToPythonName:
-    """Tests for to_python_name conversion."""
-
-    @pytest.mark.parametrize(
-        ("input_name", "expected"),
-        [
-            ("person", "person"),
-            ("isbn-13", "isbn_13"),
-            ("order-line", "order_line"),
-            ("birth-date", "birth_date"),
-            ("a", "a"),
-        ],
-    )
-    def test_conversion(self, input_name: str, expected: str) -> None:
-        """Test various kebab-case to snake_case conversions."""
-        assert to_python_name(input_name) == expected
+def test_to_python_name_replaces_hyphens_with_underscores() -> None:
+    assert to_python_name("birth-date") == "birth_date"
 
 
-class TestBuildClassNameMap:
-    """Tests for build_class_name_map."""
-
-    def test_builds_mapping(self) -> None:
-        """Build mapping from TypeDB names to class names."""
-        names = {"person": None, "order-line": None, "isbn-13": None}
-        result = build_class_name_map(names)
-        assert result == {
-            "person": "Person",
-            "order-line": "OrderLine",
-            "isbn-13": "Isbn13",
-        }
-
-    def test_empty_dict(self) -> None:
-        """Empty input returns empty output."""
-        assert build_class_name_map({}) == {}
+def test_build_class_name_map_uses_to_class_name() -> None:
+    result = build_class_name_map({"person-name": 1, "birth-date": 1, "firstPerson": 1})
+    assert result == {
+        "person-name": "PersonName",
+        "birth-date": "BirthDate",
+        "firstPerson": "FirstPerson",
+    }
 
 
-class TestRenderAllExport:
-    """Tests for __all__ list rendering."""
+def test_render_all_export_sorts_names() -> None:
+    assert render_all_export(["beta", "alpha", "gamma"]) == [
+        "__all__ = [",
+        '    "alpha",',
+        '    "beta",',
+        '    "gamma",',
+        "]",
+        "",
+    ]
 
-    def test_basic_export(self) -> None:
-        """Render basic __all__ export."""
-        lines = render_all_export(["Foo", "Bar", "Baz"])
-        expected = [
-            "__all__ = [",
-            '    "Bar",',
-            '    "Baz",',
-            '    "Foo",',  # Sorted alphabetically
-            "]",
-            "",
-        ]
-        assert lines == expected
 
-    def test_with_extras(self) -> None:
-        """Render __all__ with extra exports."""
-        lines = render_all_export(["Foo"], extras=["helper"])
-        expected = [
-            "__all__ = [",
-            '    "Foo",',
-            '    "helper",',
-            "]",
-            "",
-        ]
-        assert lines == expected
-
-    def test_empty_list(self) -> None:
-        """Empty list still renders valid __all__."""
-        lines = render_all_export([])
-        expected = [
-            "__all__ = [",
-            "]",
-            "",
-        ]
-        assert lines == expected
+def test_render_all_export_adds_extras() -> None:
+    assert render_all_export(["beta", "alpha"], extras=["All"]) == [
+        "__all__ = [",
+        '    "alpha",',
+        '    "beta",',
+        '    "All",',
+        "]",
+        "",
+    ]

--- a/type-bridge-core/Cargo.lock
+++ b/type-bridge-core/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b46cbb362ab8752921c97e041.5.466ee6297bd428a31275b9fcf1e380f7299"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -1143,7 +1143,7 @@ dependencies = [
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51.5.413d4306cca8e46"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -1612,7 +1612,7 @@ dependencies = [
 name = "prost-derive"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1.5.4472929fdd74bec4d"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -1821,7 +1821,7 @@ dependencies = [
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa01.5.4185d0a"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "ring"

--- a/type-bridge-core/crates/core/src/bindgen.rs
+++ b/type-bridge-core/crates/core/src/bindgen.rs
@@ -256,7 +256,14 @@ fn class_name(label: &str) -> String {
             match chars.next() {
                 Some(first) => {
                     let mut out = first.to_uppercase().collect::<String>();
-                    out.push_str(&chars.as_str().to_lowercase());
+                    let rest = chars.as_str();
+                    let is_upper = part.chars().all(|c| c.is_uppercase());
+                    let is_lower = part.chars().all(|c| c.is_lowercase());
+                    if is_upper || is_lower {
+                        out.push_str(&rest.to_lowercase());
+                    } else {
+                        out.push_str(rest);
+                    }
                     out
                 }
                 None => String::new(),
@@ -284,6 +291,82 @@ fn rust_pascal_case(label: &str) -> String {
 
 fn field_name(label: &str) -> String {
     label.replace('-', "_")
+}
+
+fn python_type_name_case(
+    name: &str,
+    class: &str,
+    default_case: &str,
+    annotations: Option<&AnnotationMap>,
+) -> Option<String> {
+    if let Some(annotations) = annotations
+        && let Some(val) = annotations.get("case")
+    {
+        let mut explicit_case = None;
+        if let Some(s) = val.as_str() {
+            explicit_case = Some(s.to_string());
+        } else if let Some(arr) = val.as_array()
+            && arr.len() == 2
+            && let (Some(lang), Some(case_val)) = (arr[0].as_str(), arr[1].as_str())
+            && lang.to_lowercase() == "python"
+        {
+            explicit_case = Some(case_val.to_string());
+        }
+        if let Some(c) = explicit_case {
+            let mut c_lower = c.to_lowercase();
+            c_lower = c_lower.replace("_", "");
+            let mapped_case = match c_lower.as_str() {
+                "pascalcase" | "classname" => "CLASS_NAME",
+                "snakecase" => "SNAKE_CASE",
+                "lowercase" => "LOWERCASE",
+                _ => &c, // fallback
+            };
+            return Some(format!("case=TypeNameCase.{}", mapped_case));
+        }
+    }
+
+    let lower = class.to_lowercase();
+    let mut snake = String::new();
+    let chars: Vec<char> = class.chars().collect();
+    for i in 0..chars.len() {
+        let c = chars[i];
+        if i > 0 && c.is_uppercase() {
+            let prev = chars[i - 1];
+            let next = if i + 1 < chars.len() {
+                Some(chars[i + 1])
+            } else {
+                None
+            };
+            let is_prev_lower_or_digit = prev.is_lowercase() || prev.is_ascii_digit();
+            let is_next_lower = next.map(|n| n.is_lowercase()).unwrap_or(false);
+            if is_prev_lower_or_digit || is_next_lower {
+                snake.push('_');
+            }
+        }
+        snake.extend(c.to_lowercase());
+    }
+
+    if name == snake {
+        if default_case == "SNAKE_CASE" {
+            None
+        } else {
+            Some("case=TypeNameCase.SNAKE_CASE".to_string())
+        }
+    } else if name == class {
+        if default_case == "CLASS_NAME" {
+            None
+        } else {
+            Some("case=TypeNameCase.CLASS_NAME".to_string())
+        }
+    } else if name == lower {
+        if default_case == "LOWERCASE" {
+            None
+        } else {
+            Some("case=TypeNameCase.LOWERCASE".to_string())
+        }
+    } else {
+        Some(format!("name={}", string_literal(name)))
+    }
 }
 
 fn string_literal(value: &str) -> String {
@@ -723,12 +806,24 @@ fn render_python_attributes(schema: &TypeSchema, options: &BindgenOptions) -> St
 
         writeln!(out, "class {class}({base}):").unwrap();
         writeln!(out, "    \"\"\"{doc}\"\"\"").unwrap();
-        writeln!(
-            out,
-            "    flags = AttributeFlags(name={})",
-            string_literal(name)
-        )
-        .unwrap();
+        let mut flags = Vec::new();
+        if let Some(case) = python_type_name_case(
+            name,
+            &class,
+            "SNAKE_CASE",
+            options.python_metadata.attribute_annotations.get(name),
+        ) {
+            flags.push(case);
+        }
+        if !flags.iter().any(|f| f.starts_with("name=")) {
+            flags.insert(0, format!("name={}", string_literal(name)));
+        }
+        let flags_str = if flags.is_empty() {
+            String::new()
+        } else {
+            flags.join(", ")
+        };
+        writeln!(out, "    flags = AttributeFlags({flags_str})").unwrap();
         if attr.is_independent {
             writeln!(out, "    independent = True").unwrap();
         }
@@ -838,7 +933,14 @@ fn render_python_entities(schema: &TypeSchema, options: &BindgenOptions) -> Stri
         .values()
         .any(|entity| entity.owns.iter().any(|owned| owned.distinct));
 
-    let mut imports = vec!["Entity", "Flag", "Key", "TypeFlags", "Unique"];
+    let mut imports = vec![
+        "Entity",
+        "Flag",
+        "Key",
+        "TypeFlags",
+        "TypeNameCase",
+        "Unique",
+    ];
     if needs_card {
         imports.insert(1, "Card");
     }
@@ -873,7 +975,19 @@ fn render_python_entities(schema: &TypeSchema, options: &BindgenOptions) -> Stri
             .unwrap_or_else(|| "Entity".to_string());
         let doc = docstring(&options.python_metadata.entity_annotations, name)
             .unwrap_or_else(|| format!("Entity generated from `{name}`."));
-        let mut flags = vec![format!("name={}", string_literal(name))];
+        let mut flags = Vec::new();
+        if let Some(case) = python_type_name_case(
+            name,
+            &class,
+            "CLASS_NAME",
+            options
+                .python_metadata
+                .entity_annotations
+                .get(name)
+                .or_else(|| options.python_metadata.relation_annotations.get(name)),
+        ) {
+            flags.push(case);
+        }
         if entity.is_abstract {
             flags.push("abstract=True".to_string());
         }
@@ -1061,7 +1175,7 @@ fn render_python_relations(schema: &TypeSchema, options: &BindgenOptions) -> Str
             || relation.owns.iter().any(|owned| owned.distinct)
     });
 
-    let mut imports = vec!["Relation", "Role", "TypeFlags"];
+    let mut imports = vec!["Relation", "Role", "TypeFlags", "TypeNameCase"];
     if needs_card {
         imports.insert(0, "Card");
     }
@@ -1118,7 +1232,19 @@ fn render_python_relations(schema: &TypeSchema, options: &BindgenOptions) -> Str
             .unwrap_or_else(|| "Relation".to_string());
         let doc = docstring(&options.python_metadata.relation_annotations, name)
             .unwrap_or_else(|| format!("Relation generated from `{name}`."));
-        let mut flags = vec![format!("name={}", string_literal(name))];
+        let mut flags = Vec::new();
+        if let Some(case) = python_type_name_case(
+            name,
+            &class,
+            "CLASS_NAME",
+            options
+                .python_metadata
+                .entity_annotations
+                .get(name)
+                .or_else(|| options.python_metadata.relation_annotations.get(name)),
+        ) {
+            flags.push(case);
+        }
         if relation.is_abstract {
             flags.push("abstract=True".to_string());
         }
@@ -2737,5 +2863,69 @@ relation friendship, relates friend @card(1..2);"
                 .contains("#[entity(name = \"party\", r#abstract)]")
         );
         assert!(models.relations_rs.contains("player_type = \"person\""));
+    }
+
+    #[test]
+    fn python_render_infers_and_applies_case_overrides() {
+        let schema_text = r#"define
+attribute name, value string;
+
+# @case(PascalCase)
+entity forced_class_name, owns name @key;
+
+# @case(Python, LowerCase)
+entity forced_python_lower, owns name @key;
+
+entity FirstPerson, owns name @key;
+
+        entity technology_company, owns name @key;"#;
+
+        let plan = BindgenPlan::from_typeql(schema_text).unwrap();
+        let mut options = BindgenOptions::default();
+        options.python_metadata.entity_annotations.insert(
+            "forced_class_name".to_string(),
+            BTreeMap::from([("case".to_string(), serde_json::json!("PascalCase"))]),
+        );
+        options.python_metadata.entity_annotations.insert(
+            "forced_python_lower".to_string(),
+            BTreeMap::from([(
+                "case".to_string(),
+                serde_json::json!(["Python", "LowerCase"]),
+            )]),
+        );
+        let package = plan.render(TargetLanguage::Python, &options);
+        let entities = package
+            .file("entities.py")
+            .expect("entities.py was generated");
+
+        assert!(entities.contents.contains("class ForcedClassName(Entity):"));
+        assert!(
+            entities
+                .contents
+                .contains("flags = TypeFlags(case=TypeNameCase.CLASS_NAME)")
+        );
+        assert!(
+            entities
+                .contents
+                .contains("class ForcedPythonLower(Entity):")
+        );
+        assert!(
+            entities
+                .contents
+                .contains("flags = TypeFlags(case=TypeNameCase.LOWERCASE)")
+        );
+        assert!(entities.contents.contains("class FirstPerson(Entity):"));
+        assert!(
+            entities
+                .contents
+                .contains("class TechnologyCompany(Entity):")
+        );
+        assert!(
+            entities
+                .contents
+                .contains("flags = TypeFlags(case=TypeNameCase.SNAKE_CASE)")
+        );
+        assert!(entities.contents.contains("class FirstPerson(Entity):"));
+        assert!(entities.contents.contains("flags = TypeFlags()"));
     }
 }

--- a/type-bridge-core/crates/core/src/parser.rs
+++ b/type-bridge-core/crates/core/src/parser.rs
@@ -142,11 +142,19 @@ fn parse_schema(input: &mut &str) -> PResult<TypeSchema> {
 
     for plays in standalone_plays {
         if let Some(entity) = schema.entities.get_mut(&plays.player) {
-            if !entity.plays.iter().any(|p| p.role_ref == plays.played.role_ref) {
+            if !entity
+                .plays
+                .iter()
+                .any(|p| p.role_ref == plays.played.role_ref)
+            {
                 entity.plays.push(plays.played);
             }
         } else if let Some(relation) = schema.relations.get_mut(&plays.player) {
-            if !relation.plays.iter().any(|p| p.role_ref == plays.played.role_ref) {
+            if !relation
+                .plays
+                .iter()
+                .any(|p| p.role_ref == plays.played.role_ref)
+            {
                 relation.plays.push(plays.played);
             }
         } else {
@@ -1940,7 +1948,8 @@ entity person
 
     #[test]
     fn test_parse_standalone_plays() {
-        let schema = parse_typeql("define\nentity person;\nperson plays friendship:friend;\n").unwrap();
+        let schema =
+            parse_typeql("define\nentity person;\nperson plays friendship:friend;\n").unwrap();
         let person = schema.entities.get("person").unwrap();
         assert_eq!(person.plays.len(), 1);
         assert_eq!(person.plays[0].role_ref, "friendship:friend");

--- a/type-bridge-core/crates/toml-transpiler/src/emit.rs
+++ b/type-bridge-core/crates/toml-transpiler/src/emit.rs
@@ -79,6 +79,13 @@ pub fn emit(schema: &TomlSchema) -> String {
         // The head itself is: `attribute <name>[sub <parent>] [@abstract]`
         // Then value + value-annotations follow as additional clauses.
 
+        for ann in &attr.annotations {
+            out.push_str(&format!("# @{}\n", ann));
+        }
+        if let Some(case) = &attr.bindgen_case {
+            out.push_str(&format!("# @case({})\n", case));
+        }
+
         let head = type_head("attribute", name, attr.is_abstract, attr.sub.as_deref());
 
         // Build the value clause (with optional value-level annotations).
@@ -114,6 +121,12 @@ pub fn emit(schema: &TomlSchema) -> String {
     // --- entities ---
     for (name, entity) in &schema.entities {
         // Build the type-head: `entity <name>` + optional abstract/sub tokens.
+        for ann in &entity.annotations {
+            out.push_str(&format!("# @{}\n", ann));
+        }
+        if let Some(case) = &entity.bindgen_case {
+            out.push_str(&format!("# @case({})\n", case));
+        }
         let head = type_head("entity", name, entity.is_abstract, entity.sub.as_deref());
 
         let mut clauses: Vec<String> = Vec::new();
@@ -151,6 +164,12 @@ pub fn emit(schema: &TomlSchema) -> String {
     // --- relations ---
     for (name, relation) in &schema.relations {
         // Build the type-head: `relation <name>` + optional abstract/sub tokens.
+        for ann in &relation.annotations {
+            out.push_str(&format!("# @{}\n", ann));
+        }
+        if let Some(case) = &relation.bindgen_case {
+            out.push_str(&format!("# @case({})\n", case));
+        }
         let head = type_head(
             "relation",
             name,
@@ -576,6 +595,40 @@ regex = "^(paid|dispatched)$"
         assert!(
             result.contains(r#"attribute status, value string @regex("^(paid|dispatched)$");"#),
             "expected @regex after value; got:\n{result}"
+        );
+    }
+
+    /// Explicit `annotations` and `bindgen_case` emit correctly.
+    #[test]
+    fn test_emit_annotations_and_bindgen_case() {
+        let toml_text = r#"
+[attributes.my-attr]
+value = "string"
+bindgen_case = "PascalCase"
+annotations = ["internal"]
+
+[entities.my-entity]
+bindgen_case = "Python, SnakeCase"
+annotations = ["dto_name(MyEntityDto)"]
+
+[relations.my-relation]
+bindgen_case = "CamelCase"
+annotations = ["custom_annotation"]
+"#;
+        let result = toml_to_typeql(toml_text).expect("toml_to_typeql failed");
+
+        assert!(
+            result.contains("# @internal\n# @case(PascalCase)\nattribute my-attr"),
+            "expected attr annotations; got:\n{result}"
+        );
+        assert!(
+            result
+                .contains("# @dto_name(MyEntityDto)\n# @case(Python, SnakeCase)\nentity my-entity"),
+            "expected entity annotations; got:\n{result}"
+        );
+        assert!(
+            result.contains("# @custom_annotation\n# @case(CamelCase)\nrelation my-relation"),
+            "expected relation annotations; got:\n{result}"
         );
     }
 

--- a/type-bridge-core/crates/toml-transpiler/src/model.rs
+++ b/type-bridge-core/crates/toml-transpiler/src/model.rs
@@ -44,6 +44,12 @@ pub struct TomlSchema {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct TomlAttribute {
+    /// Code generator annotations to emit as `# @...` before the definition.
+    #[serde(default)]
+    pub annotations: Vec<String>,
+    /// Explicit case override for bindgen (emitted as `# @case(...)`).
+    #[serde(default)]
+    pub bindgen_case: Option<String>,
     /// TypeDB value type, e.g. `"string"` or `"long"`. `None` when `sub` is set.
     #[serde(default)]
     pub value: Option<String>,
@@ -73,6 +79,12 @@ pub struct TomlAttribute {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct TomlEntity {
+    /// Code generator annotations to emit as `# @...` before the definition.
+    #[serde(default)]
+    pub annotations: Vec<String>,
+    /// Explicit case override for bindgen (emitted as `# @case(...)`).
+    #[serde(default)]
+    pub bindgen_case: Option<String>,
     /// Parent entity type for inheritance (`sub <parent>`).
     #[serde(default)]
     pub sub: Option<String>,
@@ -110,6 +122,12 @@ pub struct TomlPlays {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct TomlRelation {
+    /// Code generator annotations to emit as `# @...` before the definition.
+    #[serde(default)]
+    pub annotations: Vec<String>,
+    /// Explicit case override for bindgen (emitted as `# @case(...)`).
+    #[serde(default)]
+    pub bindgen_case: Option<String>,
     /// Parent relation type for inheritance (`sub <parent>`).
     #[serde(default)]
     pub sub: Option<String>,

--- a/type_bridge/generator/naming.py
+++ b/type_bridge/generator/naming.py
@@ -22,7 +22,11 @@ def to_class_name(label: str) -> str:
     """
     # Split by both - and _
     parts = label.replace("_", "-").split("-")
-    return "".join(part.capitalize() for part in parts)
+    return "".join(
+        part.capitalize() if part.isupper() or part.islower() else part[0].upper() + part[1:]
+        for part in parts
+        if part
+    )
 
 
 def to_python_name(label: str) -> str:


### PR DESCRIPTION
…TOML schema annotations

- Bindgen now matches language and casing arguments case-insensitively (e.g. `@case(PascalCase)`).
- Added explicit mapping of PascalCase to Python's `TypeNameCase.CLASS_NAME`.
- Fixed `rust_pascal_case` and Python's `to_class_name` to preserve mixed-case sub-segments instead of blindly lowercasing them (e.g., preserving `FirstPerson`).
- Updated the Rust core to inject explicit `name="..."` flags into generated attribute configs when the TypeDB name does not align with default inference.
- Refactored the TOML transpiler to natively support a `bindgen_case` field and an `annotations` array on all attributes, entities, and relations.
- Updated `generator.md` and `toml.md` documentation with case mapping rules and TOML schema examples.
- Added comprehensive integration tests verifying case overrides and TOML `bindgen_case` metadata.