### PR TITLE
design(migration): expose state-schema boundary for external ledgers (#165)

### DIFF
--- a/docs/guide/generator.md
+++ b/docs/guide/generator.md
@@ -74,11 +74,16 @@ available for explicit custom TypeQL, but schema diffs are not flattened to
 
 Existing files in `--migrations-dir` determine the next migration number and
 dependency. The current diff source is the live TypeDB schema, so apply each
-generated migration before generating the next one. See
+generated migration before generating the next one. `MigrationGenerator`
+removes TypeBridge's own ledger types from that live view with the public
+`without_migration_state_schema` helper, backed by the canonical
+`MIGRATION_STATE_SCHEMA` contract. Embedding schema exporters should use the
+same helper, or `is_migration_state_type` for individual objects, rather than
+copying the reserved labels. See
 [`examples/advanced/toml_migration`](../../examples/advanced/toml_migration/)
 for a two-step `schema.toml` example, and see [Migrations](migrations.md) for
 the full migration workflow, snapshot rationale, data migrations, rollback, and
-database-backed migration state.
+migration-state backends.
 
 ### Programmatic Usage
 

--- a/docs/guide/migrations.md
+++ b/docs/guide/migrations.md
@@ -3,7 +3,9 @@
 TypeBridge migrations are ordered Python files that apply schema and data
 changes to a TypeDB database. They are intended for production workflows where
 schema history must be replayable, data backfills must use the ORM, and applied
-state must live in the database.
+state must have one durable source of truth. Standalone TypeBridge stores that
+state in TypeDB by default; embedding orchestrators can inject an externally
+owned ledger instead.
 
 ## Workflow
 
@@ -276,11 +278,13 @@ python -m type_bridge.migration migrate 0001_initial \
 If any operation in the rollback path is irreversible, the executor raises an
 error before pretending the rollback succeeded.
 
-## Migration State In TypeDB
+## Migration State Backends
 
-TypeBridge stores migration state in TypeDB, not in memory or local files. This
-is the database source of truth used by `migrate`, `showmigrations`, and
-checksum drift checks.
+### Default TypeDB-backed state
+
+By default, `MigrationExecutor` constructs a TypeDB-backed
+`MigrationStateManager`. The target database is the source of truth used by
+`migrate`, `showmigrations`, and checksum drift checks.
 
 Two internal entity types are created automatically:
 
@@ -309,6 +313,72 @@ for run in runs:
 Because the state is in TypeDB, a different process can inspect the same
 migration history, and TypeDB Studio can view the internal migration entities
 after the migration tracking schema has been ensured.
+
+The migration CLI uses this default backend. Its `migrate` and
+`showmigrations` commands do not accept an external state store; embedding
+applications should use the programmatic executor API described below.
+
+### External ledgers for embedding orchestrators
+
+An orchestrator that already has an authoritative, project-scoped migration
+ledger can inject an implementation of the `MigrationStateStore` protocol:
+
+```python
+from pathlib import Path
+
+from type_bridge.migration import MigrationExecutor, MigrationStateStore
+
+external_store: MigrationStateStore = project_migration_store
+executor = MigrationExecutor(
+    db,
+    Path("migrations"),
+    state_manager=external_store,
+)
+executor.migrate()
+```
+
+With an injected store, the executor reads and writes migration state through
+that store and does not define TypeBridge migration-ledger types in the target
+database. The target therefore contains only the application ontology and the
+schema changes made by the migrations themselves.
+
+The ownership boundary is deliberate: TypeBridge owns migration specs,
+planning, lowering, checksums, and execution. The embedding orchestrator owns
+applied-state persistence and any external run logging. Keep the default
+TypeDB-backed manager for standalone TypeBridge workflows; inject a store only
+when another system is the authoritative ledger.
+
+### Excluding infrastructure from schema exports
+
+`MIGRATION_STATE_SCHEMA` is the canonical public description of every schema
+object owned by TypeBridge's default ledger. Consumers should use it through
+the public helpers instead of copying a list of reserved labels:
+
+```python
+from type_bridge.migration import (
+    MIGRATION_STATE_SCHEMA,
+    is_migration_state_type,
+    migration_state_schema,
+    without_migration_state_schema,
+)
+
+# Filter a complete result from SchemaIntrospector before snapshotting it.
+application_schema = without_migration_state_schema(introspected_schema)
+
+# Or classify individual objects in another exporter.
+if is_migration_state_type(kind="entity", label=label):
+    continue
+
+# Access value types, ownership annotations, and relation roles when needed.
+full_state_schema = migration_state_schema()
+```
+
+Use `is_migration_state_type` with the object's actual kind (`entity`,
+`relation`, `attribute`, or `role`). Exact kind-and-label matching avoids
+discarding application types that merely resemble migration infrastructure.
+`MIGRATION_STATE_SCHEMA` is the immutable kind-and-label projection used for
+classification. Call `migration_state_schema()` for the full Rust `SchemaInfo`
+contract, including value types, ownership annotations, and relation roles.
 
 ## Sidecars And Hand Editing
 

--- a/docs/guide/schema.md
+++ b/docs/guide/schema.md
@@ -370,8 +370,8 @@ class MatchResult(Entity):
 For production schema history, use the dedicated migration system documented in
 [Migrations](migrations.md). It covers generated schema migrations,
 `ops.RunPython` data migrations that can use `User.manager(db)`, historical
-snapshot bindings, rollback, sidecar drift checks, and migration state stored in
-TypeDB.
+snapshot bindings, rollback, sidecar drift checks, and migration state backed by
+TypeDB by default or by an injected external ledger for embedding workflows.
 
 ## Complete Schema Workflow
 

