### PR TITLE
feat(compat): band-9 driver and given-stage bulk queries (#169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,25 @@ All notable changes to TypeBridge will be documented in this file.
   syntax error. `Database.check_schema_annotation_support()` exposes the
   check directly.
 
+- **Band-9 embedded driver (#169)** - the TypeDB 3.12 Rust driver ships
+  vendored as `type-bridge-typedb-driver-b9` alongside the band-7 fork and
+  the crates.io band-8 driver, so 3.12 connections negotiate the native
+  band-9 protocol automatically. Live measurement surfaced a hazard: a
+  band-9 connection attempt crashes a 3.11 server, so the gRPC fallback
+  discovers unknown servers through band 8 and upgrades to band 9 only
+  after the reported version proves it safe.
+
+- **`given`-stage parameterized queries (#169)** - one compiled TypeQL
+  pipeline runs over many input rows, with the rows passed through the
+  driver API instead of interpolated into the query string.
+  `Database.execute_with_rows()` / `TransactionContext.execute_with_rows()`
+  expose the raw surface (gated on TypeDB 3.12+ with an actionable
+  versioned error below it; `Database.supports_given_stage()` reports the
+  capability), and entity `insert_many()` automatically rides one given
+  pipeline for homogeneous batches on 3.12+ servers — measured ~4x faster
+  than the per-row path at 1000 rows — while degrading transparently to
+  per-row inserts on older servers and heterogeneous batches.
+
 - **TypeDB 3.12 server support** - the compatibility window now extends to
   3.12.x. Compatibility was measured live: server 3.12 accepts band-8 (3.11)
   drivers, while a 3.12 driver is refused by a 3.11 server, so the version

--- a/docs/development/typedb.md
+++ b/docs/development/typedb.md
@@ -68,9 +68,19 @@ Current feature gates:
 | Feature | Minimum server | Gated surfaces |
 |---------|----------------|----------------|
 | `@doc`/`@meta` schema annotations | 3.12.0 | `SchemaManager.sync_schema`, migration executor steps |
+| `given`-stage parameterized queries | 3.12.0 | `Database.execute_with_rows`, `TransactionContext.execute_with_rows`; `insert_many` uses it opportunistically |
 
 When the server version is unknown (band-7 gRPC fallback without a
-`server_version=` pin), gated DDL is sent as-is and the server decides.
+`server_version=` pin), gated DDL is sent as-is and the server decides;
+given-stage queries are rejected by the runtime when the negotiated driver
+band cannot carry input rows.
+
+The band map itself is `{7, 8, 9}` in the default build: band 9 is the
+vendored TypeDB 3.12 driver, and its protocol is the wire path for given
+rows. One measured hazard shapes the connect design: a band-9 connection
+attempt crashes a 3.11 server outright, so the gRPC fallback discovers
+unknown servers through band 8 and upgrades to band 9 only after the
+reported version proves it safe.
 
 ### Update-safety contract
 

--- a/docs/guide/crud.md
+++ b/docs/guide/crud.md
@@ -139,6 +139,22 @@ person_manager.insert_many(persons)
 
 Both `insert()` and `insert_many()` run in a single write transaction when a transaction/context is provided to the manager. Without one, each call opens exactly one write transaction (no per-entity commits).
 
+#### Given-Stage Fast Path (TypeDB 3.12+)
+
+Against a TypeDB 3.12+ server, `insert_many()` for entities automatically
+runs as **one compiled `given`-stage pipeline** over the whole batch: the
+values travel through the driver API instead of being interpolated into
+per-row TypeQL strings, removing both the per-row query-compilation
+overhead and the string-interpolation surface.
+
+The fast path engages when the batch is homogeneous — every instance binds
+the same attribute set with matching value types. Batches with optional
+attributes present on only some instances, decimal/duration values, or
+transaction-bound managers use the per-row path instead, with identical
+results. On servers older than 3.12 the per-row path is always used; no
+code changes are needed either way. Check `db.supports_given_stage()` to
+see which path a connection takes.
+
 **Note on special characters**: TypeBridge automatically escapes special characters in string attributes (quotes, backslashes) when generating TypeQL queries. You don't need to manually escape values - just pass them as normal Python strings.
 
 ## PUT Operations (Idempotent Insert)

--- a/docs/guide/queries.md
+++ b/docs/guide/queries.md
@@ -946,6 +946,41 @@ Each helper returns an `ArithmeticExpr` which implements the standard `Expressio
 | `mod`  | `%`      | `mod("x", 2)`       |
 | `pow_` | `^`      | `pow_("base", 3)`   |
 
+## Given-Stage Parameterized Queries (TypeDB 3.12+)
+
+TypeQL's `given` stage runs **one compiled pipeline over many input rows**,
+with the rows passed through the driver API instead of interpolated into the
+query string — the first injection-safe parameter mechanism in TypeQL.
+`Database.execute_with_rows()` exposes it directly:
+
+```python
+docs = db.execute_with_rows(
+    'given $n: string, $a: integer;\n'
+    'insert $p isa person, has name == $n, has age == $a;\n'
+    'fetch { "iid": iid($p), "name": $n };',
+    "write",
+    ["n", "a"],                      # given variables, no "$" sigil
+    ["string", "integer"],           # TypeQL value types per column
+    [["Alice", 30], ["Bob", 25]],    # one list per input row
+)
+```
+
+`TransactionContext.execute_with_rows(query, variables, column_types, rows)`
+is the same call inside an open transaction. Supported column types are
+`string`, `integer`, `double`, `boolean`, `date`, `datetime`, and
+`datetime-tz` (temporal values as ISO-8601 strings).
+
+Requirements and fallbacks:
+
+- Requires a TypeDB 3.12+ server; on older servers the call raises the
+  versioned error from the feature gate (naming the detected server and the
+  required 3.12 line) before anything reaches the server.
+- `db.supports_given_stage()` reports whether the connection can take this
+  path — `False` on pre-3.12 servers and when the server version is unknown.
+- Bulk ORM operations (`insert_many()` on entities) use this mechanism
+  automatically on 3.12+ and fall back to per-row queries elsewhere; see
+  [CRUD Operations](crud.md#given-stage-fast-path-typedb-312).
+
 ## See Also
 
 - [CRUD Operations](crud.md) - Basic CRUD operations

--- a/tests/integration/session/test_version_gate.py
+++ b/tests/integration/session/test_version_gate.py
@@ -12,7 +12,8 @@ from typing import Any
 import pytest
 
 import type_bridge.typedb_driver as _tdm
-from type_bridge import version
+from type_bridge import Entity, Flag, Integer, String, TypeFlags, Unique, version
+from type_bridge.attribute import AttributeFlags
 from type_bridge.session import Database
 
 # ---------------------------------------------------------------------------
@@ -372,3 +373,107 @@ class TestSchemaAnnotationGateLive:
             with pytest.raises(type_bridge_core.VersionError):
                 manager.sync_schema(skip_if_exists=True)
             assert "vg-gated-person" not in clean_db.get_schema()
+
+
+# Module level so `from __future__ import annotations` string hints resolve
+# during model scanning (method-local classes cannot be resolved by
+# get_type_hints).
+class VgGivenBulkName(String):
+    flags = AttributeFlags(name="vg-given-bulk-name")
+
+
+class VgGivenBulkAge(Integer):
+    flags = AttributeFlags(name="vg-given-bulk-age")
+
+
+class VgGivenBulkPerson(Entity):
+    flags = TypeFlags(name="vg-given-bulk-person")
+    name: VgGivenBulkName = Flag(Unique)
+    age: VgGivenBulkAge
+
+
+@pytest.mark.integration
+@pytest.mark.order(4124)
+class TestGivenStageLive:
+    """given-stage parameterized queries against the live server.
+
+    Version-adaptive: on a 3.12+ leg one compiled pipeline runs over the
+    input rows through the driver API; on a pre-3.12 leg the raw surface
+    raises the versioned error and bulk operations fall back to per-row
+    queries with identical results.
+    """
+
+    GIVEN_DDL = (
+        "define entity vg-given-person, owns vg-given-name @key, owns vg-given-age;"
+        " attribute vg-given-name, value string;"
+        " attribute vg-given-age, value integer;"
+    )
+    GIVEN_PIPELINE = (
+        "given $n: string, $a: integer;\n"
+        "insert $p isa vg-given-person, has vg-given-name == $n, has vg-given-age == $a;\n"
+        'fetch { "iid": iid($p), "name": $n };'
+    )
+
+    @staticmethod
+    def _live_server_supports_given() -> bool:
+        from tests.integration.conftest import TEST_DB_ADDRESS, TEST_DB_HTTP_PORT
+
+        detected = _tdm.server_version(TEST_DB_ADDRESS, http_port=TEST_DB_HTTP_PORT)
+        major, minor = (int(part) for part in detected.split(".")[:2])
+        return (major, minor) >= (3, 12)
+
+    def test_supports_given_stage_matches_server_line(self, clean_db: Database):
+        """supports_given_stage() agrees with the probed server version."""
+        assert clean_db.supports_given_stage() == self._live_server_supports_given()
+
+    def test_execute_with_rows_is_version_adaptive(self, clean_db: Database):
+        """3.12+ legs run the pipeline; pre-3.12 legs get the versioned error."""
+        import type_bridge_core
+
+        rows = [["alice", 28], ["bob", 26], ["carol", 31]]
+        if self._live_server_supports_given():
+            clean_db.execute_query(self.GIVEN_DDL, transaction_type="schema")
+            docs = clean_db.execute_with_rows(
+                self.GIVEN_PIPELINE, "write", ["n", "a"], ["string", "integer"], rows
+            )
+            assert len(docs) == len(rows)
+            assert {doc["name"] for doc in docs} == {"alice", "bob", "carol"}
+            assert all(doc["iid"] for doc in docs)
+            fetched = clean_db.execute_query(
+                "match $p isa vg-given-person, has vg-given-name $n; select $n;",
+                transaction_type="read",
+            )
+            assert {row["n"]["value"] for row in fetched} == {"alice", "bob", "carol"}
+        else:
+            with pytest.raises(type_bridge_core.VersionError) as exc_info:
+                clean_db.execute_with_rows(
+                    self.GIVEN_PIPELINE, "write", ["n", "a"], ["string", "integer"], rows
+                )
+            message = str(exc_info.value)
+            assert "3.12" in message
+            assert "given-stage" in message
+
+    def test_insert_many_works_on_every_server_leg(self, clean_db: Database):
+        """Bulk insert succeeds everywhere: given fast path on 3.12+, per-row below."""
+        from type_bridge.migration import SchemaManager
+
+        manager = SchemaManager(clean_db)
+        manager.register(VgGivenBulkPerson)
+        manager.sync_schema()
+
+        people = [
+            VgGivenBulkPerson(name=VgGivenBulkName(f"bulk-{i}"), age=VgGivenBulkAge(20 + i))
+            for i in range(5)
+        ]
+        inserted = VgGivenBulkPerson.manager(clean_db).insert_many(people)
+
+        iids = [getattr(person, "_iid", None) for person in inserted]
+        assert all(iids)
+        assert len(set(iids)) == len(people)
+
+        fetched = sorted(
+            VgGivenBulkPerson.manager(clean_db).all(), key=lambda person: person.age.value
+        )
+        assert [(person.name.value, person.age.value) for person in fetched] == [
+            (f"bulk-{i}", 20 + i) for i in range(5)
+        ]

--- a/tests/unit/infra/test_default_band_coherence.py
+++ b/tests/unit/infra/test_default_band_coherence.py
@@ -21,9 +21,10 @@ import type_bridge_core
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
-# Expected embedded pins for the default (both-bands) build.
+# Expected embedded pins for the default (all-bands) build.
 EXPECTED_BAND7_VERSION = "3.8.1"
 EXPECTED_BAND8_VERSION = "3.11.5"
+EXPECTED_BAND9_VERSION = "3.12.0"
 
 
 def _embedded_version() -> str:
@@ -39,11 +40,12 @@ def _embedded_versions() -> dict[int, str]:
 class TestEmbeddedPins:
     """Both embedded pins are present and match expected values."""
 
-    def test_embedded_driver_versions_contains_both_bands(self):
-        """Default build must report both band-7 and band-8 pins."""
+    def test_embedded_driver_versions_contains_all_bands(self):
+        """Default build must report band-7, band-8, and band-9 pins."""
         versions = _embedded_versions()
         assert 7 in versions, f"band-7 pin missing from embedded_driver_versions(): {versions}"
         assert 8 in versions, f"band-8 pin missing from embedded_driver_versions(): {versions}"
+        assert 9 in versions, f"band-9 pin missing from embedded_driver_versions(): {versions}"
 
     def test_band7_pin_value(self):
         """Band-7 embedded pin must equal the expected fork version."""
@@ -57,6 +59,13 @@ class TestEmbeddedPins:
         versions = _embedded_versions()
         assert versions[8] == EXPECTED_BAND8_VERSION, (
             f"band-8 embedded pin is {versions[8]!r}; expected {EXPECTED_BAND8_VERSION!r}"
+        )
+
+    def test_band9_pin_value(self):
+        """Band-9 embedded pin must equal the expected fork version."""
+        versions = _embedded_versions()
+        assert versions[9] == EXPECTED_BAND9_VERSION, (
+            f"band-9 embedded pin is {versions[9]!r}; expected {EXPECTED_BAND9_VERSION!r}"
         )
 
     def test_band7_pin_on_3_8_line(self):

--- a/tests/unit/session/test_version_gate.py
+++ b/tests/unit/session/test_version_gate.py
@@ -986,3 +986,86 @@ class TestSchemaAnnotationGate:
         with pytest.raises(type_bridge_core.VersionError):
             manager.sync_schema()
         db.transaction.assert_not_called()
+
+
+class TestGivenStageSurface:
+    """The given-stage parameterized-query surface (TypeDB 3.12+).
+
+    `Database.supports_given_stage()` reports the feature check on the
+    detected server version; `execute_with_rows()` runs one compiled pipeline
+    over out-of-band input rows; `TransactionContext.execute_with_rows()`
+    requires an open Rust transaction.
+    """
+
+    def _database_with_rust_stub(self, monkeypatch, stub):
+        import type_bridge._rust_runtime as rust_mod
+        from type_bridge import session as session_mod
+
+        monkeypatch.setattr(rust_mod, "rust_database_for", lambda _conn: stub)
+        return session_mod.Database(address="localhost:1729", database="given_unit")
+
+    def test_supports_given_stage_delegates_to_rust_handle(self, monkeypatch):
+        stub = MagicMock()
+        stub.supports_given_stage.return_value = True
+        db = self._database_with_rust_stub(monkeypatch, stub)
+
+        assert db.supports_given_stage() is True
+        stub.supports_given_stage.assert_called_once()
+
+    def test_execute_with_rows_forwards_full_argument_contract(self, monkeypatch):
+        stub = MagicMock()
+        stub.execute_with_rows.return_value = [{"iid": "0x1e"}]
+        db = self._database_with_rust_stub(monkeypatch, stub)
+
+        query = "given $n: string; insert $p isa person, has name == $n;"
+        result = db.execute_with_rows(query, "write", ["n"], ["string"], [["alice"]])
+
+        assert result == [{"iid": "0x1e"}]
+        stub.execute_with_rows.assert_called_once_with(
+            query, "write", ["n"], ["string"], [["alice"]]
+        )
+
+    def test_execute_with_rows_propagates_versioned_error(self, monkeypatch):
+        stub = MagicMock()
+        stub.execute_with_rows.side_effect = type_bridge_core.VersionError(
+            "given-stage parameterized queries require TypeDB 3.12 or newer; detected server 3.11.5"
+        )
+        db = self._database_with_rust_stub(monkeypatch, stub)
+
+        with pytest.raises(type_bridge_core.VersionError, match="3.12 or newer"):
+            db.execute_with_rows(
+                "given $n: string; insert $p isa person, has name == $n;",
+                "write",
+                ["n"],
+                ["string"],
+                [["alice"]],
+            )
+
+    def test_transaction_context_execute_with_rows_requires_rust_transaction(self):
+        from type_bridge import session as session_mod
+
+        db = session_mod.Database(address="localhost:1729", database="given_unit")
+        context = session_mod.TransactionContext(db, session_mod.TransactionType.WRITE)
+
+        with pytest.raises(RuntimeError, match="Rust-backend transaction"):
+            context.execute_with_rows(
+                "given $n: string; insert $p isa person, has name == $n;",
+                ["n"],
+                ["string"],
+                [["alice"]],
+            )
+
+    def test_transaction_context_execute_with_rows_forwards_to_rust_tx(self):
+        from type_bridge import session as session_mod
+
+        db = session_mod.Database(address="localhost:1729", database="given_unit")
+        context = session_mod.TransactionContext(db, session_mod.TransactionType.WRITE)
+        rust_tx = MagicMock()
+        rust_tx.execute_with_rows.return_value = [{"iid": "0x1e"}]
+        context._rust_tx = rust_tx
+
+        query = "given $n: string; insert $p isa person, has name == $n;"
+        result = context.execute_with_rows(query, ["n"], ["string"], [["alice"]])
+
+        assert result == [{"iid": "0x1e"}]
+        rust_tx.execute_with_rows.assert_called_once_with(query, ["n"], ["string"], [["alice"]])

--- a/type-bridge-core/Cargo.lock
+++ b/type-bridge-core/Cargo.lock
@@ -2734,6 +2734,7 @@ dependencies = [
  "tracing",
  "type-bridge-core-lib",
  "type-bridge-typedb-driver-b7",
+ "type-bridge-typedb-driver-b9",
  "typedb-driver",
 ]
 

--- a/type-bridge-core/Cargo.lock
+++ b/type-bridge-core/Cargo.lock
@@ -2726,6 +2726,7 @@ dependencies = [
 name = "type-bridge-typedb-runtime"
 version = "1.5.7"
 dependencies = [
+ "chrono",
  "futures",
  "serde",
  "serde_json",

--- a/type-bridge-core/crates/core/src/bindgen.rs
+++ b/type-bridge-core/crates/core/src/bindgen.rs
@@ -407,7 +407,13 @@ fn doc_meta_flag_args(doc: Option<&str>, meta: &BTreeMap<String, String>) -> Str
         write!(out, ", Doc({})", string_literal(doc)).unwrap();
     }
     for (key, value) in meta {
-        write!(out, ", Meta({}, {})", string_literal(key), string_literal(value)).unwrap();
+        write!(
+            out,
+            ", Meta({}, {})",
+            string_literal(key),
+            string_literal(value)
+        )
+        .unwrap();
     }
     out
 }
@@ -2401,7 +2407,12 @@ fn render_ts_entities(schema: &TypeSchema, options: &BindgenOptions) -> String {
     for name in &order {
         let entity = &schema.entities[name];
         let class = class_name(name);
-        let first_arg = ts_type_first_arg(name, entity.is_abstract, entity.doc.as_deref(), &entity.meta);
+        let first_arg = ts_type_first_arg(
+            name,
+            entity.is_abstract,
+            entity.doc.as_deref(),
+            &entity.meta,
+        );
         let third_arg = entity
             .parent
             .as_deref()
@@ -3061,7 +3072,9 @@ relation friendship @doc("Friendship docs."),
         assert!(attributes.contains("doc=\"Name docs.\", meta={\"owner\": \"core\"})"));
         let entities = &python.file("entities.py").unwrap().contents;
         assert!(entities.contains("\"\"\"Party docs.\"\"\""));
-        assert!(entities.contains("abstract=True, doc=\"Party docs.\", meta={\"steward\": \"team\"}"));
+        assert!(
+            entities.contains("abstract=True, doc=\"Party docs.\", meta={\"steward\": \"team\"}")
+        );
         assert!(entities.contains(
             "name: attributes.Name = Flag(Key, Doc(\"Ownership docs.\"), Meta(\"column\", \"name\"))"
         ));
@@ -3083,7 +3096,9 @@ relation friendship @doc("Friendship docs."),
         ));
         assert!(ts_entities.contains("nick: field(Nick, Doc(\"Nick docs.\")).optional()"));
         let ts_relations = &typescript.file("relations.ts").unwrap().contents;
-        assert!(ts_relations.contains("TypeFlags({ name: \"friendship\", doc: \"Friendship docs.\" })"));
+        assert!(
+            ts_relations.contains("TypeFlags({ name: \"friendship\", doc: \"Friendship docs.\" })")
+        );
         assert!(ts_relations.contains("doc: \"Role docs.\", meta: { \"side\": \"a\" }"));
 
         let models = plan.render_rust_models();
@@ -3091,15 +3106,21 @@ relation friendship @doc("Friendship docs."),
         assert!(models.entities_rs.contains(
             "#[entity(name = \"party\", r#abstract, doc = \"Party docs.\", meta(\"steward\", \"team\"))]"
         ));
-        assert!(models.entities_rs.contains(
-            "#[field(key, doc = \"Ownership docs.\", meta(\"column\", \"name\"))]"
-        ));
-        assert!(models.relations_rs.contains(
-            "#[relation(name = \"friendship\", doc = \"Friendship docs.\")]"
-        ));
-        assert!(models.relations_rs.contains(
-            "doc = \"Role docs.\", meta(\"side\", \"a\"))]"
-        ));
+        assert!(
+            models
+                .entities_rs
+                .contains("#[field(key, doc = \"Ownership docs.\", meta(\"column\", \"name\"))]")
+        );
+        assert!(
+            models
+                .relations_rs
+                .contains("#[relation(name = \"friendship\", doc = \"Friendship docs.\")]")
+        );
+        assert!(
+            models
+                .relations_rs
+                .contains("doc = \"Role docs.\", meta(\"side\", \"a\"))]")
+        );
     }
 
     #[test]

--- a/type-bridge-core/crates/core/src/bindgen.rs
+++ b/type-bridge-core/crates/core/src/bindgen.rs
@@ -927,12 +927,15 @@ fn render_python_attributes(schema: &TypeSchema, options: &BindgenOptions) -> St
 
 fn render_python_attr_field(owned: &OwnedAttribute, attr_class: &str, is_key: bool) -> String {
     let py_name = field_name(&owned.name);
-    let extras = doc_meta_flag_args(owned.doc.as_deref(), &owned.meta);
+    let mut extras = doc_meta_flag_args(owned.doc.as_deref(), &owned.meta);
     if is_key {
         return format!("{py_name}: attributes.{attr_class} = Flag(Key{extras})");
     }
+    // @unique does not imply required: unlike @key it keeps the default
+    // card(0..1), so it composes with the cardinality handling below as a
+    // plain marker instead of short-circuiting the optionality logic.
     if owned.is_unique {
-        return format!("{py_name}: attributes.{attr_class} = Flag(Unique{extras})");
+        extras = format!(", Unique{extras}");
     }
     if owned.ordered {
         if owned.distinct {
@@ -2309,12 +2312,15 @@ fn render_ts_attributes(schema: &TypeSchema) -> String {
 }
 
 fn ts_field_expr(owned: &OwnedAttribute, attr_class: &str, is_key: bool) -> String {
-    let extras = doc_meta_flag_args(owned.doc.as_deref(), &owned.meta);
+    let mut extras = doc_meta_flag_args(owned.doc.as_deref(), &owned.meta);
     if is_key {
         return format!("field({attr_class}, Key{extras})");
     }
+    // @unique does not imply required: unlike @key it keeps the default
+    // card(0..1), so it composes with the cardinality handling below as a
+    // plain marker instead of short-circuiting the optionality logic.
     if owned.is_unique {
-        return format!("field({attr_class}, Unique{extras})");
+        extras = format!(", Unique{extras}");
     }
     if owned.ordered {
         let base = format!("field({attr_class}{extras}).ordered()");
@@ -3121,6 +3127,31 @@ relation friendship @doc("Friendship docs."),
                 .relations_rs
                 .contains("doc = \"Role docs.\", meta(\"side\", \"a\"))]")
         );
+    }
+
+    #[test]
+    fn unique_ownership_respects_cardinality() {
+        let schema_text = r#"define
+attribute email, value string;
+attribute handle, value string;
+attribute alias, value string;
+entity person,
+    owns email @unique,
+    owns handle @unique @card(1..1),
+    owns alias @unique @card(0..3);"#;
+        let plan = BindgenPlan::from_typeql(schema_text).unwrap();
+
+        let python = plan.render(TargetLanguage::Python, &BindgenOptions::default());
+        let entities = &python.file("entities.py").unwrap().contents;
+        assert!(entities.contains("email: attributes.Email | None = Flag(Unique)"));
+        assert!(entities.contains("handle: attributes.Handle = Flag(Unique)"));
+        assert!(entities.contains("alias: list[attributes.Alias] = Flag(Card(0, 3), Unique)"));
+
+        let typescript = plan.render(TargetLanguage::TypeScript, &BindgenOptions::default());
+        let ts_entities = &typescript.file("entities.ts").unwrap().contents;
+        assert!(ts_entities.contains("email: field(Email, Unique).optional()"));
+        assert!(ts_entities.contains("handle: field(Handle, Unique),"));
+        assert!(ts_entities.contains("alias: field(Alias, Unique).list(Card(0, 3))"));
     }
 
     #[test]

--- a/type-bridge-core/crates/core/src/version.rs
+++ b/type-bridge-core/crates/core/src/version.rs
@@ -198,6 +198,11 @@ pub fn band(v: &Version) -> Option<u8> {
 /// per-version band cannot express that, so servers carry an accepted *set*
 /// and drivers keep their single native [`band`].
 ///
+/// HAZARD (measured live on 3.11.5): a band-9 connection attempt does not
+/// just fail against a 3.11 server — it crashes the server process.  Never
+/// probe band 9 against a server of unknown version; discover through
+/// band 8 first (the embedded runtime's gRPC fallback does exactly that).
+///
 /// Measured live (see [`band`] for the measurement grid):
 ///
 /// | Server line | Accepts |
@@ -370,6 +375,14 @@ impl Feature {
             Feature::GivenStage => Version::new(3, 12, 0),
         }
     }
+
+    /// Feature-specific remediation for the versioned error message.
+    pub fn remediation(self) -> &'static str {
+        match self {
+            Feature::SchemaAnnotations => "remove the annotations from the schema",
+            Feature::GivenStage => "use per-row queries instead",
+        }
+    }
 }
 
 /// Check that `server` supports `feature`.
@@ -385,6 +398,7 @@ pub fn check_feature_supported(feature: Feature, server: &Version) -> Result<(),
             feature: feature.name(),
             server: *server,
             required,
+            remediation: feature.remediation(),
         });
     }
     Ok(())
@@ -537,6 +551,8 @@ pub enum VersionError {
         server: Version,
         /// The minimum server version that supports the feature.
         required: Version,
+        /// Feature-specific remediation appended to the error message.
+        remediation: &'static str,
     },
 }
 
@@ -578,13 +594,14 @@ impl fmt::Display for VersionError {
                 feature,
                 server,
                 required,
+                remediation,
             } => {
                 let required_line = format!("{}.{}", required.major, required.minor);
                 write!(
                     f,
                     "{feature} require TypeDB {required_line} or newer; detected server \
-                     {server} — upgrade the server to the {required_line} line or remove \
-                     the annotations from the schema"
+                     {server} — upgrade the server to the {required_line} line or \
+                     {remediation}"
                 )
             }
         }
@@ -1102,10 +1119,12 @@ mod tests {
                 feature,
                 server,
                 required,
+                remediation,
             } => {
                 assert_eq!(*feature, "schema annotations (@doc/@meta)");
                 assert_eq!(*server, Version::new(3, 11, 5));
                 assert_eq!(*required, Version::new(3, 12, 0));
+                assert_eq!(*remediation, "remove the annotations from the schema");
             }
             other => panic!("expected FeatureUnsupported, got {other:?}"),
         }

--- a/type-bridge-core/crates/core/src/version.rs
+++ b/type-bridge-core/crates/core/src/version.rs
@@ -350,6 +350,8 @@ pub fn check_server_supported(server: &Version, embedded_bands: &[u8]) -> Result
 pub enum Feature {
     /// `@doc("...")` / `@meta("key", "value")` schema annotations (TypeDB 3.12+).
     SchemaAnnotations,
+    /// `given` stage: parameterized multi-row query input (TypeDB 3.12+).
+    GivenStage,
 }
 
 impl Feature {
@@ -357,6 +359,7 @@ impl Feature {
     pub fn name(self) -> &'static str {
         match self {
             Feature::SchemaAnnotations => "schema annotations (@doc/@meta)",
+            Feature::GivenStage => "given-stage parameterized queries",
         }
     }
 
@@ -364,6 +367,7 @@ impl Feature {
     pub fn minimum_version(self) -> Version {
         match self {
             Feature::SchemaAnnotations => Version::new(3, 12, 0),
+            Feature::GivenStage => Version::new(3, 12, 0),
         }
     }
 }

--- a/type-bridge-core/crates/core/src/version.rs
+++ b/type-bridge-core/crates/core/src/version.rs
@@ -1113,8 +1113,14 @@ mod tests {
 
     #[test]
     fn feature_gate_accepts_312_and_newer() {
-        assert!(check_feature_supported(Feature::SchemaAnnotations, &Version::new(3, 12, 0)).is_ok());
-        assert!(check_feature_supported(Feature::SchemaAnnotations, &Version::new(3, 12, 7)).is_ok());
-        assert!(check_feature_supported(Feature::SchemaAnnotations, &Version::new(4, 0, 0)).is_ok());
+        assert!(
+            check_feature_supported(Feature::SchemaAnnotations, &Version::new(3, 12, 0)).is_ok()
+        );
+        assert!(
+            check_feature_supported(Feature::SchemaAnnotations, &Version::new(3, 12, 7)).is_ok()
+        );
+        assert!(
+            check_feature_supported(Feature::SchemaAnnotations, &Version::new(4, 0, 0)).is_ok()
+        );
     }
 }

--- a/type-bridge-core/crates/migration/Cargo.toml
+++ b/type-bridge-core/crates/migration/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/bin/type_bridge_migration.rs"
 
 [dependencies]
 type-bridge-core-lib = { path = "../core", version = "1.5.7" }
-type-bridge-orm = { path = "../orm", version = "1.5.7", default-features = false, features = ["band7", "band8"] }
+type-bridge-orm = { path = "../orm", version = "1.5.7", default-features = false, features = ["band7", "band8", "band9"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4.5", features = ["derive"] }
 network-interface = "2.0.5"

--- a/type-bridge-core/crates/node/Cargo.toml
+++ b/type-bridge-core/crates/node/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 type-bridge-core-lib = { path = "../core", version = "1.5.7" }
-type-bridge-orm = { path = "../orm", version = "1.5.7", default-features = false, features = ["band7", "band8"] }
+type-bridge-orm = { path = "../orm", version = "1.5.7", default-features = false, features = ["band7", "band8", "band9"] }
 napi = { version = "2", features = ["napi4"] }
 napi-derive = "2"
 serde = { version = "1.0", features = ["derive"] }

--- a/type-bridge-core/crates/node/tests/typed-integration/generator-render.test.ts
+++ b/type-bridge-core/crates/node/tests/typed-integration/generator-render.test.ts
@@ -75,7 +75,8 @@ describe("generator render decisions", () => {
   });
 
   test("flags: Key, Unique, optional, and multi-value list are emitted correctly", () => {
-    assert.match(entities, /parity_email: field\(ParityEmail, Unique\)/);
+    // @unique keeps the default card(0..1): the field stays optional.
+    assert.match(entities, /parity_email: field\(ParityEmail, Unique\)\.optional\(\)/);
     assert.match(entities, /parity_name: field\(ParityName\)\.optional\(\)/);
     assert.match(entities, /parity_tag: field\(ParityTag\)\.list\(Card\(0, 5\)\)/);
   });

--- a/type-bridge-core/crates/orm/Cargo.toml
+++ b/type-bridge-core/crates/orm/Cargo.toml
@@ -16,12 +16,13 @@ name = "type-bridge-codegen"
 path = "src/bin/codegen.rs"
 
 [features]
-default = ["band7", "band8"]
+default = ["band7", "band8", "band9"]
 typedb = ["dep:type-bridge-typedb-runtime"]
 band7 = ["typedb", "type-bridge-typedb-runtime/band7"]
 band8 = ["typedb", "type-bridge-typedb-runtime/band8"]
+band9 = ["typedb", "type-bridge-typedb-runtime/band9"]
 derive = ["dep:type-bridge-orm-derive"]
-integration-tests = ["derive", "band7", "band8"]
+integration-tests = ["derive", "band7", "band8", "band9"]
 
 [dependencies]
 type-bridge-core-lib = { path = "../core", version = "1.5.7" }

--- a/type-bridge-core/crates/orm/src/lib.rs
+++ b/type-bridge-core/crates/orm/src/lib.rs
@@ -110,7 +110,7 @@ pub use session::ConnectOptions;
 pub use session::embedded_driver_versions;
 #[cfg(feature = "typedb")]
 pub use session::ensure_database_exists;
-pub use session::{Database, Transaction, TransactionContext, TxType};
+pub use session::{Database, GivenRowsSpec, GivenValue, Transaction, TransactionContext, TxType};
 pub use value::AttributeValue;
 
 // Re-export derive macros when the `derive` feature is enabled.

--- a/type-bridge-core/crates/orm/src/manager/dynamic.rs
+++ b/type-bridge-core/crates/orm/src/manager/dynamic.rs
@@ -9,8 +9,9 @@ use crate::dynamic::{
 };
 use crate::error::{OrmError, Result};
 use crate::filter::Filter;
-use crate::session::backend::{QueryResult, TxType};
+use crate::session::backend::{GivenRowsSpec, GivenValue, QueryResult, TxType};
 use crate::session::{Database, TransactionContext};
+use crate::value::AttributeValue;
 
 use super::hydration::{extract_count, hydrate_dynamic_entity, hydrate_dynamic_relation};
 use super::query_builder;
@@ -264,6 +265,25 @@ impl<'db> DynamicEntityManager<'db> {
     ) -> Result<Vec<String>> {
         if items.is_empty() {
             return Ok(vec![]);
+        }
+
+        // Given-stage fast path (TypeDB 3.12+): one compiled insert pipeline
+        // over all rows, values passed through the driver API instead of
+        // being interpolated per row. Requires a homogeneous batch; anything
+        // else falls through to the per-row path below.
+        if matches!(operation, DynamicWriteOperation::Insert)
+            && let DynamicExecutionTarget::Database(db) = &self.target
+            && db.supports_given_stage()
+            && let Some((typeql, rows)) = given_entity_insert(&self.descriptor, items, "$e")
+        {
+            tracing::debug!(
+                typeql = %typeql,
+                entity_type = %self.descriptor.type_name,
+                rows = items.len(),
+                "DYNAMIC GIVEN INSERT MANY"
+            );
+            let result = db.execute_with_rows(&typeql, TxType::Write, rows).await?;
+            return extract_insert_iids(&self.descriptor.type_name, result, items.len());
         }
 
         match &self.target {
@@ -714,6 +734,176 @@ fn ensure_transaction_can_execute(active: TxType, required: TxType) -> Result<()
     }
 }
 
+/// Build the `given`-stage bulk insert for a homogeneous entity batch.
+///
+/// Returns `None` when the batch cannot ride one compiled pipeline, so the
+/// caller falls back to per-row inserts:
+/// - an item binds an attribute the descriptor does not know,
+/// - items bind different attribute sets (optional attributes present on
+///   some rows only), or repeat an attribute within one row,
+/// - a column's value type varies across rows, or
+/// - a value type has no given-row representation (decimal, duration).
+fn given_entity_insert(
+    descriptor: &EntityDescriptor,
+    items: &[DynamicAttributeMap],
+    var: &str,
+) -> Option<(String, GivenRowsSpec)> {
+    let first = items.first()?;
+    if first.is_empty() {
+        return None;
+    }
+
+    // Column layout comes from the first item: resolved TypeDB attribute
+    // names, the given type of each column, and one given variable each.
+    let mut columns: Vec<(String, &'static str)> = Vec::with_capacity(first.len());
+    for (name, value) in first {
+        let attr = descriptor.attribute(name)?;
+        let type_name = given_type_name(value)?;
+        if columns
+            .iter()
+            .any(|(existing, _)| *existing == attr.attr_name)
+        {
+            return None;
+        }
+        columns.push((attr.attr_name.clone(), type_name));
+    }
+
+    let mut rows = Vec::with_capacity(items.len());
+    for (row_index, item) in items.iter().enumerate() {
+        if item.len() != columns.len() {
+            return None;
+        }
+        let mut row: Vec<Option<GivenValue>> = vec![None; columns.len()];
+        for (name, value) in item {
+            let attr = descriptor.attribute(name)?;
+            let index = columns
+                .iter()
+                .position(|(attr_name, _)| *attr_name == attr.attr_name)?;
+            if row[index].is_some() || given_type_name(value)? != columns[index].1 {
+                return None;
+            }
+            row[index] = Some(given_value(value)?);
+        }
+        let mut row = row.into_iter().collect::<Option<Vec<_>>>()?;
+        // Synthetic trailing column: the input row index, fetched back so
+        // IIDs correlate to input rows explicitly instead of relying on
+        // pipeline stream order.
+        row.push(GivenValue::Integer(row_index as i64));
+        rows.push(row);
+    }
+
+    let mut variables: Vec<String> = (0..columns.len()).map(|i| format!("g{i}")).collect();
+    let given_header = columns
+        .iter()
+        .zip(&variables)
+        .map(|((_, type_name), variable)| format!("${variable}: {type_name}"))
+        .chain(std::iter::once("$g_row: integer".to_string()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let has_clauses = columns
+        .iter()
+        .zip(&variables)
+        .map(|((attr_name, _), variable)| format!("has {attr_name} == ${variable}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    variables.push("g_row".to_string());
+    let typeql = format!(
+        "given {given_header};\ninsert {var} isa {}, {has_clauses};\nfetch {{ \"iid\": iid({var}), \"row\": $g_row }};",
+        descriptor.type_name,
+    );
+
+    Some((typeql, GivenRowsSpec { variables, rows }))
+}
+
+/// The TypeQL value type name for a `given` header column, or `None` when
+/// the value has no given-row representation.
+fn given_type_name(value: &AttributeValue) -> Option<&'static str> {
+    Some(match value {
+        AttributeValue::String(_) => "string",
+        AttributeValue::Long(_) => "integer",
+        AttributeValue::Double(_) => "double",
+        AttributeValue::Boolean(_) => "boolean",
+        AttributeValue::Date(_) => "date",
+        AttributeValue::DateTime(_) => "datetime",
+        AttributeValue::DateTimeTZ(_) => "datetime-tz",
+        AttributeValue::Decimal(_) | AttributeValue::Duration(_) => return None,
+    })
+}
+
+/// Convert an attribute value into its given-row form, or `None` when the
+/// value type has no given-row representation.
+fn given_value(value: &AttributeValue) -> Option<GivenValue> {
+    Some(match value {
+        AttributeValue::String(s) => GivenValue::String(s.clone()),
+        AttributeValue::Long(n) => GivenValue::Integer(*n),
+        AttributeValue::Double(d) => GivenValue::Double(*d),
+        AttributeValue::Boolean(b) => GivenValue::Boolean(*b),
+        AttributeValue::Date(s) => GivenValue::Date(s.clone()),
+        AttributeValue::DateTime(s) => GivenValue::Datetime(s.clone()),
+        AttributeValue::DateTimeTZ(s) => GivenValue::DatetimeTz(s.clone()),
+        AttributeValue::Decimal(_) | AttributeValue::Duration(_) => return None,
+    })
+}
+
+/// Extract one IID per input row from a bulk insert + fetch result.
+///
+/// Each document carries the fetched-back input row index (`"row"`), so
+/// IIDs are placed by explicit correlation rather than stream order.
+fn extract_insert_iids(
+    type_name: &str,
+    result: QueryResult,
+    expected: usize,
+) -> Result<Vec<String>> {
+    let hydration_error = |message: String| OrmError::Hydration {
+        type_name: type_name.to_string(),
+        message,
+    };
+    match result {
+        QueryResult::Documents(docs) => {
+            if docs.len() != expected {
+                return Err(hydration_error(format!(
+                    "Bulk insert returned {} documents for {expected} input rows",
+                    docs.len()
+                )));
+            }
+            let mut iids: Vec<Option<String>> = vec![None; expected];
+            for doc in &docs {
+                let obj = doc.as_object().ok_or_else(|| {
+                    hydration_error("Expected JSON object from insert+fetch".into())
+                })?;
+                let iid = super::hydration::extract_scalar_string(obj, "iid")
+                    .ok_or_else(|| hydration_error("No IID in bulk insert response".into()))?;
+                let row_index = obj
+                    .get("row")
+                    .and_then(serde_json::Value::as_f64)
+                    .map(|row| row as usize)
+                    .ok_or_else(|| {
+                        hydration_error("No row index in bulk insert response".into())
+                    })?;
+                let slot = iids.get_mut(row_index).ok_or_else(|| {
+                    hydration_error(format!(
+                        "Bulk insert row index {row_index} out of range for {expected} input rows"
+                    ))
+                })?;
+                if slot.replace(iid).is_some() {
+                    return Err(hydration_error(format!(
+                        "Bulk insert returned row index {row_index} twice"
+                    )));
+                }
+            }
+            iids.into_iter()
+                .collect::<Option<Vec<_>>>()
+                .ok_or_else(|| hydration_error("Bulk insert response missing rows".into()))
+        }
+        QueryResult::Ok => Err(hydration_error(
+            "Expected Documents from bulk insert+fetch, got Ok".into(),
+        )),
+        QueryResult::Rows(_) => Err(hydration_error(
+            "Expected Documents from bulk insert+fetch, got Rows".into(),
+        )),
+    }
+}
+
 fn extract_insert_iid(type_name: &str, result: QueryResult) -> Result<String> {
     match result {
         QueryResult::Documents(docs) => {
@@ -760,5 +950,168 @@ fn extract_rows(
             type_name: type_name.to_string(),
             message: "Expected Rows from reduce query, got Documents".into(),
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::attribute::ValueType;
+    use crate::descriptor::OwnedAttributeDescriptor;
+
+    fn attribute(
+        field_name: &str,
+        attr_name: &str,
+        value_type: ValueType,
+    ) -> OwnedAttributeDescriptor {
+        OwnedAttributeDescriptor {
+            field_name: field_name.to_string(),
+            attr_name: attr_name.to_string(),
+            value_type,
+            annotations: vec![],
+            is_optional: false,
+            is_ordered: false,
+            doc: None,
+            meta: std::collections::BTreeMap::new(),
+        }
+    }
+
+    fn person_descriptor() -> EntityDescriptor {
+        EntityDescriptor {
+            type_name: "person".to_string(),
+            is_abstract: false,
+            parent_type: None,
+            owned_attributes: vec![
+                attribute("name", "name", ValueType::String),
+                attribute("age", "age", ValueType::Long),
+            ],
+            doc: None,
+            meta: std::collections::BTreeMap::new(),
+        }
+    }
+
+    fn item(pairs: &[(&str, AttributeValue)]) -> DynamicAttributeMap {
+        pairs
+            .iter()
+            .map(|(name, value)| (name.to_string(), value.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn given_insert_builds_typed_header_and_rows() {
+        let descriptor = person_descriptor();
+        let items = vec![
+            item(&[
+                ("name", AttributeValue::String("alice".into())),
+                ("age", AttributeValue::Long(28)),
+            ]),
+            item(&[
+                ("age", AttributeValue::Long(26)),
+                ("name", AttributeValue::String("bob".into())),
+            ]),
+        ];
+
+        let (typeql, spec) =
+            given_entity_insert(&descriptor, &items, "$e").expect("homogeneous batch");
+
+        assert_eq!(
+            typeql,
+            "given $g0: string, $g1: integer, $g_row: integer;\n\
+             insert $e isa person, has name == $g0, has age == $g1;\n\
+             fetch { \"iid\": iid($e), \"row\": $g_row };"
+        );
+        assert_eq!(
+            spec.variables,
+            vec!["g0".to_string(), "g1".to_string(), "g_row".to_string()]
+        );
+        // The second item binds in a different order; the row is normalized
+        // to the first item's column layout, with the trailing row index.
+        assert_eq!(
+            spec.rows,
+            vec![
+                vec![
+                    GivenValue::String("alice".into()),
+                    GivenValue::Integer(28),
+                    GivenValue::Integer(0),
+                ],
+                vec![
+                    GivenValue::String("bob".into()),
+                    GivenValue::Integer(26),
+                    GivenValue::Integer(1),
+                ],
+            ]
+        );
+    }
+
+    #[test]
+    fn given_insert_resolves_field_names_to_attr_names() {
+        let mut descriptor = person_descriptor();
+        descriptor.owned_attributes[0] =
+            attribute("display_name", "display-name", ValueType::String);
+        let items = vec![item(&[(
+            "display_name",
+            AttributeValue::String("alice".into()),
+        )])];
+
+        let (typeql, _) = given_entity_insert(&descriptor, &items, "$e").expect("resolvable");
+        assert!(
+            typeql.contains("has display-name == $g0"),
+            "field name must resolve to the TypeDB attribute name: {typeql}"
+        );
+    }
+
+    #[test]
+    fn given_insert_rejects_heterogeneous_attribute_sets() {
+        let descriptor = person_descriptor();
+        let items = vec![
+            item(&[
+                ("name", AttributeValue::String("alice".into())),
+                ("age", AttributeValue::Long(28)),
+            ]),
+            item(&[("name", AttributeValue::String("bob".into()))]),
+        ];
+        assert!(given_entity_insert(&descriptor, &items, "$e").is_none());
+    }
+
+    #[test]
+    fn given_insert_rejects_mixed_value_types_per_column() {
+        let descriptor = person_descriptor();
+        let items = vec![
+            item(&[("age", AttributeValue::Long(28))]),
+            item(&[("age", AttributeValue::Double(26.5))]),
+        ];
+        assert!(given_entity_insert(&descriptor, &items, "$e").is_none());
+    }
+
+    #[test]
+    fn given_insert_rejects_unrepresentable_value_types() {
+        let mut descriptor = person_descriptor();
+        descriptor.owned_attributes[0] = attribute("price", "price", ValueType::Decimal);
+        let items = vec![item(&[("price", AttributeValue::Decimal("1.50".into()))])];
+        assert!(given_entity_insert(&descriptor, &items, "$e").is_none());
+    }
+
+    #[test]
+    fn given_insert_rejects_repeated_attribute_within_row() {
+        let descriptor = person_descriptor();
+        let items = vec![item(&[
+            ("name", AttributeValue::String("alice".into())),
+            ("name", AttributeValue::String("also-alice".into())),
+        ])];
+        assert!(given_entity_insert(&descriptor, &items, "$e").is_none());
+    }
+
+    #[test]
+    fn given_insert_rejects_unknown_attribute() {
+        let descriptor = person_descriptor();
+        let items = vec![item(&[("nickname", AttributeValue::String("al".into()))])];
+        assert!(given_entity_insert(&descriptor, &items, "$e").is_none());
+    }
+
+    #[test]
+    fn given_insert_rejects_empty_first_item() {
+        let descriptor = person_descriptor();
+        let items = vec![item(&[])];
+        assert!(given_entity_insert(&descriptor, &items, "$e").is_none());
     }
 }

--- a/type-bridge-core/crates/orm/src/schema/annotations.rs
+++ b/type-bridge-core/crates/orm/src/schema/annotations.rs
@@ -237,7 +237,8 @@ pub fn diff_annotation_tokens(
             None => diff.added.push((*new_token).clone()),
             Some(old_token) => {
                 if old_token.render() != new_token.render() {
-                    diff.changed.push(((*old_token).clone(), (*new_token).clone()));
+                    diff.changed
+                        .push(((*old_token).clone(), (*new_token).clone()));
                 }
             }
         }
@@ -314,10 +315,7 @@ mod tests {
 
     #[test]
     fn constraint_part_drops_doc_meta() {
-        assert_eq!(
-            constraint_part(r#"@key @doc("x") @meta("k", "v")"#),
-            "@key"
-        );
+        assert_eq!(constraint_part(r#"@key @doc("x") @meta("k", "v")"#), "@key");
         assert_eq!(constraint_part(r#"@doc("x")"#), "");
     }
 

--- a/type-bridge-core/crates/orm/src/schema/diff.rs
+++ b/type-bridge-core/crates/orm/src/schema/diff.rs
@@ -1674,7 +1674,11 @@ mod tests {
             Some((meta(&[]), meta(&[("owner", "core")])))
         );
         assert!(!diff.has_breaking_changes());
-        assert!(diff.classify().iter().all(|c| c.category == ChangeCategory::Safe));
+        assert!(
+            diff.classify()
+                .iter()
+                .all(|c| c.category == ChangeCategory::Safe)
+        );
         assert!(diff.summary().contains("~ entity person: doc"));
         assert!(diff.summary().contains("~ entity person: meta"));
     }
@@ -1709,7 +1713,10 @@ mod tests {
             }]
         );
         assert!(!diff.has_breaking_changes());
-        assert!(diff.summary().contains("~ relation employment: ~ role employee doc, meta"));
+        assert!(
+            diff.summary()
+                .contains("~ relation employment: ~ role employee doc, meta")
+        );
     }
 
     #[test]
@@ -1758,7 +1765,11 @@ mod tests {
         assert!(new_flags.contains("@meta(\"column\", \"name\")"));
         // A doc/meta-only flag change is metadata-only: Safe, not Warning.
         assert!(!diff.has_breaking_changes());
-        assert!(diff.classify().iter().all(|c| c.category == ChangeCategory::Safe));
+        assert!(
+            diff.classify()
+                .iter()
+                .all(|c| c.category == ChangeCategory::Safe)
+        );
     }
 
     #[test]

--- a/type-bridge-core/crates/orm/src/session/backend.rs
+++ b/type-bridge-core/crates/orm/src/session/backend.rs
@@ -35,6 +35,41 @@ pub enum TxType {
     Schema,
 }
 
+/// A single value bound to a `given` variable.
+///
+/// Temporal variants carry ISO-8601 text; the real backend parses them when
+/// lowering onto the driver, mirroring how [`QueryResult`] renders temporal
+/// values back to strings.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum GivenValue {
+    /// TypeQL `boolean`.
+    Boolean(bool),
+    /// TypeQL `integer`.
+    Integer(i64),
+    /// TypeQL `double`.
+    Double(f64),
+    /// TypeQL `string`.
+    String(String),
+    /// TypeQL `date`, ISO-8601 (`YYYY-MM-DD`).
+    Date(String),
+    /// TypeQL `datetime`, ISO-8601 without offset.
+    Datetime(String),
+    /// TypeQL `datetime-tz`, RFC 3339 with offset.
+    DatetimeTz(String),
+}
+
+/// Input rows for a `given`-stage query: a variable header plus value rows.
+///
+/// Every row must have exactly one entry per header variable, in header
+/// order. Rows travel through the driver API, never the query string.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GivenRowsSpec {
+    /// Variable names, without the `$` sigil, in column order.
+    pub variables: Vec<String>,
+    /// Value rows; each inner vec is one input row in header order.
+    pub rows: Vec<Vec<GivenValue>>,
+}
+
 /// Abstraction over a TypeDB transaction.
 ///
 /// Implementations handle query execution and transaction lifecycle.
@@ -43,6 +78,24 @@ pub enum TxType {
 pub trait TransactionOps: Send {
     /// Execute a TypeQL query string.
     fn query(&mut self, typeql: &str) -> BoxFuture<'_, Result<QueryResult, OrmError>>;
+
+    /// Execute a TypeQL query with `given`-stage input rows.
+    ///
+    /// Rows travel through the driver API, not the query string. Defaults to
+    /// an error for backends without given-stage support (mocks, pre-band-9
+    /// drivers); the real backend overrides this on band-9 connections.
+    fn query_with_rows(
+        &mut self,
+        typeql: &str,
+        rows: GivenRowsSpec,
+    ) -> BoxFuture<'_, Result<QueryResult, OrmError>> {
+        let _ = (typeql, rows);
+        Box::pin(async move {
+            Err(OrmError::QueryExecution(
+                "given-stage parameterized queries are not supported by this backend".into(),
+            ))
+        })
+    }
 
     /// Commit this transaction. Only meaningful for write/schema transactions.
     fn commit(&mut self) -> BoxFuture<'_, Result<(), OrmError>>;

--- a/type-bridge-core/crates/orm/src/session/context.rs
+++ b/type-bridge-core/crates/orm/src/session/context.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use tokio::sync::Mutex;
 
-use super::backend::{QueryResult, TransactionOps, TxType};
+use super::backend::{GivenRowsSpec, QueryResult, TransactionOps, TxType};
 use crate::error::{OrmError, Result};
 
 /// Shared transaction context for grouping multiple operations into
@@ -33,6 +33,18 @@ impl TransactionContext {
             .as_mut()
             .ok_or_else(|| OrmError::Transaction("Transaction already consumed".into()))?;
         tx.query(typeql).await
+    }
+
+    /// Execute a `given`-stage query with input rows on the shared transaction.
+    ///
+    /// Requires a band-9 (TypeDB 3.12+) connection; see
+    /// [`Database::check_given_stage_support`](super::database::Database::check_given_stage_support).
+    pub async fn query_with_rows(&self, typeql: &str, rows: GivenRowsSpec) -> Result<QueryResult> {
+        let mut guard = self.inner.lock().await;
+        let tx = guard
+            .as_mut()
+            .ok_or_else(|| OrmError::Transaction("Transaction already consumed".into()))?;
+        tx.query_with_rows(typeql, rows).await
     }
 
     /// Commit the shared transaction.

--- a/type-bridge-core/crates/orm/src/session/database.rs
+++ b/type-bridge-core/crates/orm/src/session/database.rs
@@ -19,7 +19,7 @@
 
 use std::sync::Arc;
 
-use super::backend::{DriverBackend, QueryResult, TxType};
+use super::backend::{DriverBackend, GivenRowsSpec, QueryResult, TxType};
 use super::context::TransactionContext;
 use super::transaction::Transaction;
 use crate::error::Result;
@@ -149,6 +149,36 @@ impl Database {
         Ok(())
     }
 
+    /// Whether the connected server supports `given`-stage parameterized
+    /// queries (TypeDB 3.12+).
+    ///
+    /// `false` when the server predates 3.12 or its version is unknown
+    /// (band-7 gRPC fallback) — callers with a per-row fallback should use
+    /// it in both cases.
+    pub fn supports_given_stage(&self) -> bool {
+        use type_bridge_core_lib::version::{Feature, check_feature_supported};
+
+        self.server_version()
+            .is_some_and(|server| check_feature_supported(Feature::GivenStage, &server).is_ok())
+    }
+
+    /// Version-gate a `given`-stage query.
+    ///
+    /// When the detected server version predates 3.12, fail with an
+    /// actionable versioned error instead of a server-side parse error.
+    /// When the server version is unknown, the query is allowed through and
+    /// the runtime rejects it only if the negotiated driver band cannot
+    /// carry given rows.
+    pub fn check_given_stage_support(&self) -> Result<()> {
+        use type_bridge_core_lib::version::{Feature, check_feature_supported};
+
+        if let Some(server) = self.server_version() {
+            check_feature_supported(Feature::GivenStage, &server)
+                .map_err(crate::error::OrmError::UnsupportedVersion)?;
+        }
+        Ok(())
+    }
+
     /// Return whether this database exists on the connected TypeDB server.
     pub async fn database_exists(&self) -> Result<bool> {
         self.backend.database_exists(&self.database_name).await
@@ -191,6 +221,31 @@ impl Database {
             .open_transaction(&self.database_name, tx_type)
             .await?;
         let result = tx.query(typeql).await?;
+        if matches!(tx_type, TxType::Write | TxType::Schema) {
+            tx.commit().await?;
+        }
+        Ok(result)
+    }
+
+    /// Execute a `given`-stage TypeQL query over input rows, auto-managing
+    /// the transaction lifecycle.
+    ///
+    /// One compiled pipeline runs over every input row; rows travel through
+    /// the driver API, never the query string. Version-gated via
+    /// [`Self::check_given_stage_support`] before any transaction is opened.
+    #[tracing::instrument(skip(self, typeql, rows), fields(db = %self.database_name))]
+    pub async fn execute_with_rows(
+        &self,
+        typeql: &str,
+        tx_type: TxType,
+        rows: GivenRowsSpec,
+    ) -> Result<QueryResult> {
+        self.check_given_stage_support()?;
+        let mut tx = self
+            .backend
+            .open_transaction(&self.database_name, tx_type)
+            .await?;
+        let result = tx.query_with_rows(typeql, rows).await?;
         if matches!(tx_type, TxType::Write | TxType::Schema) {
             tx.commit().await?;
         }

--- a/type-bridge-core/crates/orm/src/session/mod.rs
+++ b/type-bridge-core/crates/orm/src/session/mod.rs
@@ -12,7 +12,7 @@ pub mod transaction;
 #[cfg(feature = "typedb")]
 pub mod real_driver;
 
-pub use backend::TxType;
+pub use backend::{GivenRowsSpec, GivenValue, TxType};
 pub use context::TransactionContext;
 pub use database::Database;
 pub use transaction::Transaction;

--- a/type-bridge-core/crates/orm/src/session/real_driver.rs
+++ b/type-bridge-core/crates/orm/src/session/real_driver.rs
@@ -14,7 +14,9 @@ pub use runtime::{
     embedded_driver_versions,
 };
 
-use super::backend::{BoxFuture, DriverBackend, QueryResult, TransactionOps, TxType};
+use super::backend::{
+    BoxFuture, DriverBackend, GivenRowsSpec, GivenValue, QueryResult, TransactionOps, TxType,
+};
 use crate::error::OrmError;
 
 /// Real TypeDB backend wrapping the shared runtime.
@@ -136,6 +138,22 @@ impl TransactionOps for RealTransaction {
         })
     }
 
+    fn query_with_rows(
+        &mut self,
+        typeql: &str,
+        rows: GivenRowsSpec,
+    ) -> BoxFuture<'_, Result<QueryResult, OrmError>> {
+        let typeql = typeql.to_string();
+        let rows = runtime_given_rows(rows);
+        Box::pin(async move {
+            self.inner
+                .query_with_rows(&typeql, rows)
+                .await
+                .map(query_result)
+                .map_err(OrmError::from)
+        })
+    }
+
     fn commit(&mut self) -> BoxFuture<'_, Result<(), OrmError>> {
         Box::pin(async move { self.inner.commit().await.map_err(OrmError::from) })
     }
@@ -154,6 +172,29 @@ fn runtime_tx_type(tx_type: TxType) -> runtime::TxType {
         TxType::Read => runtime::TxType::Read,
         TxType::Write => runtime::TxType::Write,
         TxType::Schema => runtime::TxType::Schema,
+    }
+}
+
+fn runtime_given_rows(spec: GivenRowsSpec) -> runtime::GivenRowsSpec {
+    runtime::GivenRowsSpec {
+        variables: spec.variables,
+        rows: spec
+            .rows
+            .into_iter()
+            .map(|row| row.into_iter().map(runtime_given_value).collect())
+            .collect(),
+    }
+}
+
+fn runtime_given_value(value: GivenValue) -> runtime::GivenValue {
+    match value {
+        GivenValue::Boolean(b) => runtime::GivenValue::Boolean(b),
+        GivenValue::Integer(i) => runtime::GivenValue::Integer(i),
+        GivenValue::Double(d) => runtime::GivenValue::Double(d),
+        GivenValue::String(s) => runtime::GivenValue::String(s),
+        GivenValue::Date(s) => runtime::GivenValue::Date(s),
+        GivenValue::Datetime(s) => runtime::GivenValue::Datetime(s),
+        GivenValue::DatetimeTz(s) => runtime::GivenValue::DatetimeTz(s),
     }
 }
 

--- a/type-bridge-core/crates/orm/src/session/real_driver.rs
+++ b/type-bridge-core/crates/orm/src/session/real_driver.rs
@@ -2,15 +2,16 @@
 //!
 //! This module is only compiled when the `typedb` feature is enabled.
 
-#[cfg(not(any(feature = "band7", feature = "band8")))]
+#[cfg(not(any(feature = "band7", feature = "band8", feature = "band9")))]
 compile_error!(
-    "type-bridge-orm: the `typedb` machinery requires at least one band feature; enable `band7` and/or `band8` (both are default)"
+    "type-bridge-orm: the `typedb` machinery requires at least one band feature; enable `band7`, `band8`, and/or `band9` (all are default)"
 );
 
 use type_bridge_typedb_runtime as runtime;
 
 pub use runtime::{
-    ConnectOptions, PINNED_DRIVER_VERSION, PINNED_DRIVER_VERSION_B7, embedded_driver_versions,
+    ConnectOptions, PINNED_DRIVER_VERSION, PINNED_DRIVER_VERSION_B7, PINNED_DRIVER_VERSION_B9,
+    embedded_driver_versions,
 };
 
 use super::backend::{BoxFuture, DriverBackend, QueryResult, TransactionOps, TxType};

--- a/type-bridge-core/crates/orm/src/session/transaction.rs
+++ b/type-bridge-core/crates/orm/src/session/transaction.rs
@@ -1,6 +1,6 @@
 //! Transaction wrapper for TypeDB operations.
 
-use super::backend::{QueryResult, TransactionOps, TxType};
+use super::backend::{GivenRowsSpec, QueryResult, TransactionOps, TxType};
 use crate::error::{OrmError, Result};
 
 /// A single TypeDB transaction.
@@ -27,6 +27,22 @@ impl Transaction {
             .as_mut()
             .ok_or_else(|| OrmError::Transaction("Transaction already consumed".into()))?;
         tx.query(typeql).await
+    }
+
+    /// Execute a TypeQL query with `given`-stage input rows.
+    ///
+    /// Requires a band-9 (TypeDB 3.12+) connection; see
+    /// [`Database::check_given_stage_support`](super::database::Database::check_given_stage_support).
+    pub async fn query_with_rows(
+        &mut self,
+        typeql: &str,
+        rows: GivenRowsSpec,
+    ) -> Result<QueryResult> {
+        let tx = self
+            .inner
+            .as_mut()
+            .ok_or_else(|| OrmError::Transaction("Transaction already consumed".into()))?;
+        tx.query_with_rows(typeql, rows).await
     }
 
     /// Commit this transaction.

--- a/type-bridge-core/crates/orm/tests/version_gate_tests.rs
+++ b/type-bridge-core/crates/orm/tests/version_gate_tests.rs
@@ -12,7 +12,9 @@
 
 use type_bridge_core_lib::version::{self as core_version, VersionError};
 use type_bridge_orm::error::OrmError;
-use type_bridge_orm::session::real_driver::{PINNED_DRIVER_VERSION, PINNED_DRIVER_VERSION_B7};
+use type_bridge_orm::session::real_driver::{
+    PINNED_DRIVER_VERSION, PINNED_DRIVER_VERSION_B7, PINNED_DRIVER_VERSION_B9,
+};
 
 // ── 1. Cargo.lock pin assertion ──────────────────────────────────────────────
 
@@ -114,6 +116,53 @@ fn cargo_lock_pin_b7() {
         Some(7),
         "pinned band-7 fork {PINNED_DRIVER_VERSION_B7} is no longer in band 7; \
          update PINNED_DRIVER_VERSION_B7 and review the compatibility window"
+    );
+}
+
+/// Assert that `PINNED_DRIVER_VERSION_B9` matches the
+/// `type-bridge-typedb-driver-b9` entry in `Cargo.lock`, and that the pinned
+/// fork version falls in the expected protocol band (9).
+///
+/// If this test breaks after a fork refresh, update `PINNED_DRIVER_VERSION_B9`
+/// in `crates/typedb-runtime/src/lib.rs` to the new value.
+#[test]
+fn cargo_lock_pin_b9() {
+    let lock_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../Cargo.lock");
+    let lock_contents =
+        std::fs::read_to_string(lock_path).expect("Cargo.lock not found relative to crate root");
+
+    // Find the type-bridge-typedb-driver-b9 package block and extract its version.
+    let lock_version = lock_contents
+        .split("[[package]]")
+        .find(|block| block.contains("name = \"type-bridge-typedb-driver-b9\""))
+        .and_then(|block| {
+            block
+                .lines()
+                .find(|l| l.trim_start().starts_with("version = "))
+        })
+        .and_then(|line| {
+            let start = line.find('"')? + 1;
+            let end = line.rfind('"')?;
+            Some(&line[start..end])
+        })
+        .expect("could not parse type-bridge-typedb-driver-b9 version from Cargo.lock");
+
+    assert_eq!(
+        lock_version, PINNED_DRIVER_VERSION_B9,
+        "PINNED_DRIVER_VERSION_B9 ({PINNED_DRIVER_VERSION_B9}) does not match \
+         Cargo.lock type-bridge-typedb-driver-b9 version ({lock_version}); \
+         update the constant in crates/typedb-runtime/src/lib.rs"
+    );
+
+    // Assert the band-9 fork is in band 9.
+    let pinned: core_version::Version = PINNED_DRIVER_VERSION_B9
+        .parse()
+        .expect("PINNED_DRIVER_VERSION_B9 must be a valid version string");
+    assert_eq!(
+        core_version::band(&pinned),
+        Some(9),
+        "pinned band-9 fork {PINNED_DRIVER_VERSION_B9} is no longer in band 9; \
+         update PINNED_DRIVER_VERSION_B9 and review the compatibility window"
     );
 }
 
@@ -226,7 +275,6 @@ fn connect_options_default_equals_ssot() {
     assert!(!opts.tls, "ConnectOptions::default().tls must be false");
 }
 
-
 // ── Schema-annotation feature gate (TypeDB 3.12+) ────────────────────
 
 mod common;
@@ -282,7 +330,10 @@ fn annotation_gate_rejects_annotated_ddl_on_pre_312_server() {
         .check_schema_annotation_support(ANNOTATED_DDL)
         .expect_err("pre-3.12 server must reject annotated DDL");
     let message = error.to_string();
-    assert!(message.contains("3.12"), "message must name 3.12: {message}");
+    assert!(
+        message.contains("3.12"),
+        "message must name 3.12: {message}"
+    );
     assert!(
         message.contains("3.11.5"),
         "message must name the detected server: {message}"

--- a/type-bridge-core/crates/orm/tests/version_gate_tests.rs
+++ b/type-bridge-core/crates/orm/tests/version_gate_tests.rs
@@ -374,3 +374,91 @@ fn mock_backend_reports_no_server_version_by_default() {
     let backend = common::MockBackend::new(vec![]);
     assert_eq!(backend.server_version(), None);
 }
+
+// ── Given-stage feature gate (TypeDB 3.12+) ──────────────────────────
+
+use type_bridge_orm::{GivenRowsSpec, TxType};
+
+fn empty_rows() -> GivenRowsSpec {
+    GivenRowsSpec {
+        variables: vec!["n".to_string()],
+        rows: vec![],
+    }
+}
+
+#[test]
+fn given_stage_gate_rejects_pre_312_server() {
+    let db = Database::with_backend(
+        Box::new(VersionedBackend::new(Some(Version::new(3, 11, 5)))),
+        "gate-test",
+    );
+    let error = db
+        .check_given_stage_support()
+        .expect_err("pre-3.12 server must reject given-stage queries");
+    let message = error.to_string();
+    assert!(
+        message.contains("3.12"),
+        "message must name 3.12: {message}"
+    );
+    assert!(
+        message.contains("3.11.5"),
+        "message must name the detected server: {message}"
+    );
+    assert!(
+        message.contains("given-stage"),
+        "message must name the feature: {message}"
+    );
+}
+
+#[test]
+fn given_stage_gate_passes_on_312_server() {
+    let db = Database::with_backend(
+        Box::new(VersionedBackend::new(Some(Version::new(3, 12, 0)))),
+        "gate-test",
+    );
+    assert!(db.check_given_stage_support().is_ok());
+    assert!(db.supports_given_stage());
+}
+
+#[test]
+fn supports_given_stage_is_false_pre_312_and_when_unknown() {
+    let pre = Database::with_backend(
+        Box::new(VersionedBackend::new(Some(Version::new(3, 11, 5)))),
+        "gate-test",
+    );
+    assert!(!pre.supports_given_stage());
+
+    let unknown = Database::with_backend(Box::new(VersionedBackend::new(None)), "gate-test");
+    assert!(!unknown.supports_given_stage());
+}
+
+#[tokio::test]
+async fn execute_with_rows_rejects_pre_312_before_opening_transaction() {
+    let db = Database::with_backend(
+        Box::new(VersionedBackend::new(Some(Version::new(3, 11, 5)))),
+        "gate-test",
+    );
+    let error = db
+        .execute_with_rows("given $n: string; insert ...;", TxType::Write, empty_rows())
+        .await
+        .expect_err("pre-3.12 server must reject execute_with_rows");
+    assert!(
+        matches!(error, OrmError::UnsupportedVersion(_)),
+        "expected UnsupportedVersion, got {error:?}"
+    );
+}
+
+#[tokio::test]
+async fn execute_with_rows_unknown_version_reaches_backend_default_error() {
+    // Version unknown → the gate defers; the mock backend's TransactionOps
+    // does not override query_with_rows, so the default trait error fires.
+    let db = Database::with_backend(Box::new(VersionedBackend::new(None)), "gate-test");
+    let error = db
+        .execute_with_rows("given $n: string; insert ...;", TxType::Write, empty_rows())
+        .await
+        .expect_err("backend without given-stage support must error");
+    assert!(
+        error.to_string().contains("not supported by this backend"),
+        "unexpected error: {error}"
+    );
+}

--- a/type-bridge-core/crates/python/src/orm_runtime.rs
+++ b/type-bridge-core/crates/python/src/orm_runtime.rs
@@ -17,8 +17,9 @@ use type_bridge_orm::session::backend::QueryResult;
 use type_bridge_orm::{
     AttributeValue, DescriptorRegistry, DynamicAggregate, DynamicAttributeMap, DynamicComparisonOp,
     DynamicEntityManager, DynamicEntityRow, DynamicExpr, DynamicRelationManager,
-    DynamicRelationRow, DynamicRolePlayerInput, DynamicSort, EntityDescriptor, Filter, OrmError,
-    RelationDescriptor, SchemaInfo, SortDir, TransactionContext, TxType, ValueType,
+    DynamicRelationRow, DynamicRolePlayerInput, DynamicSort, EntityDescriptor, Filter,
+    GivenRowsSpec, GivenValue, OrmError, RelationDescriptor, SchemaInfo, SortDir,
+    TransactionContext, TxType, ValueType,
 };
 
 /// Python-facing descriptor registry wrapper.
@@ -501,6 +502,40 @@ impl PyRustDatabase {
             .map_err(py_orm_error)
     }
 
+    /// Whether the connected server supports given-stage parameterized
+    /// queries (TypeDB 3.12+). `False` when the server predates 3.12 or its
+    /// version is unknown.
+    fn supports_given_stage(&self) -> bool {
+        self.db.supports_given_stage()
+    }
+
+    /// Execute a `given`-stage TypeQL query over input rows, auto-managing
+    /// the transaction lifecycle.
+    ///
+    /// `variables` are the given variable names without the `$` sigil;
+    /// `column_types` are TypeQL value type names (`string`, `integer`,
+    /// `double`, `boolean`, `date`, `datetime`, `datetime-tz`) aligned with
+    /// `variables`; `rows` is a list of rows, each a list of primitives in
+    /// column order (temporal values as ISO-8601 strings).
+    #[pyo3(signature = (query, transaction_type, variables, column_types, rows))]
+    fn execute_with_rows(
+        &self,
+        py: Python<'_>,
+        query: &str,
+        transaction_type: &str,
+        variables: Vec<String>,
+        column_types: Vec<String>,
+        rows: Bound<'_, PyAny>,
+    ) -> PyResult<PyObject> {
+        let tx_type = parse_tx_type(transaction_type)?;
+        let spec = given_rows_from_py(variables, &column_types, &rows)?;
+        let result = self
+            .runtime
+            .block_on(self.db.execute_with_rows(query, tx_type, spec))
+            .map_err(py_orm_error)?;
+        query_result_to_py(py, result)
+    }
+
     /// Return whether the configured database exists.
     fn database_exists(&self) -> PyResult<bool> {
         self.runtime
@@ -570,6 +605,26 @@ impl PyRustTransactionContext {
         let result = self
             .runtime
             .block_on(self.context.query(query))
+            .map_err(py_orm_error)?;
+        query_result_to_py(py, result)
+    }
+
+    /// Execute a `given`-stage TypeQL query with input rows in this Rust
+    /// transaction. See `RustDatabase.execute_with_rows` for the argument
+    /// contract; requires a band-9 (TypeDB 3.12+) connection.
+    #[pyo3(signature = (query, variables, column_types, rows))]
+    fn execute_with_rows(
+        &self,
+        py: Python<'_>,
+        query: &str,
+        variables: Vec<String>,
+        column_types: Vec<String>,
+        rows: Bound<'_, PyAny>,
+    ) -> PyResult<PyObject> {
+        let spec = given_rows_from_py(variables, &column_types, &rows)?;
+        let result = self
+            .runtime
+            .block_on(self.context.query_with_rows(query, spec))
             .map_err(py_orm_error)?;
         query_result_to_py(py, result)
     }
@@ -1578,6 +1633,69 @@ fn parse_tx_type(value: &str) -> PyResult<TxType> {
             "transaction_type must be 'read', 'write', or 'schema', got {other:?}"
         ))),
     }
+}
+
+/// Marshal Python given rows into the ORM's [`GivenRowsSpec`].
+///
+/// `column_types` drives per-cell extraction so an int cell bound to a
+/// `double` column fails loudly instead of being coerced silently.
+fn given_rows_from_py(
+    variables: Vec<String>,
+    column_types: &[String],
+    rows: &Bound<'_, PyAny>,
+) -> PyResult<GivenRowsSpec> {
+    if variables.len() != column_types.len() {
+        return Err(py_value_error(format!(
+            "variables ({}) and column_types ({}) must have the same length",
+            variables.len(),
+            column_types.len()
+        )));
+    }
+    let rows: Vec<Vec<Bound<'_, PyAny>>> = rows
+        .extract()
+        .map_err(|error| py_value_error(format!("rows must be a sequence of rows: {error}")))?;
+    let mut spec_rows = Vec::with_capacity(rows.len());
+    for (row_index, row) in rows.iter().enumerate() {
+        if row.len() != column_types.len() {
+            return Err(py_value_error(format!(
+                "row {row_index} has {} cells; expected {} (one per variable)",
+                row.len(),
+                column_types.len()
+            )));
+        }
+        let mut cells = Vec::with_capacity(row.len());
+        for (cell, column_type) in row.iter().zip(column_types) {
+            cells.push(
+                given_value_from_py(cell, column_type)
+                    .map_err(|error| py_value_error(format!("row {row_index}: {error}")))?,
+            );
+        }
+        spec_rows.push(cells);
+    }
+    Ok(GivenRowsSpec {
+        variables,
+        rows: spec_rows,
+    })
+}
+
+/// Extract one given cell according to its declared TypeQL column type.
+fn given_value_from_py(cell: &Bound<'_, PyAny>, column_type: &str) -> PyResult<GivenValue> {
+    Ok(match column_type {
+        "boolean" => GivenValue::Boolean(cell.extract()?),
+        // "long" is the ORM-internal name for the TypeQL "integer" type.
+        "integer" | "long" => GivenValue::Integer(cell.extract()?),
+        "double" => GivenValue::Double(cell.extract()?),
+        "string" => GivenValue::String(cell.extract()?),
+        "date" => GivenValue::Date(cell.extract()?),
+        "datetime" => GivenValue::Datetime(cell.extract()?),
+        "datetime-tz" => GivenValue::DatetimeTz(cell.extract()?),
+        other => {
+            return Err(py_value_error(format!(
+                "Unsupported given column type {other:?}; expected one of string, \
+                 integer, double, boolean, date, datetime, datetime-tz"
+            )));
+        }
+    })
 }
 
 fn tx_type_name(tx_type: TxType) -> &'static str {

--- a/type-bridge-core/crates/server/Cargo.toml
+++ b/type-bridge-core/crates/server/Cargo.toml
@@ -17,10 +17,11 @@ path = "src/main.rs"
 required-features = ["typedb", "axum-transport"]
 
 [features]
-default = ["band7", "band8", "axum-transport"]
+default = ["band7", "band8", "band9", "axum-transport"]
 typedb = ["dep:type-bridge-typedb-runtime"]
 band7 = ["typedb", "type-bridge-typedb-runtime/band7"]
 band8 = ["typedb", "type-bridge-typedb-runtime/band8"]
+band9 = ["typedb", "type-bridge-typedb-runtime/band9"]
 axum-transport = ["dep:axum", "dep:tower-http"]
 test-helpers = []
 

--- a/type-bridge-core/crates/server/src/typedb/real_driver.rs
+++ b/type-bridge-core/crates/server/src/typedb/real_driver.rs
@@ -2,9 +2,9 @@
 //!
 //! This module is only compiled when the `typedb` feature is enabled.
 
-#[cfg(not(any(feature = "band7", feature = "band8")))]
+#[cfg(not(any(feature = "band7", feature = "band8", feature = "band9")))]
 compile_error!(
-    "type-bridge-server: the `typedb` machinery requires at least one band feature; enable `band7` and/or `band8` (both are default)"
+    "type-bridge-server: the `typedb` machinery requires at least one band feature; enable `band7`, `band8`, and/or `band9` (all are default)"
 );
 
 use type_bridge_typedb_runtime as runtime;

--- a/type-bridge-core/crates/typedb-runtime/Cargo.toml
+++ b/type-bridge-core/crates/typedb-runtime/Cargo.toml
@@ -12,9 +12,10 @@ name = "type_bridge_typedb_runtime"
 path = "src/lib.rs"
 
 [features]
-default = ["band7", "band8"]
+default = ["band7", "band8", "band9"]
 band7 = ["dep:type-bridge-typedb-driver-b7"]
 band8 = ["dep:typedb-driver"]
+band9 = ["dep:type-bridge-typedb-driver-b9"]
 
 [dependencies]
 type-bridge-core-lib = { path = "../core", version = "1.5.7" }
@@ -26,6 +27,7 @@ tracing = "0.1"
 futures = "0.3"
 typedb-driver = { version = "3", optional = true }
 type-bridge-typedb-driver-b7 = { path = "../../vendor/typedb-driver-b7", version = "=3.8.1", optional = true }
+type-bridge-typedb-driver-b9 = { path = "../../vendor/typedb-driver-b9", version = "=3.12.0", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/type-bridge-core/crates/typedb-runtime/Cargo.toml
+++ b/type-bridge-core/crates/typedb-runtime/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/lib.rs"
 default = ["band7", "band8", "band9"]
 band7 = ["dep:type-bridge-typedb-driver-b7"]
 band8 = ["dep:typedb-driver"]
-band9 = ["dep:type-bridge-typedb-driver-b9"]
+band9 = ["dep:type-bridge-typedb-driver-b9", "dep:chrono"]
 
 [dependencies]
 type-bridge-core-lib = { path = "../core", version = "1.5.7" }
@@ -28,6 +28,9 @@ futures = "0.3"
 typedb-driver = { version = "3", optional = true }
 type-bridge-typedb-driver-b7 = { path = "../../vendor/typedb-driver-b7", version = "=3.8.1", optional = true }
 type-bridge-typedb-driver-b9 = { path = "../../vendor/typedb-driver-b9", version = "=3.12.0", optional = true }
+# Band-9 only: parse the ISO-8601 temporal strings in GivenValue when
+# lowering onto the driver's GivenRows (same chrono line the driver uses).
+chrono = { version = "0.4", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/type-bridge-core/crates/typedb-runtime/src/lib.rs
+++ b/type-bridge-core/crates/typedb-runtime/src/lib.rs
@@ -4,9 +4,9 @@
 //! can share version gating, gRPC fallback, database lifecycle, transactions,
 //! and JSON conversion without depending on each other.
 
-#[cfg(not(any(feature = "band7", feature = "band8")))]
+#[cfg(not(any(feature = "band7", feature = "band8", feature = "band9")))]
 compile_error!(
-    "type-bridge-typedb-runtime requires at least one band feature; enable `band7` and/or `band8` (both are default)"
+    "type-bridge-typedb-runtime requires at least one band feature; enable `band7`, `band8`, and/or `band9` (all are default)"
 );
 
 use std::future::Future;
@@ -31,6 +31,15 @@ use type_bridge_typedb_driver_b7::answer::QueryAnswer as B7QueryAnswer;
 use type_bridge_typedb_driver_b7::{
     Credentials as B7Credentials, DriverOptions as B7DriverOptions,
     TransactionType as B7TransactionType, TypeDBDriver as B7Driver,
+};
+
+#[cfg(feature = "band9")]
+use type_bridge_typedb_driver_b9::answer::QueryAnswer as B9QueryAnswer;
+#[cfg(feature = "band9")]
+use type_bridge_typedb_driver_b9::{
+    Addresses as B9Addresses, Credentials as B9Credentials, DriverOptions as B9DriverOptions,
+    DriverTlsConfig as B9DriverTlsConfig, TransactionType as B9TransactionType,
+    TypeDBDriver as B9Driver,
 };
 
 /// Boxed future returned by async runtime methods.
@@ -103,6 +112,15 @@ pub const PINNED_DRIVER_VERSION: &str = "3.11.5";
 /// catch any divergence.
 pub const PINNED_DRIVER_VERSION_B7: &str = "3.8.1";
 
+/// The compile-pinned version of the vendored band-9 driver fork
+/// (`type-bridge-typedb-driver-b9`) this runtime crate was built against.
+///
+/// Mirrors [`PINNED_DRIVER_VERSION`] for the band-8 upstream driver.  When
+/// the band-9 fork is refreshed, update this constant to match the new
+/// `Cargo.lock` entry — the `tests::cargo_lock_pin_b9` test will
+/// catch any divergence.
+pub const PINNED_DRIVER_VERSION_B9: &str = "3.12.0";
+
 /// Protocol bands this build embeds a driver for, derived from the compiled-in
 /// band features.  This is the `embedded_bands` argument to
 /// [`core_version::check_server_supported`] — the embedded-runtime gate accepts
@@ -110,20 +128,22 @@ pub const PINNED_DRIVER_VERSION_B7: &str = "3.8.1";
 ///
 /// Each element is individually cfg-gated so the set reflects exactly the bands
 /// the build can construct; there is no hardcoded band-set literal (master-plan
-/// I6).  The default build compiles both, so the set is `{7, 8}`.
+/// I6).  The default build compiles all three, so the set is `{7, 8, 9}`.
 const EMBEDDED_BANDS: &[u8] = &[
     #[cfg(feature = "band7")]
     7,
     #[cfg(feature = "band8")]
     8,
+    #[cfg(feature = "band9")]
+    9,
 ];
 
 /// Return the driver versions compiled into this build, keyed by protocol band.
 ///
 /// Each entry is `(band, version_string)` and is individually cfg-gated so only
 /// compiled-in bands appear in the slice (master-plan I6 — no hardcoded
-/// band-set literal).  The default build embeds both bands and returns
-/// `[(7, "3.8.1"), (8, "3.11.5")]`.
+/// band-set literal).  The default build embeds all three bands and returns
+/// `[(7, "3.8.1"), (8, "3.11.5"), (9, "3.12.0")]`.
 ///
 /// This is the Rust-side source of truth for the Python `embedded_driver_versions()`
 /// binding — `crates/python/src/version.rs` wraps this function and exposes it
@@ -134,6 +154,8 @@ pub fn embedded_driver_versions() -> &'static [(u8, &'static str)] {
         (7, PINNED_DRIVER_VERSION_B7),
         #[cfg(feature = "band8")]
         (8, PINNED_DRIVER_VERSION),
+        #[cfg(feature = "band9")]
+        (9, PINNED_DRIVER_VERSION_B9),
     ]
 }
 
@@ -170,6 +192,8 @@ pub(crate) enum DriverHandle {
     B7(B7Driver),
     #[cfg(feature = "band8")]
     B8(B8Driver),
+    #[cfg(feature = "band9")]
+    B9(B9Driver),
 }
 
 /// Real TypeDB backend wrapping a band-tagged [`DriverHandle`].
@@ -269,23 +293,26 @@ async fn driver_for_server_version(
             .map(DriverHandle::B7);
     }
 
-    // Every band that is not 7 is band 8 here: the gate already rejected any
-    // band outside EMBEDDED_BANDS, so a non-band-7 server is necessarily a
-    // band-8 server this build embedded.
     #[cfg(feature = "band8")]
-    {
-        connect_band8_driver(address, username, password)
+    if band == 8 {
+        return connect_band8_driver(address, username, password)
             .await
-            .map(DriverHandle::B8)
+            .map(DriverHandle::B8);
     }
 
-    // Unreachable by invariant: with band8 compiled out, EMBEDDED_BANDS cannot
-    // contain 8, so check_server_supported already rejected every non-band-7
-    // server above.  The arm exists only to keep the cfg-complementary tail
-    // total; it is never entered.
-    #[cfg(not(feature = "band8"))]
+    #[cfg(feature = "band9")]
+    if band == 9 {
+        return connect_band9_driver(address, username, password)
+            .await
+            .map(DriverHandle::B9);
+    }
+
+    // Unreachable by invariant: the gate already rejected any server whose
+    // accepted-band set does not intersect EMBEDDED_BANDS, and negotiation
+    // only yields embedded bands, each of which returned above.  The arm
+    // exists only to keep the tail total; it is never entered.
     Err(RuntimeError::Connection(format!(
-        "No compiled driver band supports the detected server band ({band:?})"
+        "No compiled driver band supports the negotiated server band ({band})"
     )))
 }
 
@@ -315,6 +342,21 @@ async fn connect_band8_driver(address: &str, username: &str, password: &str) -> 
     .map_err(|e| RuntimeError::Connection(format!("Failed to connect to {address}: {e}")))
 }
 
+#[cfg(feature = "band9")]
+async fn connect_band9_driver(address: &str, username: &str, password: &str) -> Result<B9Driver> {
+    // Same construction shape as band 8; TLS disabled explicitly for the
+    // same reason (`DriverTlsConfig::default()` would enable it).
+    let addresses = B9Addresses::try_from_address_str(address)
+        .map_err(|e| RuntimeError::Connection(format!("Invalid TypeDB address {address}: {e}")))?;
+    B9Driver::new(
+        addresses,
+        B9Credentials::new(username, password),
+        B9DriverOptions::new(B9DriverTlsConfig::disabled()),
+    )
+    .await
+    .map_err(|e| RuntimeError::Connection(format!("Failed to connect to {address}: {e}")))
+}
+
 async fn grpc_fallback_driver(
     address: &str,
     username: &str,
@@ -322,6 +364,42 @@ async fn grpc_fallback_driver(
     http_error: core_version::VersionError,
 ) -> Result<(DriverHandle, Option<core_version::Version>)> {
     let mut failures = vec![format!("HTTP version probe failed: {http_error}")];
+
+    #[cfg(feature = "band9")]
+    {
+        match connect_band9_driver(address, username, password).await {
+            Ok(driver) => {
+                let reported = driver.server_version().await.map_err(|e| {
+                    RuntimeError::Connection(format!(
+                        "Band-9 gRPC version validation failed after connect to {address}: {e}"
+                    ))
+                })?;
+                let server_version = reported
+                    .version()
+                    .parse::<core_version::Version>()
+                    .map_err(RuntimeError::UnsupportedVersion)?;
+                validate_server_band(&server_version)?;
+                if !core_version::server_accepted_bands(&server_version).contains(&9) {
+                    return Err(RuntimeError::UnsupportedVersion(
+                        core_version::VersionError::Probe(format!(
+                            "band-9 gRPC connection reported server version {server_version}, \
+                             which does not accept band 9"
+                        )),
+                    ));
+                }
+                tracing::debug!(
+                    address,
+                    server_version = %server_version,
+                    "Connected through gRPC band-9 fallback after HTTP version probe failed"
+                );
+                return Ok((DriverHandle::B9(driver), Some(server_version)));
+            }
+            Err(error) => failures.push(format!("band-9 gRPC attempt failed: {error}")),
+        }
+    }
+
+    #[cfg(not(feature = "band9"))]
+    failures.push("band-9 gRPC attempt skipped: band9 feature is not compiled in".to_string());
 
     #[cfg(feature = "band8")]
     {
@@ -336,11 +414,17 @@ async fn grpc_fallback_driver(
                     .version()
                     .parse::<core_version::Version>()
                     .map_err(RuntimeError::UnsupportedVersion)?;
-                let band = validate_server_band(&server_version)?;
-                if band != 8 {
+                // Window + embedded-band gate, then confirm the server accepts
+                // band 8.  The acceptance check (not negotiate == 8): a 3.12
+                // server reached here negotiates its native band 9 when band9
+                // is embedded, but this band-8 connection is still legitimate
+                // through the server's band-8 backward acceptance.
+                validate_server_band(&server_version)?;
+                if !core_version::server_accepted_bands(&server_version).contains(&8) {
                     return Err(RuntimeError::UnsupportedVersion(
                         core_version::VersionError::Probe(format!(
-                            "band-8 gRPC connection reported non-band-8 server version {server_version}"
+                            "band-8 gRPC connection reported server version {server_version}, \
+                             which does not accept band 8"
                         )),
                     ));
                 }
@@ -481,6 +565,19 @@ pub async fn ensure_database_exists(
                 })?;
             }
         }
+        #[cfg(feature = "band9")]
+        DriverHandle::B9(d) => {
+            let databases = d.databases();
+            let exists = databases
+                .contains(database)
+                .await
+                .map_err(|e| RuntimeError::Connection(format!("Database lookup failed: {e}")))?;
+            if !exists {
+                databases.create(database).await.map_err(|e| {
+                    RuntimeError::Connection(format!("Database create failed: {e}"))
+                })?;
+            }
+        }
     }
 
     Ok(())
@@ -524,6 +621,20 @@ impl TypeDBRuntime {
                         inner: RuntimeTransactionInner::B8(Some(transaction)),
                     })
                 }
+                #[cfg(feature = "band9")]
+                DriverHandle::B9(d) => {
+                    let typedb_tx_type = match tx_type {
+                        TxType::Read => B9TransactionType::Read,
+                        TxType::Write => B9TransactionType::Write,
+                        TxType::Schema => B9TransactionType::Schema,
+                    };
+                    let transaction = d.transaction(&db, typedb_tx_type).await.map_err(|e| {
+                        RuntimeError::Transaction(format!("Failed to open transaction: {e}"))
+                    })?;
+                    Ok(RuntimeTransaction {
+                        inner: RuntimeTransactionInner::B9(Some(transaction)),
+                    })
+                }
             }
         })
     }
@@ -535,6 +646,8 @@ impl TypeDBRuntime {
             DriverHandle::B7(d) => d.is_open(),
             #[cfg(feature = "band8")]
             DriverHandle::B8(d) => d.is_open(),
+            #[cfg(feature = "band9")]
+            DriverHandle::B9(d) => d.is_open(),
         }
     }
 
@@ -551,6 +664,12 @@ impl TypeDBRuntime {
                 }
                 #[cfg(feature = "band8")]
                 DriverHandle::B8(d) => {
+                    d.databases().contains(database).await.map_err(|e| {
+                        RuntimeError::Connection(format!("Database lookup failed: {e}"))
+                    })
+                }
+                #[cfg(feature = "band9")]
+                DriverHandle::B9(d) => {
                     d.databases().contains(database).await.map_err(|e| {
                         RuntimeError::Connection(format!("Database lookup failed: {e}"))
                     })
@@ -576,6 +695,12 @@ impl TypeDBRuntime {
                         RuntimeError::Connection(format!("Database create failed: {e}"))
                     })
                 }
+                #[cfg(feature = "band9")]
+                DriverHandle::B9(d) => {
+                    d.databases().create(database).await.map_err(|e| {
+                        RuntimeError::Connection(format!("Database create failed: {e}"))
+                    })
+                }
             }
         })
     }
@@ -596,6 +721,15 @@ impl TypeDBRuntime {
                 }
                 #[cfg(feature = "band8")]
                 DriverHandle::B8(d) => {
+                    let db = d.databases().get(database).await.map_err(|e| {
+                        RuntimeError::Connection(format!("Database lookup failed: {e}"))
+                    })?;
+                    db.delete().await.map_err(|e| {
+                        RuntimeError::Connection(format!("Database delete failed: {e}"))
+                    })
+                }
+                #[cfg(feature = "band9")]
+                DriverHandle::B9(d) => {
                     let db = d.databases().get(database).await.map_err(|e| {
                         RuntimeError::Connection(format!("Database lookup failed: {e}"))
                     })?;
@@ -630,6 +764,15 @@ impl TypeDBRuntime {
                         .await
                         .map_err(|e| RuntimeError::Connection(format!("Schema export failed: {e}")))
                 }
+                #[cfg(feature = "band9")]
+                DriverHandle::B9(d) => {
+                    let db = d.databases().get(&database).await.map_err(|e| {
+                        RuntimeError::Connection(format!("Database lookup failed: {e}"))
+                    })?;
+                    db.schema()
+                        .await
+                        .map_err(|e| RuntimeError::Connection(format!("Schema export failed: {e}")))
+                }
             }
         })
     }
@@ -645,6 +788,8 @@ enum RuntimeTransactionInner {
     B7(Option<type_bridge_typedb_driver_b7::Transaction>),
     #[cfg(feature = "band8")]
     B8(Option<typedb_driver::Transaction>),
+    #[cfg(feature = "band9")]
+    B9(Option<type_bridge_typedb_driver_b9::Transaction>),
 }
 
 /// Open TypeDB transaction owned by the shared runtime.
@@ -754,6 +899,17 @@ impl RuntimeTransaction {
                         }
                     }
                 }
+                #[cfg(feature = "band9")]
+                RuntimeTransactionInner::B9(opt) => {
+                    let tx = opt.as_ref().ok_or_else(|| {
+                        RuntimeError::Transaction("Transaction already consumed".into())
+                    })?;
+                    let answer = tx
+                        .query(&tql)
+                        .await
+                        .map_err(|e| RuntimeError::QueryExecution(format!("{e}")))?;
+                    convert_answer_b9(answer).await
+                }
             }
         })
     }
@@ -777,6 +933,18 @@ impl RuntimeTransaction {
             }
             #[cfg(feature = "band8")]
             RuntimeTransactionInner::B8(opt) => {
+                let tx = opt.take();
+                Box::pin(async move {
+                    let t = tx.ok_or_else(|| {
+                        RuntimeError::Transaction("Transaction already consumed".into())
+                    })?;
+                    t.commit()
+                        .await
+                        .map_err(|e| RuntimeError::Transaction(format!("Commit failed: {e}")))
+                })
+            }
+            #[cfg(feature = "band9")]
+            RuntimeTransactionInner::B9(opt) => {
                 let tx = opt.take();
                 Box::pin(async move {
                     let t = tx.ok_or_else(|| {
@@ -820,6 +988,18 @@ impl RuntimeTransaction {
                         .map_err(|e| RuntimeError::Transaction(format!("Rollback failed: {e}")))
                 })
             }
+            #[cfg(feature = "band9")]
+            RuntimeTransactionInner::B9(opt) => {
+                let tx = opt.take();
+                Box::pin(async move {
+                    let t = tx.ok_or_else(|| {
+                        RuntimeError::Transaction("Transaction already consumed".into())
+                    })?;
+                    t.rollback()
+                        .await
+                        .map_err(|e| RuntimeError::Transaction(format!("Rollback failed: {e}")))
+                })
+            }
         }
     }
 
@@ -840,6 +1020,18 @@ impl RuntimeTransaction {
             }
             #[cfg(feature = "band8")]
             RuntimeTransactionInner::B8(opt) => {
+                let tx = opt.take();
+                Box::pin(async move {
+                    let Some(t) = tx else {
+                        return Ok(());
+                    };
+                    t.close()
+                        .await
+                        .map_err(|e| RuntimeError::Transaction(format!("Close failed: {e}")))
+                })
+            }
+            #[cfg(feature = "band9")]
+            RuntimeTransactionInner::B9(opt) => {
                 let tx = opt.take();
                 Box::pin(async move {
                     let Some(t) = tx else {
@@ -980,6 +1172,115 @@ fn value_to_json_b8(value: &typedb_driver::concept::Value) -> serde_json::Value 
     serde_json::Value::String(value.to_string())
 }
 
+/// Convert a band-9 [`B9QueryAnswer`] into the runtime's [`QueryResult`].
+///
+/// Shared by the plain `query` arm and the given-stage `query_with_rows`
+/// path — both produce the same driver answer type.
+#[cfg(feature = "band9")]
+async fn convert_answer_b9(answer: B9QueryAnswer) -> Result<QueryResult> {
+    match answer {
+        B9QueryAnswer::Ok(_) => Ok(QueryResult::Ok),
+        B9QueryAnswer::ConceptRowStream(_, stream) => {
+            let rows: Vec<_> = stream
+                .try_collect()
+                .await
+                .map_err(|e| RuntimeError::QueryExecution(format!("Row collect: {e}")))?;
+            let json_rows = rows
+                .iter()
+                .map(|row| {
+                    let mut obj = serde_json::Map::new();
+                    for (i, col) in row.get_column_names().iter().enumerate() {
+                        let value = row
+                            .row
+                            .get(i)
+                            .and_then(|c| c.as_ref())
+                            .map(concept_to_json_b9)
+                            .unwrap_or(serde_json::Value::Null);
+                        obj.insert(col.clone(), value);
+                    }
+                    serde_json::Value::Object(obj)
+                })
+                .collect();
+            Ok(QueryResult::Rows(json_rows))
+        }
+        B9QueryAnswer::ConceptDocumentStream(_, stream) => {
+            let docs: Vec<_> = stream
+                .try_collect()
+                .await
+                .map_err(|e| RuntimeError::QueryExecution(format!("Doc collect: {e}")))?;
+            let json_docs = docs
+                .into_iter()
+                .map(|doc| serde_json::to_value(doc.into_json()).unwrap_or(serde_json::Value::Null))
+                .collect();
+            Ok(QueryResult::Documents(json_docs))
+        }
+    }
+}
+
+/// Convert a band-9 TypeDB concept to a JSON value.
+///
+/// Output shape is identical to [`concept_to_json_b8`] for all common concepts.
+#[cfg(feature = "band9")]
+fn concept_to_json_b9(
+    concept: &type_bridge_typedb_driver_b9::concept::Concept,
+) -> serde_json::Value {
+    let mut obj = serde_json::Map::new();
+    obj.insert(
+        "category".into(),
+        serde_json::Value::String(concept.get_category().name().into()),
+    );
+    obj.insert(
+        "label".into(),
+        serde_json::Value::String(concept.get_label().into()),
+    );
+    if let Some(iid) = concept.try_get_iid() {
+        obj.insert("iid".into(), serde_json::Value::String(iid.to_string()));
+    }
+    if let Some(value) = concept.try_get_value() {
+        obj.insert("value".into(), value_to_json_b9(value));
+    }
+    if let Some(vt) = concept.try_get_value_type() {
+        obj.insert(
+            "value_type".into(),
+            serde_json::Value::String(vt.name().into()),
+        );
+    }
+    serde_json::Value::Object(obj)
+}
+
+/// Convert a band-9 TypeDB value to a JSON value.
+#[cfg(feature = "band9")]
+fn value_to_json_b9(value: &type_bridge_typedb_driver_b9::concept::Value) -> serde_json::Value {
+    if let Some(b) = value.get_boolean() {
+        return serde_json::Value::Bool(b);
+    }
+    if let Some(i) = value.get_integer() {
+        return serde_json::json!(i);
+    }
+    if let Some(d) = value.get_double() {
+        return serde_json::json!(d);
+    }
+    if let Some(s) = value.get_string() {
+        return serde_json::Value::String(s.to_string());
+    }
+    if let Some(date) = value.get_date() {
+        return serde_json::Value::String(date.to_string());
+    }
+    if let Some(dt) = value.get_datetime() {
+        return serde_json::Value::String(dt.to_string());
+    }
+    if let Some(dt_tz) = value.get_datetime_tz() {
+        return serde_json::Value::String(dt_tz.to_string());
+    }
+    if let Some(dec) = value.get_decimal() {
+        return serde_json::Value::String(dec.to_string());
+    }
+    if let Some(dur) = value.get_duration() {
+        return serde_json::Value::String(dur.to_string());
+    }
+    serde_json::Value::String(value.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1056,6 +1357,7 @@ mod tests {
             Err(RuntimeError::UnsupportedVersion(err)) => {
                 let msg = err.to_string();
                 assert!(msg.contains("HTTP endpoint unavailable"), "{msg}");
+                assert!(msg.contains("band-9 gRPC attempt failed"), "{msg}");
                 assert!(msg.contains("band-8 gRPC attempt failed"), "{msg}");
                 assert!(msg.contains("band-7 gRPC attempt failed"), "{msg}");
             }
@@ -1208,6 +1510,42 @@ mod tests {
             core_version::band(&pinned),
             Some(7),
             "pinned band-7 fork version {PINNED_DRIVER_VERSION_B7} left protocol band 7; \
+             review the gate expectations before accepting the bump"
+        );
+    }
+
+    #[test]
+    fn cargo_lock_pin_b9() {
+        let lock_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../Cargo.lock");
+        let lock_contents = std::fs::read_to_string(lock_path)
+            .expect("Cargo.lock not found relative to crate root");
+
+        let lock_version = lock_contents
+            .split("[[package]]")
+            .find(|block| block.contains("name = \"type-bridge-typedb-driver-b9\""))
+            .and_then(|block| {
+                block
+                    .lines()
+                    .find(|line| line.trim_start().starts_with("version = "))
+            })
+            .and_then(|line| {
+                let start = line.find('"')? + 1;
+                let end = line.rfind('"')?;
+                Some(&line[start..end])
+            })
+            .expect("type-bridge-typedb-driver-b9 entry not found in Cargo.lock");
+
+        assert_eq!(
+            lock_version, PINNED_DRIVER_VERSION_B9,
+            "Cargo.lock resolves type-bridge-typedb-driver-b9 {lock_version} but \
+             PINNED_DRIVER_VERSION_B9 is {PINNED_DRIVER_VERSION_B9}; update the runtime constant"
+        );
+
+        let pinned: core_version::Version = PINNED_DRIVER_VERSION_B9.parse().unwrap();
+        assert_eq!(
+            core_version::band(&pinned),
+            Some(9),
+            "pinned band-9 fork version {PINNED_DRIVER_VERSION_B9} left protocol band 9; \
              review the gate expectations before accepting the bump"
         );
     }

--- a/type-bridge-core/crates/typedb-runtime/src/lib.rs
+++ b/type-bridge-core/crates/typedb-runtime/src/lib.rs
@@ -91,6 +91,41 @@ pub enum TxType {
     Schema,
 }
 
+/// A single value bound to a `given` variable, band-agnostic and serializable.
+///
+/// Temporal variants carry ISO-8601 text and are parsed when lowering onto
+/// the band-9 driver — symmetric with [`QueryResult`], which renders temporal
+/// values back to strings.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum GivenValue {
+    /// TypeQL `boolean`.
+    Boolean(bool),
+    /// TypeQL `integer`.
+    Integer(i64),
+    /// TypeQL `double`.
+    Double(f64),
+    /// TypeQL `string`.
+    String(String),
+    /// TypeQL `date`, ISO-8601 (`YYYY-MM-DD`).
+    Date(String),
+    /// TypeQL `datetime`, ISO-8601 without offset.
+    Datetime(String),
+    /// TypeQL `datetime-tz`, RFC 3339 with offset.
+    DatetimeTz(String),
+}
+
+/// Input rows for a `given`-stage query: a variable header plus value rows.
+///
+/// Every row must have exactly one entry per header variable, in header
+/// order. Rows travel through the driver API, never the query string.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GivenRowsSpec {
+    /// Variable names, without the `$` sigil, in column order.
+    pub variables: Vec<String>,
+    /// Value rows; each inner vec is one input row in header order.
+    pub rows: Vec<Vec<GivenValue>>,
+}
+
 /// The compile-pinned `typedb-driver` crate version resolved in `Cargo.lock`.
 ///
 /// This constant records the exact driver version this runtime crate was built
@@ -914,6 +949,49 @@ impl RuntimeTransaction {
         })
     }
 
+    /// Execute TypeQL with `given`-stage input rows within this transaction.
+    ///
+    /// Rows travel through the driver API, not the query string, so this
+    /// path is only available on the band-9 (TypeDB 3.12+) driver. On a
+    /// band-7 or band-8 connection this returns an actionable error —
+    /// callers that can fall back to per-row queries should consult the
+    /// detected server version before choosing this path.
+    pub fn query_with_rows(
+        &mut self,
+        typeql: &str,
+        rows: GivenRowsSpec,
+    ) -> BoxFuture<'_, Result<QueryResult>> {
+        let tql = typeql.to_string();
+        Box::pin(async move {
+            match &self.inner {
+                #[cfg(feature = "band7")]
+                RuntimeTransactionInner::B7(_) => Err(RuntimeError::QueryExecution(
+                    "given-stage parameterized queries require the band-9 driver \
+                     (TypeDB 3.12+); this connection negotiated band 7"
+                        .into(),
+                )),
+                #[cfg(feature = "band8")]
+                RuntimeTransactionInner::B8(_) => Err(RuntimeError::QueryExecution(
+                    "given-stage parameterized queries require the band-9 driver \
+                     (TypeDB 3.12+); this connection negotiated band 8"
+                        .into(),
+                )),
+                #[cfg(feature = "band9")]
+                RuntimeTransactionInner::B9(opt) => {
+                    let tx = opt.as_ref().ok_or_else(|| {
+                        RuntimeError::Transaction("Transaction already consumed".into())
+                    })?;
+                    let given_rows = given_rows_b9(rows)?;
+                    let answer = tx
+                        .query_with_rows(&tql, given_rows)
+                        .await
+                        .map_err(|e| RuntimeError::QueryExecution(format!("{e}")))?;
+                    convert_answer_b9(answer).await
+                }
+            }
+        })
+    }
+
     /// Commit this transaction.
     pub fn commit(&mut self) -> BoxFuture<'_, Result<()>> {
         // Take ownership out of the Option so the async block can move the
@@ -1170,6 +1248,61 @@ fn value_to_json_b8(value: &typedb_driver::concept::Value) -> serde_json::Value 
         return serde_json::Value::String(dur.to_string());
     }
     serde_json::Value::String(value.to_string())
+}
+
+/// Lower a portable [`GivenRowsSpec`] onto the band-9 driver's `GivenRows`.
+///
+/// Fails when a row's width does not match the header or a temporal string
+/// does not parse — both are caller mistakes reported before any wire I/O.
+#[cfg(feature = "band9")]
+fn given_rows_b9(spec: GivenRowsSpec) -> Result<type_bridge_typedb_driver_b9::given::GivenRows> {
+    use type_bridge_typedb_driver_b9::given::GivenRows;
+
+    let mut given = GivenRows::new(spec.variables, spec.rows.len());
+    for row in spec.rows {
+        let entries = row
+            .into_iter()
+            .map(given_entry_b9)
+            .collect::<Result<Vec<_>>>()?;
+        given
+            .push_row(entries)
+            .map_err(|e| RuntimeError::QueryExecution(format!("Invalid given row: {e}")))?;
+    }
+    Ok(given)
+}
+
+/// Convert one portable [`GivenValue`] to a band-9 driver row entry.
+#[cfg(feature = "band9")]
+fn given_entry_b9(value: GivenValue) -> Result<type_bridge_typedb_driver_b9::given::GivenRowEntry> {
+    use chrono::{DateTime, NaiveDate, NaiveDateTime};
+    use type_bridge_typedb_driver_b9::concept::value::TimeZone as B9TimeZone;
+    use type_bridge_typedb_driver_b9::given::GivenRowEntry;
+
+    Ok(match value {
+        GivenValue::Boolean(b) => GivenRowEntry::from(b),
+        GivenValue::Integer(i) => GivenRowEntry::from(i),
+        GivenValue::Double(d) => GivenRowEntry::from(d),
+        GivenValue::String(s) => GivenRowEntry::from(s),
+        GivenValue::Date(s) => {
+            let date = s.parse::<NaiveDate>().map_err(|e| {
+                RuntimeError::QueryExecution(format!("Invalid given date {s:?}: {e}"))
+            })?;
+            GivenRowEntry::from(date)
+        }
+        GivenValue::Datetime(s) => {
+            let dt = s.parse::<NaiveDateTime>().map_err(|e| {
+                RuntimeError::QueryExecution(format!("Invalid given datetime {s:?}: {e}"))
+            })?;
+            GivenRowEntry::from(dt)
+        }
+        GivenValue::DatetimeTz(s) => {
+            let dt = DateTime::parse_from_rfc3339(&s).map_err(|e| {
+                RuntimeError::QueryExecution(format!("Invalid given datetime-tz {s:?}: {e}"))
+            })?;
+            let offset = *dt.offset();
+            GivenRowEntry::from(dt.with_timezone(&B9TimeZone::Fixed(offset)))
+        }
+    })
 }
 
 /// Convert a band-9 [`B9QueryAnswer`] into the runtime's [`QueryResult`].
@@ -1512,6 +1645,66 @@ mod tests {
             "pinned band-7 fork version {PINNED_DRIVER_VERSION_B7} left protocol band 7; \
              review the gate expectations before accepting the bump"
         );
+    }
+
+    /// Portable given-rows lower onto the band-9 driver structures, including
+    /// temporal string parsing; malformed rows fail before any wire I/O.
+    #[cfg(feature = "band9")]
+    #[test]
+    fn given_rows_lowering() {
+        let spec = GivenRowsSpec {
+            variables: vec!["n".into(), "a".into()],
+            rows: vec![
+                vec![GivenValue::String("alice".into()), GivenValue::Integer(28)],
+                vec![GivenValue::String("bob".into()), GivenValue::Integer(26)],
+            ],
+        };
+        let rows = given_rows_b9(spec).expect("valid spec must lower");
+        let (header, rows) = rows.into_parts();
+        assert_eq!(header.width(), 2);
+        assert_eq!(rows.len(), 2);
+    }
+
+    #[cfg(feature = "band9")]
+    #[test]
+    fn given_rows_lowering_rejects_width_mismatch() {
+        let spec = GivenRowsSpec {
+            variables: vec!["n".into(), "a".into()],
+            rows: vec![vec![GivenValue::String("alice".into())]],
+        };
+        let err = given_rows_b9(spec).expect_err("short row must be rejected");
+        assert!(matches!(err, RuntimeError::QueryExecution(_)), "{err}");
+    }
+
+    #[cfg(feature = "band9")]
+    #[test]
+    fn given_entry_temporal_parsing() {
+        for value in [
+            GivenValue::Date("2026-07-13".into()),
+            GivenValue::Datetime("2026-07-13T10:30:00".into()),
+            GivenValue::DatetimeTz("2026-07-13T10:30:00+09:00".into()),
+            GivenValue::Boolean(true),
+            GivenValue::Double(1.5),
+        ] {
+            given_entry_b9(value.clone()).unwrap_or_else(|e| panic!("{value:?} must convert: {e}"));
+        }
+    }
+
+    #[cfg(feature = "band9")]
+    #[test]
+    fn given_entry_rejects_malformed_temporal() {
+        for value in [
+            GivenValue::Date("not-a-date".into()),
+            GivenValue::Datetime("2026-13-45T99:00:00".into()),
+            GivenValue::DatetimeTz("2026-07-13 10:30".into()),
+        ] {
+            let err = given_entry_b9(value.clone())
+                .expect_err("malformed temporal string must be rejected");
+            assert!(
+                err.to_string().contains("Invalid given"),
+                "{value:?}: {err}"
+            );
+        }
     }
 
     #[test]

--- a/type-bridge-core/crates/typedb-runtime/src/lib.rs
+++ b/type-bridge-core/crates/typedb-runtime/src/lib.rs
@@ -400,42 +400,11 @@ async fn grpc_fallback_driver(
 ) -> Result<(DriverHandle, Option<core_version::Version>)> {
     let mut failures = vec![format!("HTTP version probe failed: {http_error}")];
 
-    #[cfg(feature = "band9")]
-    {
-        match connect_band9_driver(address, username, password).await {
-            Ok(driver) => {
-                let reported = driver.server_version().await.map_err(|e| {
-                    RuntimeError::Connection(format!(
-                        "Band-9 gRPC version validation failed after connect to {address}: {e}"
-                    ))
-                })?;
-                let server_version = reported
-                    .version()
-                    .parse::<core_version::Version>()
-                    .map_err(RuntimeError::UnsupportedVersion)?;
-                validate_server_band(&server_version)?;
-                if !core_version::server_accepted_bands(&server_version).contains(&9) {
-                    return Err(RuntimeError::UnsupportedVersion(
-                        core_version::VersionError::Probe(format!(
-                            "band-9 gRPC connection reported server version {server_version}, \
-                             which does not accept band 9"
-                        )),
-                    ));
-                }
-                tracing::debug!(
-                    address,
-                    server_version = %server_version,
-                    "Connected through gRPC band-9 fallback after HTTP version probe failed"
-                );
-                return Ok((DriverHandle::B9(driver), Some(server_version)));
-            }
-            Err(error) => failures.push(format!("band-9 gRPC attempt failed: {error}")),
-        }
-    }
-
-    #[cfg(not(feature = "band9"))]
-    failures.push("band-9 gRPC attempt skipped: band9 feature is not compiled in".to_string());
-
+    // Band 9 is deliberately NOT probed blindly: a band-9 connection attempt
+    // against a 3.11 server crashes the server outright (measured live on
+    // 3.11.5).  The fallback therefore discovers the server through band 8 —
+    // accepted by every band-{8,9} server — and only upgrades to the native
+    // band-9 protocol once the reported version proves the server accepts it.
     #[cfg(feature = "band8")]
     {
         match connect_band8_driver(address, username, password).await {
@@ -451,9 +420,9 @@ async fn grpc_fallback_driver(
                     .map_err(RuntimeError::UnsupportedVersion)?;
                 // Window + embedded-band gate, then confirm the server accepts
                 // band 8.  The acceptance check (not negotiate == 8): a 3.12
-                // server reached here negotiates its native band 9 when band9
-                // is embedded, but this band-8 connection is still legitimate
-                // through the server's band-8 backward acceptance.
+                // server negotiates its native band 9 when band9 is embedded,
+                // but this band-8 connection is still legitimate through the
+                // server's band-8 backward acceptance.
                 validate_server_band(&server_version)?;
                 if !core_version::server_accepted_bands(&server_version).contains(&8) {
                     return Err(RuntimeError::UnsupportedVersion(
@@ -462,6 +431,29 @@ async fn grpc_fallback_driver(
                              which does not accept band 8"
                         )),
                     ));
+                }
+                // Prefer the server's native band when this build embeds it:
+                // with the version now known, a band-9 connect is safe.
+                #[cfg(feature = "band9")]
+                if core_version::negotiate_server_band(&server_version, EMBEDDED_BANDS) == Some(9) {
+                    match connect_band9_driver(address, username, password).await {
+                        Ok(b9_driver) => {
+                            tracing::debug!(
+                                address,
+                                server_version = %server_version,
+                                "Connected through gRPC band-8 fallback, upgraded to native band 9"
+                            );
+                            return Ok((DriverHandle::B9(b9_driver), Some(server_version)));
+                        }
+                        Err(error) => {
+                            tracing::warn!(
+                                address,
+                                server_version = %server_version,
+                                %error,
+                                "Band-9 upgrade failed after band-8 fallback; staying on band 8"
+                            );
+                        }
+                    }
                 }
                 tracing::debug!(
                     address,
@@ -1490,9 +1482,11 @@ mod tests {
             Err(RuntimeError::UnsupportedVersion(err)) => {
                 let msg = err.to_string();
                 assert!(msg.contains("HTTP endpoint unavailable"), "{msg}");
-                assert!(msg.contains("band-9 gRPC attempt failed"), "{msg}");
                 assert!(msg.contains("band-8 gRPC attempt failed"), "{msg}");
                 assert!(msg.contains("band-7 gRPC attempt failed"), "{msg}");
+                // Band 9 must never be probed blindly: a band-9 connect
+                // attempt crashes a 3.11 server (see grpc_fallback_driver).
+                assert!(!msg.contains("band-9 gRPC attempt"), "{msg}");
             }
             Err(other) => panic!("expected aggregated version-probe failure, got {other}"),
             Ok(_) => panic!("expected aggregated version-probe failure, got successful connection"),

--- a/type_bridge/session.py
+++ b/type_bridge/session.py
@@ -448,6 +448,56 @@ class Database:
 
         rust_database_for(self).check_schema_annotation_support(typeql)
 
+    def supports_given_stage(self) -> bool:
+        """Whether the server supports ``given``-stage parameterized queries.
+
+        ``True`` on TypeDB 3.12+ servers. ``False`` when the server predates
+        3.12 or its version is unknown (band-7 gRPC fallback) — callers with
+        a per-row fallback should treat both cases the same. Bulk operations
+        such as ``insert_many`` consult this automatically and fall back to
+        per-row queries when it is ``False``.
+        """
+        from type_bridge._rust_runtime import rust_database_for
+
+        return rust_database_for(self).supports_given_stage()
+
+    def execute_with_rows(
+        self,
+        query: str,
+        transaction_type: str,
+        variables: list[str],
+        column_types: list[str],
+        rows: list[list[Any]],
+    ) -> list[dict[str, Any]]:
+        """Execute a ``given``-stage TypeQL query over input rows.
+
+        One compiled pipeline runs over every input row; the rows travel
+        through the driver API instead of being interpolated into the query
+        string, so user-supplied values never touch TypeQL text. Requires a
+        TypeDB 3.12+ server; on older servers this raises the versioned
+        error from the feature gate.
+
+        Args:
+            query: TypeQL starting with a ``given`` stage, e.g.
+                ``given $n: string; insert $p isa person, has name == $n;``
+            transaction_type: "read", "write", or "schema"
+            variables: given variable names without the ``$`` sigil,
+                in column order
+            column_types: TypeQL value type names aligned with ``variables``
+                ("string", "integer", "double", "boolean", "date",
+                "datetime", "datetime-tz")
+            rows: input rows, each a list of primitives in column order
+                (temporal values as ISO-8601 strings)
+
+        Returns:
+            List of result dictionaries (one per pipeline output row).
+        """
+        from type_bridge._rust_runtime import rust_database_for
+
+        return rust_database_for(self).execute_with_rows(
+            query, transaction_type, variables, column_types, rows
+        )
+
     def get_schema(self) -> str:
         """Get the schema definition for this database."""
         logger.debug(f"Fetching schema for database: {self.database_name}")
@@ -689,6 +739,22 @@ class TransactionContext:
         if self._rust_tx is not None:
             return self._rust_tx.execute(query)
         return self.transaction.execute(query)
+
+    def execute_with_rows(
+        self,
+        query: str,
+        variables: list[str],
+        column_types: list[str],
+        rows: list[list[Any]],
+    ) -> list[dict[str, Any]]:
+        """Execute a ``given``-stage query with input rows in this transaction.
+
+        See :meth:`Database.execute_with_rows` for the argument contract.
+        Requires the Rust backend on a TypeDB 3.12+ connection.
+        """
+        if self._rust_tx is None:
+            raise RuntimeError("execute_with_rows requires an open Rust-backend transaction")
+        return self._rust_tx.execute_with_rows(query, variables, column_types, rows)
 
     def commit(self) -> None:
         """Commit the active transaction."""


### PR DESCRIPTION
Part of #169 (Workstream B). Follows up #180, which landed Workstream A.

## Summary

Embeds the TypeDB 3.12 band-9 driver and adopts the given stage: parameterized queries from the Python surface and a transparent `insert_many` fast path with a measured ~4.4x speedup, falling back per-row on older servers. Also hardens the gRPC fallback against a measured 3.11.5 server crash and fixes a latent generator bug the #179 fix exposed.

The band-9 vendor commit (5bef09f) is already on master via #182's branch base; this PR carries the remaining Workstream B commits.

## Changes

- **Band-9 embedded driver**: vendor typedb-protocol/typedb-driver 3.12.0 as renamed `-b9` crates (cargo unifies semver-compatible versions, so 3.12.0 cannot coexist with the pinned 3.11.5 under one name); the runtime now embeds bands {7, 8, 9} and speaks the native 3.12 protocol to 3.12 servers
- **Fallback hardening**: live measurement showed a band-9 connection attempt crashes a TypeDB 3.11.5 server process. The gRPC fallback (used when the HTTP version probe is unavailable) now discovers through band 8 — accepted by every band-{8,9} server — and upgrades to band 9 only after the reported server version proves acceptance; it never probes band 9 blind
- **Given-stage parameterized queries**: `Feature::GivenStage` version gate (3.12.0+) with per-feature remediation hints on `FeatureUnsupported` errors; portable `GivenValue`/`GivenRowsSpec` types through runtime → orm → PyO3; `Database.execute_with_rows()` / `supports_given_stage()` and `TransactionContext.execute_with_rows()` on the Python surface
- **`insert_many` fast path**: homogeneous entity batches on a 3.12+ database ride one given pipeline; inserted IIDs are correlated by an explicitly fetched row index, not stream order. Heterogeneous, decimal/duration, and transaction-bound batches fall back to the per-row path transparently. Measured 4.4x faster on a 1000-row insert (0.21s vs 0.92s) against TypeDB 3.12.0
- **Generator fix**: `@unique` ownerships keep the TypeDB default card(0..1) optionality on the Python and TypeScript targets instead of being emitted as required fields — a latent bug the #179 fix exposed (generated bookstore subtypes failed construction)
- **Docs**: CRUD guide given-stage fast-path section; queries guide parameterized-queries section; TypeDB development notes feature table, band map {7, 8, 9}, and the band-9 fallback hazard; CHANGELOG entries

## Test plan

- `./test.sh` full isolated suite (Rust + Python + Node, unit + integration) green; full Python integration tier re-verified against a live TypeDB 3.11.5 after the generator fix (745 passed)
- `cargo test` 1461 passed; `cargo clippy` and `cargo fmt --check` clean
- `uv run pytest` unit suite passed; `ruff check`/`format` and `pyright` clean; `./scripts/check.sh all` green
- Version gates proven live on both server legs: TypeDB 3.12.0 (given fast path taken, band-9 negotiated) and 3.11.5 (VersionError with remediation, per-row fallback, server survives repeated fallback connections)
- Cross-language descriptor parity passes on all five fixture schemas

## Related

- Part of #169
- Refs #179