### PR TITLE
fix(boolean): reject non-bool values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to TypeBridge will be documented in this file.
 
 ## [Unreleased]
 
+## [1.5.5] - 2026-06-30
+
+### Bug Fixes
+
+- **Strict Boolean wrappers** - `Boolean` now rejects non-`bool` values at
+  construction, Pydantic validation, Pydantic serialization, hydration, and
+  Rust-backend dynamic value boundaries instead of truthiness-coercing strings
+  such as `"False"` into `True`.
+
+### Testing & Tooling
+
+- **Boolean strictness regressions** - added unit coverage for direct Boolean
+  construction, Pydantic hooks, CRUD hydration through `wrap_attribute_value`,
+  and Rust backend boolean value marshalling.
+
 ## [1.5.4] - 2026-06-26
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ See [`type-bridge-core/README.md`](type-bridge-core/README.md) for build instruc
 
 - Python 3.12–3.13
 - TypeDB 3.8.0–3.11.x server (see the [compatibility table](docs/development/typedb.md#server-and-driver-compatibility) for the full support window; band-7 and band-8 servers are all served by one artifact)
-- type-bridge-core>=1.5.4
+- type-bridge-core>=1.5.5
 - pydantic>=2.12.4
 - isodate==0.7.2 (for Duration type support)
 - jinja2>=3.1.0 (for code generation)

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -25,7 +25,7 @@ uv pip install -e ".[dev]"
 ### Project Dependencies
 
 The project requires:
-- `type-bridge-core>=1.5.4`: Rust runtime for ORM connectivity and query execution
+- `type-bridge-core>=1.5.5`: Rust runtime for ORM connectivity and query execution
 - `pydantic>=2.12.4`: For validation and type coercion
 - `isodate==0.7.2`: For Duration type support (ISO 8601)
 - `jinja2>=3.1.0`: Template engine for code generation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "type-bridge"
-version = "1.5.4"
+version = "1.5.5"
 description = "A modern, Pythonic ORM for TypeDB with an Attribute-based API"
 readme = "README.md"
 requires-python = ">=3.12,<3.14"
@@ -28,7 +28,7 @@ dependencies = [
     "isodate==0.7.2",
     "jinja2>=3.1.0",
     "typer>=0.15.0",
-    "type-bridge-core>=1.5.4",
+    "type-bridge-core>=1.5.5",
 ]
 
 [project.urls]

--- a/tests/unit/attributes/test_boolean.py
+++ b/tests/unit/attributes/test_boolean.py
@@ -1,5 +1,7 @@
 """Test Boolean attribute type."""
 
+import pytest
+
 from type_bridge import Boolean, Card, Entity, Flag, Key, String, TypeFlags
 
 
@@ -15,6 +17,50 @@ def test_boolean_creation():
 
     inactive = IsActive(False)
     assert inactive.value is False
+
+
+@pytest.mark.parametrize("raw", ["False", "false", "0", "1", "", 0, 1, None])
+def test_boolean_rejects_non_bool_values(raw):
+    """Boolean wrappers must not coerce non-bool values by truthiness."""
+
+    class IsActive(Boolean):
+        pass
+
+    with pytest.raises(TypeError, match="IsActive expects bool"):
+        IsActive(raw)
+
+
+def test_boolean_pydantic_validate_rejects_string_false():
+    """Pydantic validation must not turn string false into True."""
+
+    class IsActive(Boolean):
+        pass
+
+    with pytest.raises(TypeError, match="IsActive expects bool"):
+        IsActive._pydantic_validate("False")
+
+
+def test_boolean_pydantic_serialize_rejects_string_false():
+    """Raw string serialization must not turn string false into True."""
+
+    class IsActive(Boolean):
+        pass
+
+    with pytest.raises(TypeError, match="IsActive expects bool"):
+        IsActive._pydantic_serialize("False")
+
+
+def test_boolean_pydantic_hooks_preserve_real_bool_values():
+    """Real bool values remain valid through validation and serialization."""
+
+    class IsActive(Boolean):
+        pass
+
+    inactive = IsActive._pydantic_validate(False)
+    assert inactive.value is False
+    assert bool(inactive) is False
+    assert IsActive._pydantic_serialize(inactive) is False
+    assert IsActive._pydantic_serialize(False) is False
 
 
 def test_boolean_value_type():

--- a/tests/unit/crud/test_wrap_attribute_value.py
+++ b/tests/unit/crud/test_wrap_attribute_value.py
@@ -1,6 +1,8 @@
 """Tests for unified wrap_attribute_value function."""
 
-from type_bridge import Entity, Flag, Integer, Key, String, TypeFlags
+import pytest
+
+from type_bridge import Boolean, Entity, Flag, Integer, Key, String, TypeFlags
 from type_bridge.attribute import Card
 from type_bridge.crud.types import wrap_attribute_value
 
@@ -17,10 +19,15 @@ class Tag(String):
     pass
 
 
+class Enabled(Boolean):
+    pass
+
+
 class SampleEntity(Entity):
     flags = TypeFlags(name="test_entity")
     name: Name = Flag(Key)
     age: Age | None = None
+    enabled: Enabled | None = None
     tags: list[Tag] = Flag(Card(min=0))
 
 
@@ -53,6 +60,19 @@ class TestWrapSingleValue:
         attr_info = SampleEntity.get_all_attributes()["age"]
         result = wrap_attribute_value(None, attr_info)
         assert result is None
+
+    def test_wrap_boolean_false(self) -> None:
+        """Test wrapping a raw False value."""
+        attr_info = SampleEntity.get_all_attributes()["enabled"]
+        result = wrap_attribute_value(False, attr_info)
+        assert isinstance(result, Enabled)
+        assert result.value is False
+
+    def test_wrap_string_false_rejected_for_boolean(self) -> None:
+        """String false must not hydrate as a truthy Boolean wrapper."""
+        attr_info = SampleEntity.get_all_attributes()["enabled"]
+        with pytest.raises(TypeError, match="Enabled expects bool"):
+            wrap_attribute_value("False", attr_info)
 
 
 class TestWrapMultiValue:

--- a/tests/unit/rust_backend/test_iid_and_manager.py
+++ b/tests/unit/rust_backend/test_iid_and_manager.py
@@ -7,7 +7,7 @@ import pytest
 
 from type_bridge import Card, Entity, Flag, Integer, Key, Relation, Role, String, TypeFlags
 from type_bridge.crud.hooks import HookCancelled
-from type_bridge.crud.rust_manager import RustTypeDBManager
+from type_bridge.crud.rust_manager import RustTypeDBManager, _strict_bool
 from type_bridge.expressions import AggregateExpr
 from type_bridge.session import Database
 
@@ -36,6 +36,16 @@ class RustManagerAgedPerson(Entity):
     name: RustManagerName = Flag(Key)
     age: RustManagerAge
     scores: list[RustManagerScore] = Flag(Card(1, 4))
+
+
+def test_strict_bool_rejects_string_false() -> None:
+    with pytest.raises(TypeError, match="boolean values must be bool"):
+        _strict_bool("False")
+
+
+def test_strict_bool_accepts_real_bool_values() -> None:
+    assert _strict_bool(False) is False
+    assert _strict_bool(True) is True
 
 
 class RustManagerCompany(Entity):

--- a/type-bridge-core/Cargo.lock
+++ b/type-bridge-core/Cargo.lock
@@ -2534,7 +2534,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "type-bridge-core"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "pyo3",
  "pythonize",
@@ -2549,7 +2549,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-core-lib"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "criterion",
  "once_cell",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-migration"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "anstream 0.6.21",
  "anstyle",
@@ -2585,7 +2585,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-node"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "napi",
  "napi-derive",
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-orm"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "criterion",
  "serde",
@@ -2613,7 +2613,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-orm-derive"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2623,7 +2623,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-server"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "axum 0.8.8",
  "chrono",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-toml-transpiler"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "indexmap 2.13.1",
  "serde",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-typedb-runtime"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "futures",
  "serde",

--- a/type-bridge-core/crates/core/Cargo.toml
+++ b/type-bridge-core/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-core-lib"
-version = "1.5.4"
+version = "1.5.5"
 edition = "2024"
 description = "TypeQL AST, schema parser, query compiler, and validation engine for type-bridge"
 license.workspace = true

--- a/type-bridge-core/crates/migration/Cargo.toml
+++ b/type-bridge-core/crates/migration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-migration"
-version = "1.5.4"
+version = "1.5.5"
 edition = "2024"
 description = "Migration IR and planning substrate for type-bridge"
 license.workspace = true
@@ -20,7 +20,7 @@ name = "type-bridge-migration"
 path = "src/bin/type_bridge_migration.rs"
 
 [dependencies]
-type-bridge-orm = { path = "../orm", version = "1.5.4", default-features = false, features = ["band7", "band8"] }
+type-bridge-orm = { path = "../orm", version = "1.5.5", default-features = false, features = ["band7", "band8"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4.5", features = ["derive"] }
 network-interface = "2.0.5"

--- a/type-bridge-core/crates/node/Cargo.toml
+++ b/type-bridge-core/crates/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-node"
-version = "1.5.4"
+version = "1.5.5"
 edition = "2024"
 description = "NAPI bindings exposing the type-bridge Rust ORM runtime to Node.js"
 license.workspace = true
@@ -12,8 +12,8 @@ name = "type_bridge_node"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-type-bridge-core-lib = { path = "../core", version = "1.5.4" }
-type-bridge-orm = { path = "../orm", version = "1.5.4", default-features = false, features = ["band7", "band8"] }
+type-bridge-core-lib = { path = "../core", version = "1.5.5" }
+type-bridge-orm = { path = "../orm", version = "1.5.5", default-features = false, features = ["band7", "band8"] }
 napi = { version = "2", features = ["napi4"] }
 napi-derive = "2"
 serde = { version = "1.0", features = ["derive"] }

--- a/type-bridge-core/crates/node/package-lock.json
+++ b/type-bridge-core/crates/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@type-bridge/node",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@type-bridge/node",
-      "version": "1.5.4",
+      "version": "1.5.5",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",

--- a/type-bridge-core/crates/node/package.json
+++ b/type-bridge-core/crates/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@type-bridge/node",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "Node.js NAPI facade for the type-bridge Rust ORM runtime",
   "license": "MIT",
   "main": "dist/index.js",

--- a/type-bridge-core/crates/orm-derive/Cargo.toml
+++ b/type-bridge-core/crates/orm-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-orm-derive"
-version = "1.5.4"
+version = "1.5.5"
 edition = "2024"
 description = "Derive macros for type-bridge-orm: TypeBridgeEntity, TypeBridgeAttribute, TypeBridgeRelation"
 license.workspace = true
@@ -14,7 +14,7 @@ proc-macro = true
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full", "extra-traits"] }
-type-bridge-core-lib = { path = "../core", version = "1.5.4" }
+type-bridge-core-lib = { path = "../core", version = "1.5.5" }
 
 [lints]
 workspace = true

--- a/type-bridge-core/crates/orm/Cargo.toml
+++ b/type-bridge-core/crates/orm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-orm"
-version = "1.5.4"
+version = "1.5.5"
 edition = "2024"
 description = "Async ORM for TypeDB built on type-bridge-core-lib"
 license.workspace = true
@@ -24,14 +24,14 @@ derive = ["dep:type-bridge-orm-derive"]
 integration-tests = ["derive", "band7", "band8"]
 
 [dependencies]
-type-bridge-core-lib = { path = "../core", version = "1.5.4" }
-type-bridge-typedb-runtime = { path = "../typedb-runtime", version = "1.5.4", default-features = false, optional = true }
+type-bridge-core-lib = { path = "../core", version = "1.5.5" }
+type-bridge-typedb-runtime = { path = "../typedb-runtime", version = "1.5.5", default-features = false, optional = true }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2"
 tracing = "0.1"
-type-bridge-orm-derive = { path = "../orm-derive", version = "1.5.4", optional = true }
+type-bridge-orm-derive = { path = "../orm-derive", version = "1.5.5", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/type-bridge-core/crates/python/Cargo.toml
+++ b/type-bridge-core/crates/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-core"
-version = "1.5.4"
+version = "1.5.5"
 edition = "2024"
 description = "PyO3 bindings exposing the type-bridge Rust core to Python"
 license.workspace = true
@@ -12,10 +12,10 @@ name = "type_bridge_core"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-type-bridge-core-lib = { path = "../core", version = "1.5.4" }
-type-bridge-migration = { path = "../migration", version = "1.5.4" }
-type-bridge-orm = { path = "../orm", version = "1.5.4" }
-type-bridge-toml-transpiler = { path = "../toml-transpiler", version = "1.5.4" }
+type-bridge-core-lib = { path = "../core", version = "1.5.5" }
+type-bridge-migration = { path = "../migration", version = "1.5.5" }
+type-bridge-orm = { path = "../orm", version = "1.5.5" }
+type-bridge-toml-transpiler = { path = "../toml-transpiler", version = "1.5.5" }
 pyo3 = { version = "0.23", features = ["extension-module", "abi3-py312"] }
 pythonize = "0.23"
 serde = { version = "1.0", features = ["derive"] }

--- a/type-bridge-core/crates/server/Cargo.toml
+++ b/type-bridge-core/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-server"
-version = "1.5.4"
+version = "1.5.5"
 edition = "2024"
 description = "Query-intercepting proxy server for TypeDB with validation and audit logging"
 license.workspace = true
@@ -25,8 +25,8 @@ axum-transport = ["dep:axum", "dep:tower-http"]
 test-helpers = []
 
 [dependencies]
-type-bridge-core-lib = { path = "../core", version = "1.5.4" }
-type-bridge-typedb-runtime = { path = "../typedb-runtime", version = "1.5.4", default-features = false, optional = true }
+type-bridge-core-lib = { path = "../core", version = "1.5.5" }
+type-bridge-typedb-runtime = { path = "../typedb-runtime", version = "1.5.5", default-features = false, optional = true }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/type-bridge-core/crates/toml-transpiler/Cargo.toml
+++ b/type-bridge-core/crates/toml-transpiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-toml-transpiler"
-version = "1.5.4"
+version = "1.5.5"
 edition = "2024"
 description = "TOML schema DSL transpiler producing TypeQL define blocks for type-bridge"
 license.workspace = true

--- a/type-bridge-core/crates/typedb-runtime/Cargo.toml
+++ b/type-bridge-core/crates/typedb-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-typedb-runtime"
-version = "1.5.4"
+version = "1.5.5"
 edition = "2024"
 description = "Shared TypeDB runtime driver layer for type-bridge"
 license.workspace = true
@@ -17,7 +17,7 @@ band7 = ["dep:type-bridge-typedb-driver-b7"]
 band8 = ["dep:typedb-driver"]
 
 [dependencies]
-type-bridge-core-lib = { path = "../core", version = "1.5.4" }
+type-bridge-core-lib = { path = "../core", version = "1.5.5" }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/type-bridge-core/pyproject.toml
+++ b/type-bridge-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "type-bridge-core"
-version = "1.5.4"
+version = "1.5.5"
 description = "Rust core for type-bridge ORM"
 requires-python = ">=3.12,<3.14"
 classifiers = [

--- a/type_bridge/__init__.py
+++ b/type_bridge/__init__.py
@@ -53,7 +53,7 @@ from type_bridge.query import Query, QueryBuilder
 from type_bridge.session import Connection, Database, TransactionContext
 from type_bridge.typedb_driver import Credentials, TransactionType, TypeDB, create_driver_options
 
-__version__ = "1.5.4"
+__version__ = "1.5.5"
 
 __all__ = [
     # Database and session

--- a/type_bridge/attribute/boolean.py
+++ b/type_bridge/attribute/boolean.py
@@ -29,6 +29,8 @@ class Boolean(Attribute):
         Args:
             value: The boolean value to store
         """
+        if not isinstance(value, bool):
+            raise TypeError(f"{self.__class__.__name__} expects bool, got {type(value).__name__}")
         super().__init__(value)
 
     @property
@@ -56,12 +58,16 @@ class Boolean(Attribute):
     def _pydantic_serialize(cls, value: Any) -> bool:
         """Serialize Boolean to raw bool value."""
         if isinstance(value, cls):
-            return bool(value._value) if value._value is not None else False
-        return bool(value)
+            return value.value
+        if isinstance(value, bool):
+            return value
+        raise TypeError(f"{cls.__name__} expects bool, got {type(value).__name__}")
 
     @classmethod
     def _pydantic_validate(cls, value: Any) -> Self:
         """Validate and wrap value in Boolean instance."""
         if isinstance(value, cls):
             return value
-        return cls(bool(value))
+        if isinstance(value, bool):
+            return cls(value)
+        raise TypeError(f"{cls.__name__} expects bool, got {type(value).__name__}")

--- a/type_bridge/crud/rust_manager.py
+++ b/type_bridge/crud/rust_manager.py
@@ -1113,7 +1113,7 @@ def _dynamic_value(raw_value: Any, attr_type: type[Any]) -> Any:
     if value_type == "double":
         return core.DynamicValue.double(float(value))
     if value_type == "boolean":
-        return core.DynamicValue.boolean(bool(value))
+        return core.DynamicValue.boolean(_strict_bool(value))
     if value_type == "date":
         return core.DynamicValue.date(str(value))
     if value_type == "datetime":
@@ -1136,7 +1136,7 @@ def _dynamic_value_from_rust_type(raw_value: Any, value_type: str) -> Any:
     if value_type == "double":
         return core.DynamicValue.double(float(raw_value))
     if value_type == "boolean":
-        return core.DynamicValue.boolean(bool(raw_value))
+        return core.DynamicValue.boolean(_strict_bool(raw_value))
     if value_type == "date":
         return core.DynamicValue.date(str(raw_value))
     if value_type == "datetime":
@@ -1148,6 +1148,12 @@ def _dynamic_value_from_rust_type(raw_value: Any, value_type: str) -> Any:
     if value_type == "duration":
         return core.DynamicValue.duration(str(raw_value))
     raise ValueError(f"Unsupported Rust dynamic value type {value_type!r}")
+
+
+def _strict_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    raise TypeError(f"boolean values must be bool, got {type(value).__name__}")
 
 
 def _raw_attr_value(value: Any) -> Any:


### PR DESCRIPTION
## Summary

Reject non-bool values at TypeBridge Boolean boundaries so string values such as `"False"`, `"false"`, or `"0"` cannot be coerced by Python truthiness into `True`.

This PR also bumps the project release metadata to `1.5.5` and records the Boolean strictness fix in the changelog.

## Key Changes

- Make `Boolean.__init__`, `_pydantic_validate`, and `_pydantic_serialize` require real `bool` values.
- Make Rust-backend boolean dynamic value marshalling require real `bool` values.
- Add regressions for direct Boolean construction, Pydantic hooks, CRUD hydration, and Rust backend marshalling.
- Update `CHANGELOG.md` with the `1.5.5` Boolean strictness notes.

## Verification

- `uv run --extra dev pytest tests/unit/attributes/test_boolean.py tests/unit/crud/test_wrap_attribute_value.py tests/unit/rust_backend/test_iid_and_manager.py::test_strict_bool_rejects_string_false tests/unit/rust_backend/test_iid_and_manager.py::test_strict_bool_accepts_real_bool_values`
- `uv run --extra dev ruff check type_bridge/attribute/boolean.py type_bridge/crud/rust_manager.py tests/unit/attributes/test_boolean.py tests/unit/crud/test_wrap_attribute_value.py tests/unit/rust_backend/test_iid_and_manager.py`
- `uv run --extra dev ruff format --check type_bridge/attribute/boolean.py type_bridge/crud/rust_manager.py tests/unit/attributes/test_boolean.py tests/unit/crud/test_wrap_attribute_value.py tests/unit/rust_backend/test_iid_and_manager.py`
- `uv run --extra dev pyright type_bridge/attribute/boolean.py type_bridge/crud/rust_manager.py`
- `./scripts/check.sh python`

## Issue Refs

- None