--- a/tests/integration/migration/test_external_state.py
+++ b/tests/integration/migration/test_external_state.py
@@ -1,0 +1,210 @@
+"""Live coverage for externally owned migration state (#165)."""
+
+from __future__ import annotations
+
+# pyright: reportMissingImports=false
+from pathlib import Path
+
+import pytest
+
+from type_bridge.migration import (
+    MIGRATION_STATE_SCHEMA,
+    MigrationExecutor,
+    MigrationRecord,
+    MigrationRunRecord,
+    MigrationState,
+    SchemaIntrospector,
+)
+
+
+class _ExternalStateStore:
+    """Minimal process-local ledger used to prove target-schema isolation."""
+
+    def __init__(self) -> None:
+        self.state = MigrationState()
+        self.run_events: list[tuple[str, str]] = []
+
+    def load_state(self) -> MigrationState:
+        return self.state
+
+    def record_applied(self, app_label: str, name: str, checksum: str) -> None:
+        self.state.add(
+            MigrationRecord(
+                app_label=app_label,
+                name=name,
+                applied_at="2026-07-10T00:00:00.000000",
+                checksum=checksum,
+            )
+        )
+
+    def record_unapplied(self, app_label: str, name: str) -> None:
+        self.state.remove(app_label, name)
+
+    def record_run_started(
+        self,
+        app_label: str,
+        name: str,
+        checksum: str,
+        direction: str,
+    ) -> MigrationRunRecord:
+        self.run_events.append(("started", name))
+        return MigrationRunRecord(
+            run_id=f"run-{name}",
+            app_label=app_label,
+            name=name,
+            checksum=checksum,
+            direction=direction,
+            status="started",
+            started_at="2026-07-10T00:00:00.000000",
+        )
+
+    def record_run_finished(
+        self,
+        record: MigrationRunRecord,
+        status: str,
+        error: str | None = None,
+    ) -> MigrationRunRecord:
+        self.run_events.append((status, record.name))
+        return MigrationRunRecord(
+            run_id=record.run_id,
+            app_label=record.app_label,
+            name=record.name,
+            checksum=record.checksum,
+            direction=record.direction,
+            status=status,
+            started_at=record.started_at,
+            finished_at="2026-07-10T00:00:01.000000",
+            error=error,
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.order(326)
+def test_external_state_store_keeps_target_schema_free_of_typebridge_ledger(
+    clean_db,
+    tmp_path: Path,
+) -> None:
+    """A real Rust migration uses the external ledger and no target state schema."""
+    migrations_dir = tmp_path / "external_migrations"
+    migrations_dir.mkdir()
+    (migrations_dir / "0001_external_state.py").write_text(
+        """from type_bridge.migration import Migration, operations as ops
+
+
+class ExternalStateMigration(Migration):
+    dependencies = []
+    operations = [
+        ops.RunTypeQL(
+            forward="define attribute issue-165-app-value, value string;",
+            reverse="undefine attribute issue-165-app-value;",
+        )
+    ]
+"""
+    )
+    state_store = _ExternalStateStore()
+    executor = MigrationExecutor(
+        clean_db,
+        migrations_dir,
+        state_manager=state_store,
+    )
+
+    results = executor.migrate()
+
+    assert [(result.name, result.action, result.success) for result in results] == [
+        ("0001_external_state", "applied", True)
+    ]
+    assert state_store.state.is_applied("external_migrations", "0001_external_state")
+    assert state_store.run_events == []
+
+    raw_schema = SchemaIntrospector(clean_db).introspect()
+    assert "issue-165-app-value" in raw_schema.get_attribute_names()
+    assert MIGRATION_STATE_SCHEMA.entities.isdisjoint(raw_schema.get_entity_names())
+    assert MIGRATION_STATE_SCHEMA.relations.isdisjoint(raw_schema.get_relation_names())
+    assert MIGRATION_STATE_SCHEMA.attributes.isdisjoint(raw_schema.get_attribute_names())
+
+
+@pytest.mark.integration
+@pytest.mark.order(327)
+def test_mixed_external_state_plan_keeps_all_run_logging_outside_target(
+    clean_db,
+    tmp_path: Path,
+) -> None:
+    """Rust/Python/Rust execution uses one external ledger without DB infrastructure."""
+    migrations_dir = tmp_path / "external_migrations"
+    migrations_dir.mkdir()
+    (migrations_dir / "0001_before_python.py").write_text(
+        """from type_bridge.migration import Migration, operations as ops
+
+
+class BeforePythonMigration(Migration):
+    dependencies = []
+    operations = [
+        ops.RunTypeQL(
+            forward="define attribute issue-165-before-python, value string;",
+            reverse="undefine attribute issue-165-before-python;",
+        )
+    ]
+"""
+    )
+    (migrations_dir / "0002_python_step.py").write_text(
+        """from type_bridge.migration import Migration, operations as ops
+
+
+def forwards(db):
+    db.execute_query(
+        "define attribute issue-165-python-value, value string;",
+        transaction_type="schema",
+    )
+
+
+class PythonStepMigration(Migration):
+    dependencies = [("external_migrations", "0001_before_python")]
+    operations = [ops.RunPython(forwards)]
+"""
+    )
+    (migrations_dir / "0003_after_python.py").write_text(
+        """from type_bridge.migration import Migration, operations as ops
+
+
+class AfterPythonMigration(Migration):
+    dependencies = [("external_migrations", "0002_python_step")]
+    operations = [
+        ops.RunTypeQL(
+            forward="define attribute issue-165-after-python, value string;",
+            reverse="undefine attribute issue-165-after-python;",
+        )
+    ]
+"""
+    )
+    state_store = _ExternalStateStore()
+
+    results = MigrationExecutor(
+        clean_db,
+        migrations_dir,
+        state_manager=state_store,
+    ).migrate()
+
+    assert [(result.name, result.action, result.success) for result in results] == [
+        ("0001_before_python", "applied", True),
+        ("0002_python_step", "applied", True),
+        ("0003_after_python", "applied", True),
+    ]
+    assert {record.name for record in state_store.state.applied} == {
+        "0001_before_python",
+        "0002_python_step",
+        "0003_after_python",
+    }
+    assert state_store.run_events == [
+        ("started", "0002_python_step"),
+        ("succeeded", "0002_python_step"),
+    ]
+
+    raw_schema = SchemaIntrospector(clean_db).introspect()
+    assert {
+        "issue-165-before-python",
+        "issue-165-python-value",
+        "issue-165-after-python",
+    } <= raw_schema.get_attribute_names()
+    assert MIGRATION_STATE_SCHEMA.entities.isdisjoint(raw_schema.get_entity_names())
+    assert MIGRATION_STATE_SCHEMA.relations.isdisjoint(raw_schema.get_relation_names())
+    assert MIGRATION_STATE_SCHEMA.attributes.isdisjoint(raw_schema.get_attribute_names())

--- a/tests/integration/migration/test_state.py
+++ b/tests/integration/migration/test_state.py
@@ -20,7 +20,12 @@ Lifecycle covered:
 # pyright: reportMissingImports=false
 import pytest
 
-from type_bridge.migration import MigrationStateManager
+from type_bridge.migration import (
+    MIGRATION_STATE_SCHEMA,
+    MigrationStateManager,
+    SchemaIntrospector,
+    without_migration_state_schema,
+)
 
 
 @pytest.mark.integration
@@ -34,6 +39,12 @@ def test_load_state_empty(clean_db):
 
     assert state.applied == []
     assert not state.is_applied("myapp", "0001_initial")
+
+    raw_schema = SchemaIntrospector(clean_db).introspect()
+    assert raw_schema.get_entity_names() == MIGRATION_STATE_SCHEMA.entities
+    assert raw_schema.get_relation_names() == MIGRATION_STATE_SCHEMA.relations
+    assert raw_schema.get_attribute_names() == MIGRATION_STATE_SCHEMA.attributes
+    assert without_migration_state_schema(raw_schema).is_empty()
 
 
 @pytest.mark.integration

--- a/tests/unit/migration/test_planner.py
+++ b/tests/unit/migration/test_planner.py
@@ -133,9 +133,19 @@ class _ScriptedRunner:
     def __init__(self, results: list[dict[str, Any]]):
         self._results = results
         self.apply_calls: list[Any] = []
+        self.state_free_apply_calls: list[Any] = []
 
     def apply(self, graph: Any, applied_records: Any, target: Any) -> list[dict[str, Any]]:
         self.apply_calls.append((graph, applied_records, target))
+        return self._results
+
+    def apply_state_free(
+        self,
+        graph: Any,
+        applied_records: Any,
+        target: Any,
+    ) -> list[dict[str, Any]]:
+        self.state_free_apply_calls.append((graph, applied_records, target))
         return self._results
 
 
@@ -203,6 +213,42 @@ class _RecordingDb:
 
     def execute_query(self, query: str, *, transaction_type: str) -> None:
         self.queries.append((query, transaction_type))
+
+
+def test_executor_constructs_default_state_manager(monkeypatch: pytest.MonkeyPatch) -> None:
+    state_manager = _RecordingStateManager()
+    seen_databases: list[Any] = []
+
+    def build_default(db: Any) -> _RecordingStateManager:
+        seen_databases.append(db)
+        return state_manager
+
+    monkeypatch.setattr("type_bridge.migration.executor.MigrationStateManager", build_default)
+    db = object()
+
+    executor = MigrationExecutor(db=cast("Database", db), migrations_dir=Path("migrations"))
+
+    assert executor.state_manager is state_manager
+    assert seen_databases == [db]
+
+
+def test_executor_uses_injected_state_manager_without_constructing_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state_manager = _RecordingStateManager()
+
+    def fail_default(_db: Any) -> _RecordingStateManager:
+        pytest.fail("an injected migration state manager must bypass the TypeDB default")
+
+    monkeypatch.setattr("type_bridge.migration.executor.MigrationStateManager", fail_default)
+
+    executor = MigrationExecutor(
+        db=cast("Database", object()),
+        migrations_dir=Path("migrations"),
+        state_manager=state_manager,
+    )
+
+    assert executor.state_manager is state_manager
 
 
 def _executor_with(
@@ -275,6 +321,42 @@ def test_migrate_records_state_in_result_order(monkeypatch: pytest.MonkeyPatch) 
         ("applied", "app", "0001_a"),
         ("applied", "app", "0002_b"),
     ]
+
+
+def test_injected_state_manager_selects_state_free_rust_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _ScriptedRunner(
+        [
+            {
+                "app_label": "app",
+                "name": "0001_a",
+                "action": "apply",
+                "success": True,
+                "error": None,
+            }
+        ]
+    )
+    state_manager = _RecordingStateManager()
+    loaded = [_loaded(_runtypeql_migration("a"), "app", "0001_a", "csum-a")]
+    executor = MigrationExecutor(
+        db=cast("Database", object()),
+        migrations_dir=Path("migrations"),
+        state_manager=state_manager,
+    )
+    monkeypatch.setattr(executor.loader, "discover", lambda: loaded)
+    monkeypatch.setattr(executor, "_preflight_migrations", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "type_bridge.migration._lower.lower_execution_graph", lambda loaded: {"migrations": []}
+    )
+    monkeypatch.setattr("type_bridge._rust_runtime.migration_runner_for", lambda db: runner)
+
+    results = executor.migrate()
+
+    assert [(result.name, result.success) for result in results] == [("0001_a", True)]
+    assert runner.apply_calls == []
+    assert len(runner.state_free_apply_calls) == 1
+    assert state_manager.calls == [("applied", "app", "0001_a")]
 
 
 def test_migrate_records_unapplied_for_rollback_results(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -394,8 +476,11 @@ def test_run_python_migration_receives_db_and_records_state(
 
     state_manager = _RecordingStateManager()
     loaded = [_loaded(PythonMigration(), "app", "0001_python", "csum-py")]
-    executor = MigrationExecutor(db=dummy_db, migrations_dir=Path("migrations"))
-    executor.state_manager = cast(MigrationStateManager, state_manager)
+    executor = MigrationExecutor(
+        db=dummy_db,
+        migrations_dir=Path("migrations"),
+        state_manager=state_manager,
+    )
     monkeypatch.setattr(executor.loader, "discover", lambda: loaded)
 
     def fail_if_called(_db: object) -> object:
@@ -445,8 +530,11 @@ def test_run_python_rollback_uses_reverse_callable_and_records_unapplied(
         _loaded(BaseMigration(), "app", "0001_base", "csum-base"),
         _loaded(PythonMigration(), "app", "0002_python", "csum-py"),
     ]
-    executor = MigrationExecutor(db=cast("Database", object()), migrations_dir=Path("migrations"))
-    executor.state_manager = cast(MigrationStateManager, state_manager)
+    executor = MigrationExecutor(
+        db=cast("Database", object()),
+        migrations_dir=Path("migrations"),
+        state_manager=state_manager,
+    )
     monkeypatch.setattr(executor.loader, "discover", lambda: loaded)
 
     results = executor.migrate(target="0001_base")
@@ -611,8 +699,11 @@ def test_run_python_history_uses_python_path_for_later_typeql_migration(
         _loaded(TypeQLMigration(), "app", "0002_typeql", "csum-typeql"),
     ]
     db = _RecordingDb()
-    executor = MigrationExecutor(db=cast("Database", db), migrations_dir=Path("migrations"))
-    executor.state_manager = cast(MigrationStateManager, state_manager)
+    executor = MigrationExecutor(
+        db=cast("Database", db),
+        migrations_dir=Path("migrations"),
+        state_manager=state_manager,
+    )
     monkeypatch.setattr(executor.loader, "discover", lambda: loaded)
 
     runner = _ScriptedRunner(
@@ -634,9 +725,10 @@ def test_run_python_history_uses_python_path_for_later_typeql_migration(
     assert [(result.name, result.action, result.success) for result in results] == [
         ("0002_typeql", "applied", True)
     ]
-    assert len(runner.apply_calls) == 1
-    assert runner.apply_calls[0][2] == "0002_typeql"
-    assert len(runner.apply_calls[0][0]["migrations"]) == 2
+    assert runner.apply_calls == []
+    assert len(runner.state_free_apply_calls) == 1
+    assert runner.state_free_apply_calls[0][2] == "0002_typeql"
+    assert len(runner.state_free_apply_calls[0][0]["migrations"]) == 2
     assert db.queries == []
     assert state_manager.calls == [("applied", "app", "0002_typeql")]
 

--- a/tests/unit/migration/test_state_schema.py
+++ b/tests/unit/migration/test_state_schema.py
@@ -1,0 +1,172 @@
+"""Public migration-state schema contract and filtering tests."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+import type_bridge.migration as migration
+import type_bridge.migration.state_schema as state_schema_module
+from type_bridge.migration import (
+    MIGRATION_STATE_SCHEMA,
+    MigrationStateSchema,
+    is_migration_state_type,
+    migration_state_schema,
+    without_migration_state_schema,
+)
+from type_bridge.migration.introspection import (
+    IntrospectedAttribute,
+    IntrospectedEntity,
+    IntrospectedOwnership,
+    IntrospectedRelation,
+    IntrospectedRole,
+    IntrospectedSchema,
+)
+
+EXPECTED_ENTITIES = frozenset(
+    {
+        "type_bridge_migration",
+        "type_bridge_migration_run",
+    }
+)
+EXPECTED_ATTRIBUTES = frozenset(
+    {
+        "migration_id",
+        "migration_app_label",
+        "migration_name",
+        "migration_applied_at",
+        "migration_checksum",
+        "migration_run_id",
+        "migration_direction",
+        "migration_status",
+        "migration_started_at",
+        "migration_finished_at",
+        "migration_error",
+        "migration_executor_ip",
+        "migration_executor_mac",
+    }
+)
+
+
+def test_migration_state_schema_projects_the_canonical_rust_descriptor() -> None:
+    descriptor = migration_state_schema()
+
+    assert MIGRATION_STATE_SCHEMA == MigrationStateSchema(
+        entities=frozenset(descriptor["entities"]),
+        relations=frozenset(descriptor["relations"]),
+        attributes=frozenset(descriptor["attributes"]),
+        roles=frozenset(
+            f"{relation_name}:{role['role_name']}"
+            for relation_name, relation in descriptor["relations"].items()
+            for role in relation.get("roles", [])
+        ),
+    )
+    assert MIGRATION_STATE_SCHEMA.entities == EXPECTED_ENTITIES
+    assert MIGRATION_STATE_SCHEMA.relations == frozenset()
+    assert MIGRATION_STATE_SCHEMA.attributes == EXPECTED_ATTRIBUTES
+    assert MIGRATION_STATE_SCHEMA.roles == frozenset()
+    assert migration.MigrationStateManager.ENTITY_NAME in MIGRATION_STATE_SCHEMA.entities
+
+
+def test_migration_state_schema_projection_is_immutable() -> None:
+    with pytest.raises(FrozenInstanceError):
+        MIGRATION_STATE_SCHEMA.entities = frozenset()  # type: ignore[misc]
+
+    with pytest.raises(AttributeError):
+        MIGRATION_STATE_SCHEMA.entities.add("another-label")  # type: ignore[attr-defined]
+
+
+@pytest.mark.parametrize(
+    ("kind", "labels"),
+    [
+        ("entity", EXPECTED_ENTITIES),
+        ("attribute", EXPECTED_ATTRIBUTES),
+    ],
+)
+def test_predicate_recognizes_every_canonical_label(kind: str, labels: frozenset[str]) -> None:
+    for label in labels:
+        assert is_migration_state_type(kind=kind, label=label)  # type: ignore[arg-type]
+
+    assert not is_migration_state_type(kind=kind, label="application-label")  # type: ignore[arg-type]
+
+
+def test_predicate_is_keyword_only() -> None:
+    with pytest.raises(TypeError):
+        is_migration_state_type("entity", "type_bridge_migration")  # type: ignore[call-arg]
+
+
+def test_predicate_rejects_unknown_schema_kind() -> None:
+    with pytest.raises(ValueError, match="kind"):
+        is_migration_state_type(kind="owner", label="type_bridge_migration")  # type: ignore[arg-type]
+
+
+def test_without_migration_state_schema_filters_every_object_kind(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    synthetic_contract = MigrationStateSchema(
+        entities=frozenset({"state-entity"}),
+        relations=frozenset({"state-relation"}),
+        attributes=frozenset({"state-attribute"}),
+        roles=frozenset({"app-relation:state-role"}),
+    )
+    monkeypatch.setattr(state_schema_module, "MIGRATION_STATE_SCHEMA", synthetic_contract)
+
+    schema = IntrospectedSchema(
+        entities={
+            "state-entity": IntrospectedEntity(name="state-entity"),
+            "app-entity": IntrospectedEntity(name="app-entity"),
+        },
+        relations={
+            "state-relation": IntrospectedRelation(
+                name="state-relation",
+                roles={"state-role": IntrospectedRole(name="state-role")},
+            ),
+            "app-relation": IntrospectedRelation(
+                name="app-relation",
+                roles={
+                    "state-role": IntrospectedRole(name="state-role"),
+                    "app-role": IntrospectedRole(name="app-role"),
+                },
+            ),
+        },
+        attributes={
+            "state-attribute": IntrospectedAttribute(name="state-attribute", value_type="string"),
+            "app-attribute": IntrospectedAttribute(name="app-attribute", value_type="string"),
+        },
+        ownerships=[
+            IntrospectedOwnership("state-entity", "app-attribute"),
+            IntrospectedOwnership("state-relation", "app-attribute"),
+            IntrospectedOwnership("app-entity", "state-attribute"),
+            IntrospectedOwnership("app-entity", "app-attribute"),
+        ],
+    )
+
+    filtered = without_migration_state_schema(schema)
+
+    assert filtered is not schema
+    assert set(filtered.entities) == {"app-entity"}
+    assert set(filtered.relations) == {"app-relation"}
+    assert set(filtered.relations["app-relation"].roles) == {"app-role"}
+    assert set(filtered.attributes) == {"app-attribute"}
+    assert filtered.ownerships == [IntrospectedOwnership("app-entity", "app-attribute")]
+
+    assert set(schema.entities) == {"state-entity", "app-entity"}
+    assert set(schema.relations) == {"state-relation", "app-relation"}
+    assert set(schema.relations["app-relation"].roles) == {"state-role", "app-role"}
+    assert set(schema.attributes) == {"state-attribute", "app-attribute"}
+    assert len(schema.ownerships) == 4
+
+
+def test_public_migration_package_exports_state_schema_contract() -> None:
+    expected = {
+        "MIGRATION_STATE_SCHEMA",
+        "MigrationStateSchema",
+        "is_migration_state_type",
+        "migration_state_schema",
+        "without_migration_state_schema",
+    }
+
+    assert expected <= set(migration.__all__)
+    for name in expected:
+        assert getattr(migration, name) is globals()[name]

--- a/type-bridge-core/crates/migration/src/lib.rs
+++ b/type-bridge-core/crates/migration/src/lib.rs
@@ -30,7 +30,8 @@ pub use loader::{load_dir, load_dir_checked, load_sidecar};
 pub use plan::{ExecutionPlan, ExecutionStep, MigrationAction, MigrationExecution, StepKind, plan};
 pub use spec::{MigrationDependencySpec, MigrationGraph, MigrationSpec, OperationSpec};
 pub use state::{
-    InMemoryStateStore, MigrationExecutorInfo, MigrationRunRecord, MigrationStateStore,
-    TypeDbStateStore, collect_executor_info, finished_run_record, migration_timestamp_now,
+    InMemoryStateStore, MigrationExecutorInfo, MigrationRunRecord, MigrationStateSchemaKind,
+    MigrationStateStore, TypeDbStateStore, applied_migration_entity_label, collect_executor_info,
+    finished_run_record, is_migration_state_type, migration_state_schema, migration_timestamp_now,
     started_run_record,
 };

--- a/type-bridge-core/crates/migration/src/state/mod.rs
+++ b/type-bridge-core/crates/migration/src/state/mod.rs
@@ -5,13 +5,22 @@
 //!
 //! - [`memory::InMemoryStateStore`] — insertion-ordered, mutex-backed store
 //!   used for Rust unit tests with no TypeDB connection.
-//! - [`typedb::TypeDbStateStore`] — ports the exact TypeQL from `state.py` over
-//!   the ORM [`Database`][type_bridge_orm::session::Database] seam.
+//! - [`typedb::TypeDbStateStore`] — persists state over the ORM
+//!   [`Database`][type_bridge_orm::session::Database] seam.
+//!
+//! [`schema`] is the public, canonical description of the TypeDB types owned by
+//! the default store. Bootstrap and language bindings both consume that same
+//! [`SchemaInfo`][type_bridge_orm::schema::SchemaInfo].
 
 pub mod memory;
+pub mod schema;
 pub mod typedb;
 
 pub use memory::InMemoryStateStore;
+pub use schema::{
+    MigrationStateSchemaKind, applied_migration_entity_label, is_migration_state_type,
+    migration_state_schema,
+};
 pub use typedb::TypeDbStateStore;
 
 use std::net::UdpSocket;

--- a/type-bridge-core/crates/migration/src/state/schema.rs
+++ b/type-bridge-core/crates/migration/src/state/schema.rs
@@ -1,0 +1,324 @@
+//! Canonical TypeBridge migration-state schema contract.
+//!
+//! The migration ledger uses the ORM's existing [`SchemaInfo`] IR so schema
+//! bootstrap, Rust consumers, and language bindings all project from one
+//! structural definition. Labels remain exact-match infrastructure names; no
+//! prefix-based reservation is implied.
+
+use std::collections::BTreeMap;
+use std::sync::LazyLock;
+
+use serde::{Deserialize, Serialize};
+use type_bridge_orm::schema::SchemaInfo;
+use type_bridge_orm::schema::info::{AttributeSchemaEntry, EntitySchemaEntry, OwnedAttributeEntry};
+use type_bridge_orm::{Annotation, ValueType};
+
+/// Semantic labels used by the TypeDB-backed migration state store.
+///
+/// Keeping the storage queries and the canonical schema on these constants
+/// prevents either surface from acquiring a private copy of the label set.
+pub(crate) mod labels {
+    /// Entity storing the applied-migration projection.
+    pub const APPLIED_ENTITY: &str = "type_bridge_migration";
+    /// Entity storing individual migration execution attempts.
+    pub const RUN_ENTITY: &str = "type_bridge_migration_run";
+
+    /// Composite applied-migration identifier attribute.
+    pub const MIGRATION_ID: &str = "migration_id";
+    /// Migration application/package label attribute.
+    pub const APP_LABEL: &str = "migration_app_label";
+    /// Migration name attribute.
+    pub const NAME: &str = "migration_name";
+    /// Applied timestamp attribute.
+    pub const APPLIED_AT: &str = "migration_applied_at";
+    /// Migration checksum attribute.
+    pub const CHECKSUM: &str = "migration_checksum";
+    /// Execution-attempt identifier attribute.
+    pub const RUN_ID: &str = "migration_run_id";
+    /// Execution direction attribute.
+    pub const DIRECTION: &str = "migration_direction";
+    /// Execution status attribute.
+    pub const STATUS: &str = "migration_status";
+    /// Execution start timestamp attribute.
+    pub const STARTED_AT: &str = "migration_started_at";
+    /// Execution finish timestamp attribute.
+    pub const FINISHED_AT: &str = "migration_finished_at";
+    /// Execution error attribute.
+    pub const ERROR: &str = "migration_error";
+    /// Executor IP address attribute.
+    pub const EXECUTOR_IP: &str = "migration_executor_ip";
+    /// Executor MAC address attribute.
+    pub const EXECUTOR_MAC: &str = "migration_executor_mac";
+}
+
+/// Kind of TypeDB schema object tested against the migration-state contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MigrationStateSchemaKind {
+    /// An entity type label.
+    Entity,
+    /// A relation type label.
+    Relation,
+    /// An attribute type label.
+    Attribute,
+    /// A relation-qualified role label in `relation:role` form.
+    Role,
+}
+
+static MIGRATION_STATE_SCHEMA: LazyLock<SchemaInfo> = LazyLock::new(build_migration_state_schema);
+
+/// Return TypeBridge's canonical migration-state schema.
+///
+/// The returned [`SchemaInfo`] is immutable and process-global. It includes
+/// every TypeBridge-owned migration entity, relation, attribute, ownership,
+/// and role. Consumers should use [`is_migration_state_type`] when they only
+/// need membership checks.
+pub fn migration_state_schema() -> &'static SchemaInfo {
+    &MIGRATION_STATE_SCHEMA
+}
+
+/// Return the entity label for the applied-migration projection.
+///
+/// This semantic accessor keeps compatibility aliases in language bindings
+/// tied to the same label constant used by the canonical schema and TypeDB
+/// queries.
+pub fn applied_migration_entity_label() -> &'static str {
+    labels::APPLIED_ENTITY
+}
+
+/// Return whether `label` is owned by TypeBridge's migration-state schema.
+///
+/// Membership is exact and kind-sensitive. Role labels use the qualified
+/// `relation:role` form because TypeDB role names are scoped by their relation.
+pub fn is_migration_state_type(kind: MigrationStateSchemaKind, label: &str) -> bool {
+    let schema = migration_state_schema();
+    match kind {
+        MigrationStateSchemaKind::Entity => schema.entities.contains_key(label),
+        MigrationStateSchemaKind::Relation => schema.relations.contains_key(label),
+        MigrationStateSchemaKind::Attribute => schema.attributes.contains_key(label),
+        MigrationStateSchemaKind::Role => {
+            let Some((relation_label, role_label)) = label.split_once(':') else {
+                return false;
+            };
+            schema
+                .relations
+                .get(relation_label)
+                .is_some_and(|relation| {
+                    relation
+                        .roles
+                        .iter()
+                        .any(|role| role.role_name == role_label)
+                })
+        }
+    }
+}
+
+fn build_migration_state_schema() -> SchemaInfo {
+    use labels::*;
+
+    let attribute_specs = [
+        (MIGRATION_ID, ValueType::String),
+        (APP_LABEL, ValueType::String),
+        (NAME, ValueType::String),
+        (APPLIED_AT, ValueType::DateTime),
+        (CHECKSUM, ValueType::String),
+        (RUN_ID, ValueType::String),
+        (DIRECTION, ValueType::String),
+        (STATUS, ValueType::String),
+        (STARTED_AT, ValueType::DateTime),
+        (FINISHED_AT, ValueType::DateTime),
+        (ERROR, ValueType::String),
+        (EXECUTOR_IP, ValueType::String),
+        (EXECUTOR_MAC, ValueType::String),
+    ];
+
+    let attributes = attribute_specs
+        .into_iter()
+        .map(|(label, value_type)| {
+            (
+                label.to_string(),
+                AttributeSchemaEntry::new(label, value_type),
+            )
+        })
+        .collect();
+
+    let entities = [
+        (
+            APPLIED_ENTITY,
+            vec![
+                owned_attribute(MIGRATION_ID, ValueType::String, true),
+                owned_attribute(APP_LABEL, ValueType::String, false),
+                owned_attribute(NAME, ValueType::String, false),
+                owned_attribute(APPLIED_AT, ValueType::DateTime, false),
+                owned_attribute(CHECKSUM, ValueType::String, false),
+            ],
+        ),
+        (
+            RUN_ENTITY,
+            vec![
+                owned_attribute(RUN_ID, ValueType::String, true),
+                owned_attribute(APP_LABEL, ValueType::String, false),
+                owned_attribute(NAME, ValueType::String, false),
+                owned_attribute(CHECKSUM, ValueType::String, false),
+                owned_attribute(DIRECTION, ValueType::String, false),
+                owned_attribute(STATUS, ValueType::String, false),
+                owned_attribute(STARTED_AT, ValueType::DateTime, false),
+                owned_attribute(FINISHED_AT, ValueType::DateTime, false),
+                owned_attribute(ERROR, ValueType::String, false),
+                owned_attribute(EXECUTOR_IP, ValueType::String, false),
+                owned_attribute(EXECUTOR_MAC, ValueType::String, false),
+            ],
+        ),
+    ]
+    .into_iter()
+    .map(|(label, owned_attributes)| {
+        (
+            label.to_string(),
+            EntitySchemaEntry {
+                type_name: label.to_string(),
+                is_abstract: false,
+                parent_type: None,
+                owned_attributes,
+                plays_cardinalities: BTreeMap::new(),
+            },
+        )
+    })
+    .collect();
+
+    SchemaInfo {
+        entities,
+        relations: BTreeMap::new(),
+        attributes,
+    }
+}
+
+fn owned_attribute(label: &str, value_type: ValueType, is_key: bool) -> OwnedAttributeEntry {
+    OwnedAttributeEntry {
+        attr_name: label.to_string(),
+        value_type,
+        annotations: if is_key {
+            vec![Annotation::Key]
+        } else {
+            Vec::new()
+        },
+        is_ordered: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn descriptor_contains_the_complete_current_state_schema() {
+        let schema = migration_state_schema();
+
+        assert_eq!(
+            schema
+                .entities
+                .keys()
+                .map(String::as_str)
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from([labels::APPLIED_ENTITY, labels::RUN_ENTITY])
+        );
+        assert_eq!(
+            schema
+                .attributes
+                .keys()
+                .map(String::as_str)
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from([
+                labels::MIGRATION_ID,
+                labels::APP_LABEL,
+                labels::NAME,
+                labels::APPLIED_AT,
+                labels::CHECKSUM,
+                labels::RUN_ID,
+                labels::DIRECTION,
+                labels::STATUS,
+                labels::STARTED_AT,
+                labels::FINISHED_AT,
+                labels::ERROR,
+                labels::EXECUTOR_IP,
+                labels::EXECUTOR_MAC,
+            ])
+        );
+        assert!(schema.relations.is_empty());
+        assert!(
+            schema
+                .entities
+                .contains_key(applied_migration_entity_label())
+        );
+    }
+
+    #[test]
+    fn descriptor_preserves_value_types_and_key_ownerships() {
+        let schema = migration_state_schema();
+
+        assert_eq!(
+            schema.attributes[labels::APPLIED_AT].value_type,
+            ValueType::DateTime
+        );
+        assert_eq!(
+            schema.attributes[labels::STARTED_AT].value_type,
+            ValueType::DateTime
+        );
+        assert_eq!(
+            schema.attributes[labels::FINISHED_AT].value_type,
+            ValueType::DateTime
+        );
+
+        let applied = &schema.entities[labels::APPLIED_ENTITY];
+        let applied_key = applied
+            .owned_attributes
+            .iter()
+            .find(|attribute| attribute.attr_name == labels::MIGRATION_ID)
+            .unwrap();
+        assert_eq!(applied_key.annotations, vec![Annotation::Key]);
+
+        let run = &schema.entities[labels::RUN_ENTITY];
+        let run_key = run
+            .owned_attributes
+            .iter()
+            .find(|attribute| attribute.attr_name == labels::RUN_ID)
+            .unwrap();
+        assert_eq!(run_key.annotations, vec![Annotation::Key]);
+    }
+
+    #[test]
+    fn predicate_is_exact_and_kind_sensitive() {
+        assert!(is_migration_state_type(
+            MigrationStateSchemaKind::Entity,
+            labels::APPLIED_ENTITY
+        ));
+        assert!(is_migration_state_type(
+            MigrationStateSchemaKind::Attribute,
+            labels::CHECKSUM
+        ));
+        assert!(!is_migration_state_type(
+            MigrationStateSchemaKind::Attribute,
+            labels::APPLIED_ENTITY
+        ));
+        assert!(!is_migration_state_type(
+            MigrationStateSchemaKind::Entity,
+            "type_bridge_migration_custom"
+        ));
+        assert!(!is_migration_state_type(
+            MigrationStateSchemaKind::Role,
+            "unqualified-role"
+        ));
+    }
+
+    #[test]
+    fn canonical_schema_generates_the_existing_typeql_shape() {
+        let typeql = migration_state_schema().to_typeql().unwrap();
+
+        assert!(typeql.contains("attribute migration_applied_at, value datetime;"));
+        assert!(typeql.contains("attribute migration_started_at, value datetime;"));
+        assert!(typeql.contains("entity type_bridge_migration,"));
+        assert!(typeql.contains("owns migration_id @key"));
+        assert!(typeql.contains("entity type_bridge_migration_run,"));
+        assert!(typeql.contains("owns migration_run_id @key"));
+    }
+}

--- a/type-bridge-core/crates/migration/src/state/typedb.rs
+++ b/type-bridge-core/crates/migration/src/state/typedb.rs
@@ -1,11 +1,11 @@
 //! TypeDB-backed [`MigrationStateStore`] implementation.
 //!
-//! [`TypeDbStateStore`] ports the exact TypeQL previously hand-written in
-//! `type_bridge/migration/state.py` over the ORM
-//! [`Database`][type_bridge_orm::Database] seam. The schema, the `define`
-//! block, and every query string are byte-for-byte equivalent to the Python
-//! source (modulo the fixed `type_bridge_migration` entity name), per
-//! invariant 5 — applied-state storage is NOT redesigned.
+//! [`TypeDbStateStore`] persists the established migration projection and run
+//! log over the ORM [`Database`][type_bridge_orm::Database] seam. Its per-type
+//! bootstrap definitions are rendered from the canonical migration-state
+//! [`SchemaInfo`][type_bridge_orm::schema::SchemaInfo], and its row queries use
+//! the same semantic label constants. Existing labels, value types, keys, and
+//! storage behavior remain unchanged.
 //!
 //! All work runs through [`Database::transaction_context`], mirroring the
 //! Phase-05 executor: open a context for the right [`TxType`], run the query,
@@ -19,18 +19,16 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use chrono::Utc;
 use type_bridge_orm::Database;
 use type_bridge_orm::OrmError;
+use type_bridge_orm::schema::{SchemaError, SchemaInfo};
 use type_bridge_orm::session::backend::{BoxFuture, QueryResult, TxType};
 
+use crate::state::schema::labels::{
+    APP_LABEL, APPLIED_AT, APPLIED_ENTITY, CHECKSUM, DIRECTION, ERROR, EXECUTOR_IP, EXECUTOR_MAC,
+    FINISHED_AT, MIGRATION_ID, NAME, RUN_ENTITY, RUN_ID, STARTED_AT, STATUS,
+};
+use crate::state::schema::migration_state_schema;
 use crate::state::{MigrationRunRecord, MigrationStateStore};
 use crate::{AppliedMigrationRecord, MigrationError, Result};
-
-/// The migration-tracking entity type name.
-///
-/// Mirrors `MigrationStateManager.ENTITY_NAME` (`state.py:111`).
-const ENTITY_NAME: &str = "type_bridge_migration";
-
-/// The append/update migration run-log entity type name.
-const RUN_ENTITY_NAME: &str = "type_bridge_migration_run";
 
 /// Timestamp format mirroring Python's `strftime("%Y-%m-%dT%H:%M:%S.%f")`.
 ///
@@ -146,6 +144,12 @@ fn map_orm_error(error: OrmError) -> MigrationError {
     }
 }
 
+fn map_schema_error(error: SchemaError) -> MigrationError {
+    MigrationError::State {
+        message: error.to_string(),
+    }
+}
+
 /// Unwrap a single fetched field into its scalar string.
 ///
 /// The Phase-05 ORM backend renders a `fetch { "k": $attr }` document so that
@@ -250,7 +254,7 @@ pub fn parse_run_documents(values: &[serde_json::Value]) -> Result<Vec<Migration
 
 fn optional_run_field_query(attribute: &str, alias: &str) -> String {
     format!(
-        "\nmatch\n$r isa {RUN_ENTITY_NAME},\n    has migration_run_id $run_id,\n    has {attribute} ${alias};\nfetch {{\n    \"run_id\": $run_id,\n    \"{alias}\": ${alias}\n}};\n"
+        "\nmatch\n$r isa {RUN_ENTITY},\n    has {RUN_ID} $run_id,\n    has {attribute} ${alias};\nfetch {{\n    \"run_id\": $run_id,\n    \"{alias}\": ${alias}\n}};\n"
     )
 }
 
@@ -281,59 +285,44 @@ fn merge_optional_run_field(
 
 fn run_insert_query(record: &MigrationRunRecord) -> String {
     let mut fields = vec![
+        format!("    has {RUN_ID} {}", typeql_string_literal(&record.run_id)),
         format!(
-            "    has migration_run_id {}",
-            typeql_string_literal(&record.run_id)
-        ),
-        format!(
-            "    has migration_app_label {}",
+            "    has {APP_LABEL} {}",
             typeql_string_literal(&record.app_label)
         ),
+        format!("    has {NAME} {}", typeql_string_literal(&record.name)),
         format!(
-            "    has migration_name {}",
-            typeql_string_literal(&record.name)
-        ),
-        format!(
-            "    has migration_checksum {}",
+            "    has {CHECKSUM} {}",
             typeql_string_literal(&record.checksum)
         ),
         format!(
-            "    has migration_direction {}",
+            "    has {DIRECTION} {}",
             typeql_string_literal(&record.direction)
         ),
-        format!(
-            "    has migration_status {}",
-            typeql_string_literal(&record.status)
-        ),
-        format!("    has migration_started_at {}", record.started_at),
+        format!("    has {STATUS} {}", typeql_string_literal(&record.status)),
+        format!("    has {STARTED_AT} {}", record.started_at),
     ];
 
     if let Some(finished_at) = &record.finished_at {
-        fields.push(format!("    has migration_finished_at {finished_at}"));
+        fields.push(format!("    has {FINISHED_AT} {finished_at}"));
     }
     if let Some(error) = &record.error {
-        fields.push(format!(
-            "    has migration_error {}",
-            typeql_string_literal(error)
-        ));
+        fields.push(format!("    has {ERROR} {}", typeql_string_literal(error)));
     }
     if let Some(executor_ip) = &record.executor_ip {
         fields.push(format!(
-            "    has migration_executor_ip {}",
+            "    has {EXECUTOR_IP} {}",
             typeql_string_literal(executor_ip)
         ));
     }
     if let Some(executor_mac) = &record.executor_mac {
         fields.push(format!(
-            "    has migration_executor_mac {}",
+            "    has {EXECUTOR_MAC} {}",
             typeql_string_literal(executor_mac)
         ));
     }
 
-    format!(
-        "\ninsert $r isa {RUN_ENTITY_NAME},\n{};\n",
-        fields.join(",\n")
-    )
+    format!("\ninsert $r isa {RUN_ENTITY},\n{};\n", fields.join(",\n"))
 }
 
 impl MigrationStateStore for TypeDbStateStore {
@@ -343,34 +332,30 @@ impl MigrationStateStore for TypeDbStateStore {
                 return Ok(());
             }
 
-            for (name, value_type) in [
-                ("migration_id", "string"),
-                ("migration_app_label", "string"),
-                ("migration_name", "string"),
-                ("migration_applied_at", "datetime"),
-                ("migration_checksum", "string"),
-                ("migration_run_id", "string"),
-                ("migration_direction", "string"),
-                ("migration_status", "string"),
-                ("migration_started_at", "datetime"),
-                ("migration_finished_at", "datetime"),
-                ("migration_error", "string"),
-                ("migration_executor_ip", "string"),
-                ("migration_executor_mac", "string"),
-            ] {
-                let define = format!("define\nattribute {name}, value {value_type};\n");
+            let state_schema = migration_state_schema();
+
+            for (name, attribute) in &state_schema.attributes {
+                let mut definition = SchemaInfo::default();
+                definition
+                    .attributes
+                    .insert(name.clone(), attribute.clone());
+                let define = definition.to_typeql().map_err(map_schema_error)?;
                 self.ensure_type(name, &define).await?;
             }
 
-            let applied_entity = format!(
-                "define\nentity {ENTITY_NAME},\n    owns migration_id @key,\n    owns migration_app_label,\n    owns migration_name,\n    owns migration_applied_at,\n    owns migration_checksum;\n"
-            );
-            self.ensure_type(ENTITY_NAME, &applied_entity).await?;
+            for (name, entity) in &state_schema.entities {
+                let mut definition = SchemaInfo::default();
+                definition.entities.insert(name.clone(), entity.clone());
+                let define = definition.to_typeql().map_err(map_schema_error)?;
+                self.ensure_type(name, &define).await?;
+            }
 
-            let run_entity = format!(
-                "define\nentity {RUN_ENTITY_NAME},\n    owns migration_run_id @key,\n    owns migration_app_label,\n    owns migration_name,\n    owns migration_checksum,\n    owns migration_direction,\n    owns migration_status,\n    owns migration_started_at,\n    owns migration_finished_at,\n    owns migration_error,\n    owns migration_executor_ip,\n    owns migration_executor_mac;\n"
-            );
-            self.ensure_type(RUN_ENTITY_NAME, &run_entity).await?;
+            for (name, relation) in &state_schema.relations {
+                let mut definition = SchemaInfo::default();
+                definition.relations.insert(name.clone(), relation.clone());
+                let define = definition.to_typeql().map_err(map_schema_error)?;
+                self.ensure_type(name, &define).await?;
+            }
 
             self.schema_ensured.store(true, Ordering::Release);
             Ok(())
@@ -383,7 +368,7 @@ impl MigrationStateStore for TypeDbStateStore {
 
             // Ported verbatim from state.py:179-191.
             let query = format!(
-                "\nmatch\n$m isa {ENTITY_NAME},\n    has migration_app_label $app,\n    has migration_name $name,\n    has migration_applied_at $applied,\n    has migration_checksum $checksum;\nfetch {{\n    \"app\": $app,\n    \"name\": $name,\n    \"applied\": $applied,\n    \"checksum\": $checksum\n}};\n"
+                "\nmatch\n$m isa {APPLIED_ENTITY},\n    has {APP_LABEL} $app,\n    has {NAME} $name,\n    has {APPLIED_AT} $applied,\n    has {CHECKSUM} $checksum;\nfetch {{\n    \"app\": $app,\n    \"name\": $name,\n    \"applied\": $applied,\n    \"checksum\": $checksum\n}};\n"
             );
 
             let ctx = self
@@ -403,23 +388,23 @@ impl MigrationStateStore for TypeDbStateStore {
             self.ensure_schema().await?;
 
             let query = format!(
-                "\nmatch\n$r isa {RUN_ENTITY_NAME},\n    has migration_run_id $run_id,\n    has migration_app_label $app,\n    has migration_name $name,\n    has migration_checksum $checksum,\n    has migration_direction $direction,\n    has migration_status $status,\n    has migration_started_at $started;\nfetch {{\n    \"run_id\": $run_id,\n    \"app\": $app,\n    \"name\": $name,\n    \"checksum\": $checksum,\n    \"direction\": $direction,\n    \"status\": $status,\n    \"started\": $started\n}};\n"
+                "\nmatch\n$r isa {RUN_ENTITY},\n    has {RUN_ID} $run_id,\n    has {APP_LABEL} $app,\n    has {NAME} $name,\n    has {CHECKSUM} $checksum,\n    has {DIRECTION} $direction,\n    has {STATUS} $status,\n    has {STARTED_AT} $started;\nfetch {{\n    \"run_id\": $run_id,\n    \"app\": $app,\n    \"name\": $name,\n    \"checksum\": $checksum,\n    \"direction\": $direction,\n    \"status\": $status,\n    \"started\": $started\n}};\n"
             );
             let mut runs = parse_run_documents(&self.query_documents(&query).await?)?;
 
-            let finished_query = optional_run_field_query("migration_finished_at", "finished");
+            let finished_query = optional_run_field_query(FINISHED_AT, "finished");
             let finished_docs = self.query_documents(&finished_query).await?;
             merge_optional_run_field(&mut runs, &finished_docs, "finished_at", "finished");
 
-            let error_query = optional_run_field_query("migration_error", "error");
+            let error_query = optional_run_field_query(ERROR, "error");
             let error_docs = self.query_documents(&error_query).await?;
             merge_optional_run_field(&mut runs, &error_docs, "error", "error");
 
-            let ip_query = optional_run_field_query("migration_executor_ip", "executor_ip");
+            let ip_query = optional_run_field_query(EXECUTOR_IP, "executor_ip");
             let ip_docs = self.query_documents(&ip_query).await?;
             merge_optional_run_field(&mut runs, &ip_docs, "executor_ip", "executor_ip");
 
-            let mac_query = optional_run_field_query("migration_executor_mac", "executor_mac");
+            let mac_query = optional_run_field_query(EXECUTOR_MAC, "executor_mac");
             let mac_docs = self.query_documents(&mac_query).await?;
             merge_optional_run_field(&mut runs, &mac_docs, "executor_mac", "executor_mac");
 
@@ -450,13 +435,13 @@ impl MigrationStateStore for TypeDbStateStore {
             // This gives the TypeDB store the same dedup semantics the in-memory
             // store has behind the shared seam.
             let delete_existing = format!(
-                "\nmatch\n$m isa {ENTITY_NAME},\n    has migration_id {migration_id};\ndelete $m;\n"
+                "\nmatch\n$m isa {APPLIED_ENTITY},\n    has {MIGRATION_ID} {migration_id};\ndelete $m;\n"
             );
 
             // Field set + storage schema match state.py:253-260. `applied_at` is
             // emitted unquoted (a TypeQL datetime literal); every other field quoted.
             let insert = format!(
-                "\ninsert $m isa {ENTITY_NAME},\n    has migration_id {migration_id},\n    has migration_app_label {app},\n    has migration_name {name},\n    has migration_applied_at {applied_at},\n    has migration_checksum {checksum};\n",
+                "\ninsert $m isa {APPLIED_ENTITY},\n    has {MIGRATION_ID} {migration_id},\n    has {APP_LABEL} {app},\n    has {NAME} {name},\n    has {APPLIED_AT} {applied_at},\n    has {CHECKSUM} {checksum};\n",
             );
 
             let ctx = self
@@ -485,7 +470,7 @@ impl MigrationStateStore for TypeDbStateStore {
             let app_label = typeql_string_literal(app_label);
             let name = typeql_string_literal(name);
             let query = format!(
-                "\nmatch\n$m isa {ENTITY_NAME},\n    has migration_app_label {app_label},\n    has migration_name {name};\ndelete $m;\n"
+                "\nmatch\n$m isa {APPLIED_ENTITY},\n    has {APP_LABEL} {app_label},\n    has {NAME} {name};\ndelete $m;\n"
             );
 
             let ctx = self
@@ -504,9 +489,8 @@ impl MigrationStateStore for TypeDbStateStore {
             self.ensure_schema().await?;
 
             let run_id = typeql_string_literal(&record.run_id);
-            let delete_existing = format!(
-                "\nmatch\n$r isa {RUN_ENTITY_NAME},\n    has migration_run_id {run_id};\ndelete $r;\n"
-            );
+            let delete_existing =
+                format!("\nmatch\n$r isa {RUN_ENTITY},\n    has {RUN_ID} {run_id};\ndelete $r;\n");
             let insert = run_insert_query(&record);
 
             let ctx = self

--- a/type-bridge-core/crates/python/src/migration_runtime.rs
+++ b/type-bridge-core/crates/python/src/migration_runtime.rs
@@ -13,9 +13,12 @@ use pyo3::prelude::*;
 use pythonize::{depythonize, pythonize};
 use tokio::runtime::Runtime;
 use type_bridge_migration::{
-    AppliedMigrationRecord, MigrationGraph, MigrationRunRecord, MigrationSpec, MigrationStateStore,
-    TypeDbStateStore, check_checksum_drift, collect_executor_info, execute_plan_with_run_log,
-    load_sidecar, migration_file_checksum, plan, validate_graph,
+    AppliedMigrationRecord, MigrationGraph, MigrationRunRecord, MigrationSpec,
+    MigrationStateSchemaKind, MigrationStateStore, TypeDbStateStore,
+    applied_migration_entity_label as rust_applied_migration_entity_label, check_checksum_drift,
+    collect_executor_info, execute_plan, execute_plan_with_run_log,
+    is_migration_state_type as rust_is_migration_state_type, load_sidecar, migration_file_checksum,
+    migration_state_schema as rust_migration_state_schema, plan, validate_graph,
 };
 
 use crate::orm_runtime::PyRustDatabase;
@@ -102,6 +105,37 @@ fn migration_graph_from_json(py: Python<'_>, json: &str) -> PyResult<PyObject> {
 #[pyfunction]
 fn calculate_migration_file_checksum(content: &str) -> String {
     migration_file_checksum(content)
+}
+
+/// Return TypeBridge's canonical migration-state schema as a `SchemaInfo` dict.
+#[pyfunction]
+fn migration_state_schema(py: Python<'_>) -> PyResult<PyObject> {
+    pythonize(py, rust_migration_state_schema())
+        .map(|object| object.unbind())
+        .map_err(|error| py_value_error(error.to_string()))
+}
+
+/// Return the canonical applied-migration entity label.
+#[pyfunction]
+fn applied_migration_entity_label() -> &'static str {
+    rust_applied_migration_entity_label()
+}
+
+/// Return whether a kind/label pair belongs to the migration-state schema.
+#[pyfunction]
+fn is_migration_state_type(kind: &str, label: &str) -> PyResult<bool> {
+    let kind = match kind {
+        "entity" => MigrationStateSchemaKind::Entity,
+        "relation" => MigrationStateSchemaKind::Relation,
+        "attribute" => MigrationStateSchemaKind::Attribute,
+        "role" => MigrationStateSchemaKind::Role,
+        _ => {
+            return Err(py_value_error(format!(
+                "Invalid migration state schema kind {kind:?}; expected entity, relation, attribute, or role"
+            )));
+        }
+    };
+    Ok(rust_is_migration_state_type(kind, label))
 }
 
 /// Validate a serialized migration graph and return structured errors.
@@ -209,6 +243,35 @@ impl PyMigrationRunner {
                 &executor,
             ))
             .map_err(|error| py_value_error(error.to_string()))?;
+
+        pythonize(py, &results)
+            .map(|obj| obj.unbind())
+            .map_err(|error| py_value_error(error.to_string()))
+    }
+
+    /// Plan and execute migrations without reading or writing migration state.
+    ///
+    /// This path opens only the transactions required by the migration steps;
+    /// it never constructs a [`TypeDbStateStore`] or bootstraps TypeBridge's
+    /// state schema. Embedders with an external authoritative ledger use this
+    /// method and persist applied state/run logs through that ledger.
+    #[pyo3(signature = (graph, applied_records = None, target = None))]
+    fn apply_state_free(
+        &self,
+        py: Python<'_>,
+        graph: Bound<'_, PyAny>,
+        applied_records: Option<Bound<'_, PyAny>>,
+        target: Option<&str>,
+    ) -> PyResult<PyObject> {
+        let graph: MigrationGraph = depythonize(&graph)
+            .map_err(|error| py_value_error(format!("Invalid MigrationGraph: {error}")))?;
+        let applied = depythonize_applied_records(applied_records)?;
+
+        let execution_plan =
+            plan(&graph, &applied, target).map_err(|error| py_value_error(error.to_string()))?;
+        let results = self
+            .runtime
+            .block_on(execute_plan(&self.db, execution_plan));
 
         pythonize(py, &results)
             .map(|obj| obj.unbind())
@@ -359,6 +422,9 @@ pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(migration_graph_to_json, m)?)?;
     m.add_function(wrap_pyfunction!(migration_graph_from_json, m)?)?;
     m.add_function(wrap_pyfunction!(calculate_migration_file_checksum, m)?)?;
+    m.add_function(wrap_pyfunction!(migration_state_schema, m)?)?;
+    m.add_function(wrap_pyfunction!(applied_migration_entity_label, m)?)?;
+    m.add_function(wrap_pyfunction!(is_migration_state_type, m)?)?;
     m.add_function(wrap_pyfunction!(validate_migration_graph, m)?)?;
     m.add_function(wrap_pyfunction!(check_migration_drift, m)?)?;
     m.add_function(wrap_pyfunction!(plan_migration_graph, m)?)?;

--- a/type_bridge/_rust_runtime.py
+++ b/type_bridge/_rust_runtime.py
@@ -111,6 +111,21 @@ def generate_define_block(info: dict[str, Any]) -> str:
     return rust_core().generate_define_block(info)
 
 
+def migration_state_schema() -> dict[str, Any]:
+    """Return the canonical Rust-owned migration-state schema descriptor."""
+    return rust_core().migration_state_schema()
+
+
+def applied_migration_entity_label() -> str:
+    """Return the canonical applied-migration entity label."""
+    return str(rust_core().applied_migration_entity_label())
+
+
+def is_migration_state_type(kind: str, label: str) -> bool:
+    """Return whether a kind-and-label pair belongs to migration state."""
+    return bool(rust_core().is_migration_state_type(kind, label))
+
+
 def normalize_migration_spec(spec: dict[str, Any]) -> dict[str, Any]:
     """Normalize a migration spec dict through Rust serde."""
     return rust_core().normalize_migration_spec(spec)

--- a/type_bridge/migration/__init__.py
+++ b/type_bridge/migration/__init__.py
@@ -115,6 +115,14 @@ from type_bridge.migration.state import (
     MigrationRunRecord,
     MigrationState,
     MigrationStateManager,
+    MigrationStateStore,
+)
+from type_bridge.migration.state_schema import (
+    MIGRATION_STATE_SCHEMA,
+    MigrationStateSchema,
+    is_migration_state_type,
+    migration_state_schema,
+    without_migration_state_schema,
 )
 from type_bridge.migration.utils import type_exists
 
@@ -144,8 +152,14 @@ __all__ = [
     # State management
     "MigrationState",
     "MigrationStateManager",
+    "MigrationStateStore",
     "MigrationRecord",
     "MigrationRunRecord",
+    "MigrationStateSchema",
+    "MIGRATION_STATE_SCHEMA",
+    "migration_state_schema",
+    "is_migration_state_type",
+    "without_migration_state_schema",
     # Loader
     "MigrationLoader",
     "LoadedMigration",

--- a/type_bridge/migration/executor.py
+++ b/type_bridge/migration/executor.py
@@ -17,6 +17,7 @@ from type_bridge.migration.state import (
     MigrationRunRecord,
     MigrationState,
     MigrationStateManager,
+    MigrationStateStore,
 )
 
 if TYPE_CHECKING:
@@ -101,6 +102,8 @@ class MigrationExecutor:
         db: Database,
         migrations_dir: Path,
         dry_run: bool = False,
+        *,
+        state_manager: MigrationStateStore | None = None,
     ):
         """Initialize executor.
 
@@ -108,12 +111,17 @@ class MigrationExecutor:
             db: Database connection
             migrations_dir: Directory containing migration files
             dry_run: If True, preview operations without executing
+            state_manager: Optional externally owned migration-state store. When
+                supplied, Rust migration segments use the state-free executor
+                and never create TypeBridge's ledger schema independently in
+                the target database. The default remains TypeDB-backed.
         """
         self.db = db
         self.migrations_dir = migrations_dir
         self.dry_run = dry_run
         self.loader = MigrationLoader(migrations_dir)
-        self.state_manager = MigrationStateManager(db)
+        self._uses_injected_state_manager = state_manager is not None
+        self.state_manager = MigrationStateManager(db) if state_manager is None else state_manager
 
     def migrate(self, target: str | None = None) -> list[MigrationResult]:
         """Apply pending migrations.
@@ -151,7 +159,7 @@ class MigrationExecutor:
         applied_records = [_applied_record_dict(record) for record in state.applied]
 
         runner = _rust_runtime.migration_runner_for(self.db)
-        rust_results = runner.apply(graph, applied_records, target)
+        rust_results = self._apply_rust_graph(runner, graph, applied_records, target)
 
         checksums = {
             (loaded.migration.app_label, loaded.migration.name): loaded.checksum
@@ -211,7 +219,7 @@ class MigrationExecutor:
                 raise MigrationError("Mixed migration plan has no Rust runner configured")
             state = self.state_manager.load_state()
             applied_records = [_applied_record_dict(record) for record in state.applied]
-            rust_results = runner.apply(graph, applied_records, target)
+            rust_results = self._apply_rust_graph(runner, graph, applied_records, target)
 
             mapped: list[MigrationResult] = []
             for rust_result in rust_results:
@@ -279,6 +287,25 @@ class MigrationExecutor:
             results.extend(run_rust_segment(target))
 
         return results
+
+    def _apply_rust_graph(
+        self,
+        runner: Any,
+        graph: dict[str, Any],
+        applied_records: list[dict[str, str]],
+        target: str | None,
+    ) -> list[dict[str, Any]]:
+        """Execute a Rust migration graph with the selected state ownership.
+
+        The default runner path records attempt logs in TypeDB. An explicitly
+        injected store selects Rust's state-free executor so no hidden
+        ``TypeDbStateStore`` can bootstrap infrastructure in the target
+        database. Applied/unapplied projection writes still flow through
+        ``self.state_manager`` after each successful result.
+        """
+        if getattr(self, "_uses_injected_state_manager", False):
+            return runner.apply_state_free(graph, applied_records, target)
+        return runner.apply(graph, applied_records, target)
 
     def _execution_graph_for_mixed_plan(
         self,

--- a/type_bridge/migration/generator.py
+++ b/type_bridge/migration/generator.py
@@ -15,32 +15,13 @@ from type_bridge.migration.info import SchemaInfo
 from type_bridge.migration.introspection import IntrospectedSchema, SchemaIntrospector
 from type_bridge.migration.loader import MigrationLoader
 from type_bridge.migration.schema_manager import SchemaManager
+from type_bridge.migration.state_schema import without_migration_state_schema
 
 if TYPE_CHECKING:
     from type_bridge.models import Entity, Relation
     from type_bridge.session import Database
 
 logger = logging.getLogger(__name__)
-
-_MIGRATION_STATE_ENTITIES = {
-    "type_bridge_migration",
-    "type_bridge_migration_run",
-}
-_MIGRATION_STATE_ATTRIBUTES = {
-    "migration_id",
-    "migration_app_label",
-    "migration_name",
-    "migration_applied_at",
-    "migration_checksum",
-    "migration_run_id",
-    "migration_direction",
-    "migration_status",
-    "migration_started_at",
-    "migration_finished_at",
-    "migration_error",
-    "migration_executor_ip",
-    "migration_executor_mac",
-}
 
 
 def _add_ownership_operation(
@@ -147,29 +128,6 @@ def _type_ref(value: object) -> str:
 
 def _attribute_ref(value: object) -> str:
     return f"ref.attribute({_attribute_label(value)!r})"
-
-
-def _without_migration_state_schema(schema: IntrospectedSchema) -> IntrospectedSchema:
-    """Remove TypeBridge's migration ledger types from a live schema snapshot."""
-    return IntrospectedSchema(
-        entities={
-            name: entity
-            for name, entity in schema.entities.items()
-            if name not in _MIGRATION_STATE_ENTITIES
-        },
-        relations=dict(schema.relations),
-        attributes={
-            name: attribute
-            for name, attribute in schema.attributes.items()
-            if name not in _MIGRATION_STATE_ATTRIBUTES
-        },
-        ownerships=[
-            ownership
-            for ownership in schema.ownerships
-            if ownership.owner_name not in _MIGRATION_STATE_ENTITIES
-            and ownership.attribute_name not in _MIGRATION_STATE_ATTRIBUTES
-        ],
-    )
 
 
 class MigrationGenerator:
@@ -335,7 +293,7 @@ class MigrationGenerator:
         # still visible to the diff. TypeBridge's own migration state schema is
         # filtered out because it is storage infrastructure, not app schema.
         introspector = SchemaIntrospector(self.db)
-        db_schema = _without_migration_state_schema(introspector.introspect())
+        db_schema = without_migration_state_schema(introspector.introspect())
 
         # Generate operations - this works for both initial and incremental migrations
         # For empty database, all model types will be "new" and get Add operations

--- a/type_bridge/migration/state.py
+++ b/type_bridge/migration/state.py
@@ -1,7 +1,4 @@
-"""Migration state tracking for TypeDB.
-
-Tracks applied migrations in TypeDB as the sole source of truth.
-"""
+"""Migration-state records, external-store protocol, and TypeDB default backend."""
 
 from __future__ import annotations
 
@@ -10,7 +7,9 @@ import socket
 import uuid
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+from type_bridge import _rust_runtime
 
 if TYPE_CHECKING:
     from type_bridge.session import Database
@@ -113,6 +112,49 @@ class MigrationState:
         return [r for r in self.applied if r.app_label == app_label]
 
 
+@runtime_checkable
+class MigrationStateStore(Protocol):
+    """State operations required by :class:`MigrationExecutor`.
+
+    Implement this protocol to keep applied migration state outside the target
+    TypeDB database. Schema bootstrap and run-log reads are intentionally not
+    part of the contract: the default :class:`MigrationStateManager` provides
+    those TypeDB-specific capabilities, while embedding orchestrators may own
+    persistence and execution-attempt logging independently.
+    """
+
+    def load_state(self) -> MigrationState:
+        """Load the applied migration projection used for planning."""
+        ...
+
+    def record_applied(self, app_label: str, name: str, checksum: str) -> None:
+        """Persist one successfully applied migration."""
+        ...
+
+    def record_unapplied(self, app_label: str, name: str) -> None:
+        """Remove one successfully rolled-back migration."""
+        ...
+
+    def record_run_started(
+        self,
+        app_label: str,
+        name: str,
+        checksum: str,
+        direction: str,
+    ) -> MigrationRunRecord:
+        """Record the start of a Python-hosted migration execution."""
+        ...
+
+    def record_run_finished(
+        self,
+        record: MigrationRunRecord,
+        status: str,
+        error: str | None = None,
+    ) -> MigrationRunRecord:
+        """Record the end of a Python-hosted migration execution."""
+        ...
+
+
 class MigrationStateManager:
     """Manages migration state in TypeDB.
 
@@ -132,7 +174,9 @@ class MigrationStateManager:
             manager.record_applied("myapp", "0001_initial", "abc123")
     """
 
-    ENTITY_NAME = "type_bridge_migration"
+    # Compatibility alias for callers that referenced the original manager
+    # constant; its value still comes from the canonical Rust contract.
+    ENTITY_NAME = _rust_runtime.applied_migration_entity_label()
 
     def __init__(self, db: Database):
         """Initialize state manager.

--- a/type_bridge/migration/state_schema.py
+++ b/type_bridge/migration/state_schema.py
@@ -1,0 +1,100 @@
+"""Public boundary for TypeBridge-owned migration-state schema objects."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any, Final, Literal
+
+from type_bridge import _rust_runtime
+from type_bridge.migration.introspection import IntrospectedSchema
+
+
+@dataclass(frozen=True)
+class MigrationStateSchema:
+    """Immutable label projection of the canonical migration-state schema.
+
+    Role labels are qualified as ``relation:role`` so an application relation
+    can use the same unqualified role name without being classified as
+    TypeBridge infrastructure.
+    """
+
+    entities: frozenset[str]
+    relations: frozenset[str]
+    attributes: frozenset[str]
+    roles: frozenset[str]
+
+
+def migration_state_schema() -> dict[str, Any]:
+    """Return the full canonical migration-state schema descriptor from Rust."""
+    return _rust_runtime.migration_state_schema()
+
+
+def _label_projection(schema: dict[str, Any]) -> MigrationStateSchema:
+    entities = frozenset(str(label) for label in schema.get("entities", {}))
+    relations = frozenset(str(label) for label in schema.get("relations", {}))
+    attributes = frozenset(str(label) for label in schema.get("attributes", {}))
+
+    roles: set[str] = set()
+    for relation_label, relation in schema.get("relations", {}).items():
+        for role in relation.get("roles", []):
+            roles.add(f"{relation_label}:{role['role_name']}")
+
+    return MigrationStateSchema(
+        entities=entities,
+        relations=relations,
+        attributes=attributes,
+        roles=frozenset(roles),
+    )
+
+
+MIGRATION_STATE_SCHEMA: Final = _label_projection(migration_state_schema())
+"""Immutable labels for all schema objects owned by TypeBridge migration state."""
+
+
+def is_migration_state_type(
+    *,
+    kind: Literal["entity", "relation", "attribute", "role"],
+    label: str,
+) -> bool:
+    """Return whether ``label`` is a TypeBridge migration-state schema object.
+
+    Role labels must use the qualified ``relation:role`` form.
+    """
+    return _rust_runtime.is_migration_state_type(kind, label)
+
+
+def without_migration_state_schema(schema: IntrospectedSchema) -> IntrospectedSchema:
+    """Return a copy of ``schema`` without TypeBridge migration-state objects."""
+    state_schema = MIGRATION_STATE_SCHEMA
+    state_owners = state_schema.entities | state_schema.relations
+
+    relations = {}
+    for relation_name, relation in schema.relations.items():
+        if relation_name in state_schema.relations:
+            continue
+        roles = {
+            role_name: role
+            for role_name, role in relation.roles.items()
+            if f"{relation_name}:{role_name}" not in state_schema.roles
+        }
+        relations[relation_name] = replace(relation, roles=roles)
+
+    return IntrospectedSchema(
+        entities={
+            name: entity
+            for name, entity in schema.entities.items()
+            if name not in state_schema.entities
+        },
+        relations=relations,
+        attributes={
+            name: attribute
+            for name, attribute in schema.attributes.items()
+            if name not in state_schema.attributes
+        },
+        ownerships=[
+            ownership
+            for ownership in schema.ownerships
+            if ownership.owner_name not in state_owners
+            and ownership.attribute_name not in state_schema.attributes
+        ],
+    )


### PR DESCRIPTION
## Summary
Expose migration-state internals as a canonical boundary and make migration execution work with an externally owned ledger without creating TypeBridge migration types in the target application database.

## Key changes
- Added a canonical migration-state schema definition in Rust and exported it through PyO3/Python.
- Added a public Python schema boundary helper for detecting and filtering migration-state labels.
- Removed generator private copied label sets and switched filtering to the canonical helper.
- Added `state_manager` injection to `MigrationExecutor` and added a state-free execution path when a store is injected.
- Added unit and integration coverage for both default TypeDB-backed state and external state manager execution.
- Documented the default vs external state ownership boundary and external-ledger workflow.

## Verification
- `./scripts/check.sh rust` passed before PR with full Rust checks.
- `./scripts/check.sh python` passed before PR with full Python checks.
- `uv run pytest tests/unit/migration -q` (full migration unit tests) passed.
- Live migration integration with and without external state passed:
  - `USE_DOCKER=false TYPEDB_ADDRESS=localhost:32778 TYPEDB_HTTP_PORT=32779 uv run pytest -m integration tests/integration/migration/test_external_state.py tests/integration/migration/test_state.py -q -rs`
  - `uv run pytest -m integration tests/integration/migration/test_autogenerate.py::test_no_changes_returns_none -q`

## Related
Closes #165
