### PR TITLE
fix(query): harden F8 relation-player release contract (#170)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
   # driver-b9 → typedb-runtime → orm → server
   publish-crates:
     name: Publish Rust crates to crates.io
-    needs: [validate-release-identity, accept-python-artifacts, accept-node-package]
+    needs: [validate-release-identity, accept-python-artifacts, accept-node-package, accept-live-artifact-parity]
     runs-on: ubuntu-latest
     environment: release
     steps:
@@ -682,11 +682,225 @@ jobs:
           npm run smoke:legacy-package -- --artifact-directory
           "${{ github.workspace }}/tmp/release-node-package"
 
+  # Exercise the exact Linux wheel pair and the one final multi-native npm
+  # tarball against live TypeDB before any registry mutation. This job consumes
+  # only uploaded release candidates: it performs no source build or repack.
+  accept-live-artifact-parity:
+    name: Accept live artifact parity (Python ${{ matrix.python-version }}, ${{ matrix.typedb-server }})
+    needs: [build-core-wheels, build-python, pack-node-package]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: "3.12"
+            typedb-server: "typedb/typedb:3.8.3"
+            expect-given: "0"
+          - python-version: "3.13.5"
+            typedb-server: "typedb/typedb:3.11.5"
+            expect-given: "0"
+          - python-version: "3.14"
+            typedb-server: "typedb/typedb:3.12.1"
+            expect-given: "1"
+    services:
+      typedb:
+        image: ${{ matrix.typedb-server }}
+        ports:
+          - 1729:1729
+          - 8000:8000
+    env:
+      USE_DOCKER: "false"
+      TYPEDB_ADDRESS: localhost:1729
+      TYPEDB_HTTP_PORT: "8000"
+      TYPE_BRIDGE_PARITY_STRICT: "1"
+      TYPE_BRIDGE_PARITY_EXPECT_GIVEN: ${{ matrix.expect-given }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          enable-cache: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Download exact Linux x64 core wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: core-wheels-linux-x86_64
+          path: tmp/release-live-artifacts/core
+
+      - name: Download exact root Python distribution
+        uses: actions/download-artifact@v4
+        with:
+          name: python-dist
+          path: tmp/release-live-artifacts/root
+
+      - name: Download exact multi-native npm tarball
+        uses: actions/download-artifact@v4
+        with:
+          name: node-package
+          path: tmp/release-live-artifacts/node
+
+      - name: Export exact release candidate paths
+        run: |
+          mapfile -t core_wheels < <(
+            find tmp/release-live-artifacts/core -maxdepth 1 -type f \
+              -name 'type_bridge_core-*linux*x86_64.whl' -print
+          )
+          mapfile -t root_wheels < <(
+            find tmp/release-live-artifacts/root -maxdepth 1 -type f \
+              -name 'type_bridge-*.whl' -print
+          )
+          mapfile -t node_packages < <(
+            find tmp/release-live-artifacts/node -maxdepth 1 -type f \
+              -name '*.tgz' -print
+          )
+          if [[ ${#core_wheels[@]} -ne 1 ]]; then
+            printf 'Expected one Linux x64 core wheel, found %s\n' \
+              "${#core_wheels[@]}" >&2
+            exit 1
+          fi
+          if [[ ${#root_wheels[@]} -ne 1 ]]; then
+            printf 'Expected one root Python wheel, found %s\n' \
+              "${#root_wheels[@]}" >&2
+            exit 1
+          fi
+          if [[ ${#node_packages[@]} -ne 1 ]]; then
+            printf 'Expected one multi-native npm tarball, found %s\n' \
+              "${#node_packages[@]}" >&2
+            exit 1
+          fi
+          printf 'TYPE_BRIDGE_PARITY_CORE_WHEEL=%s\n' \
+            "$(realpath "${core_wheels[0]}")" >> "$GITHUB_ENV"
+          printf 'TYPE_BRIDGE_PARITY_ROOT_WHEEL=%s\n' \
+            "$(realpath "${root_wheels[0]}")" >> "$GITHUB_ENV"
+          printf 'TYPE_BRIDGE_PARITY_NODE_PACKAGE=%s\n' \
+            "$(realpath "${node_packages[0]}")" >> "$GITHUB_ENV"
+
+      - name: Prepare exact-wheel parity environment
+        run: |
+          parity_venv="$RUNNER_TEMP/release-live-parity"
+          uv venv --python python "$parity_venv"
+          uv pip install --python "$parity_venv/bin/python" \
+            "$TYPE_BRIDGE_PARITY_CORE_WHEEL" \
+            "$TYPE_BRIDGE_PARITY_ROOT_WHEEL" \
+            'pytest>=9.0.1' 'pyright>=1.1.407'
+
+      - name: Wait for TypeDB connect and version endpoints
+        run: |
+          for i in {1..30}; do
+            if nc -z localhost 1729 2>/dev/null \
+              && curl --fail --silent http://localhost:8000/v1/version >/dev/null; then
+              echo "TypeDB is ready on ports 1729 and 8000"
+              break
+            fi
+            echo "Waiting for TypeDB endpoints... ($i/30)"
+            sleep 2
+          done
+          if ! nc -z localhost 1729 2>/dev/null \
+            || ! curl --fail --silent http://localhost:8000/v1/version >/dev/null; then
+            echo "ERROR: TypeDB did not become ready within 60 seconds"
+            docker logs ${{ job.services.typedb.id }} 2>&1 || true
+            exit 1
+          fi
+
+      - name: Run exact-artifact live F8 parity
+        env:
+          TYPE_BRIDGE_LIVE_PARITY_REPORT: ${{ runner.temp }}/release-live-parity.xml
+        run: |
+          cd "$RUNNER_TEMP"
+          PATH="$RUNNER_TEMP/release-live-parity/bin:$PATH" \
+            "$RUNNER_TEMP/release-live-parity/bin/python" -I - <<'PY'
+          import importlib
+          import os
+          import sys
+          from pathlib import Path
+
+          workspace = Path(os.environ["GITHUB_WORKSPACE"]).resolve()
+          environment = Path(sys.prefix).resolve()
+          for module_name in ("type_bridge", "type_bridge_core"):
+              module = importlib.import_module(module_name)
+              module_path = Path(module.__file__).resolve()
+              if module_path == workspace or workspace in module_path.parents:
+                  raise SystemExit(
+                      f"{module_name} leaked to the source checkout: {module_path}"
+                  )
+              if module_path != environment and environment not in module_path.parents:
+                  raise SystemExit(
+                      f"{module_name} escaped the exact-wheel environment: {module_path}"
+                  )
+
+          import pytest
+
+          sys.path.insert(0, str(workspace))
+          test = (
+              workspace
+              / "tests/integration/parity/test_typed_query_live_parity.py"
+          )
+          test_node = (
+              f"{test}::test_live_typed_query_summary_and_f8_contract_match_built_artifacts"
+          )
+          raise SystemExit(
+              pytest.main(
+                  [
+                      test_node,
+                      "--rootdir",
+                      str(workspace),
+                      "--import-mode=importlib",
+                      "-o",
+                      "addopts=",
+                      "-m",
+                      "integration",
+                      "-ra",
+                      "--tb=short",
+                      f"--junitxml={os.environ['TYPE_BRIDGE_LIVE_PARITY_REPORT']}",
+                  ]
+              )
+          )
+          PY
+
+      - name: Require one passing live artifact regression
+        env:
+          TYPE_BRIDGE_LIVE_PARITY_REPORT: ${{ runner.temp }}/release-live-parity.xml
+        run: |
+          python - <<'PY'
+          import os
+          import xml.etree.ElementTree as ET
+          from pathlib import Path
+
+          report = Path(os.environ["TYPE_BRIDGE_LIVE_PARITY_REPORT"])
+          if not report.is_file():
+              raise SystemExit(f"Live artifact parity report is missing: {report}")
+          root = ET.parse(report).getroot()
+          suites = [root] if root.tag == "testsuite" else list(root.iter("testsuite"))
+          totals = {
+              key: sum(int(suite.get(key, "0")) for suite in suites)
+              for key in ("tests", "failures", "errors", "skipped")
+          }
+          expected_name = "test_live_typed_query_summary_and_f8_contract_match_built_artifacts"
+          names = [case.get("name") for case in root.iter("testcase")]
+          print(f"live artifact parity: totals={totals} tests={names}")
+          if totals != {"tests": 1, "failures": 0, "errors": 0, "skipped": 0}:
+              raise SystemExit(f"Live artifact parity did not pass exactly once: {totals}")
+          if names != [expected_name]:
+              raise SystemExit(f"Unexpected live artifact parity test cases: {names}")
+          PY
+
   # Publish only the accepted tarball. The job stays inert when NPM_TOKEN is
   # absent, so tagging a release still succeeds without registry credentials.
   publish-node-npm:
     name: Publish Node package to npm
-    needs: [validate-release-identity, accept-python-artifacts, accept-node-package]
+    needs: [validate-release-identity, accept-python-artifacts, accept-node-package, accept-live-artifact-parity]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -769,7 +983,7 @@ jobs:
   # Publish type-bridge-core to PyPI (must complete before type-bridge)
   publish-core-pypi:
     name: Publish type-bridge-core to PyPI
-    needs: [validate-release-identity, build-core-wheels, build-core-sdist, accept-python-artifacts, accept-node-package]
+    needs: [validate-release-identity, build-core-wheels, build-core-sdist, accept-python-artifacts, accept-node-package, accept-live-artifact-parity]
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -833,7 +1047,7 @@ jobs:
   # Publish type-bridge to PyPI (after core is available)
   publish-python-pypi:
     name: Publish type-bridge to PyPI
-    needs: [validate-release-identity, build-python, accept-python-artifacts, accept-node-package, publish-core-pypi]
+    needs: [validate-release-identity, build-python, accept-python-artifacts, accept-node-package, publish-core-pypi, accept-live-artifact-parity]
     runs-on: ubuntu-latest
     environment: release
     permissions:

--- a/docs/guide/typed-queries.md
+++ b/docs/guide/typed-queries.md
@@ -198,6 +198,13 @@ and hydrates exactly those roots in the same transaction snapshot.
 `collect()` preserves matching-solution multiplicity. `distinct()` changes only
 that collection slot and deduplicates by TypeDB concept identity.
 
+Python typed queries currently reject a relation model whose role player is
+another relation while descriptors are being planned, before TypeDB I/O. The
+legacy `Role[Relation]` declaration and CRUD surface remain supported; typed
+recursive relation hydration will require a separate cycle-safe result
+contract. The released TypeScript binding continues to expose its existing
+nonrecursive `ShallowRelationInstance` result for this shape.
+
 ## Count and Existence
 
 Counts and existence use distinct root identity and do not inherit a row/page

--- a/tests/compat/typed_python/live.py
+++ b/tests/compat/typed_python/live.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -104,6 +105,9 @@ def _run(args: argparse.Namespace) -> dict[str, Any]:
     class EmploymentCode(String):
         flags = AttributeFlags(name=labels["employment_code"])
 
+    class EnvelopeCode(String):
+        flags = AttributeFlags(name=labels["envelope_code"])
+
     globals().update(
         {
             "PersonId": PersonId,
@@ -113,6 +117,7 @@ def _run(args: argparse.Namespace) -> dict[str, Any]:
             "CompanyId": CompanyId,
             "CompanyName": CompanyName,
             "EmploymentCode": EmploymentCode,
+            "EnvelopeCode": EnvelopeCode,
         }
     )
 
@@ -145,6 +150,17 @@ def _run(args: argparse.Namespace) -> dict[str, Any]:
         employer: Role[Company] = Role("employer", Company, cardinality=Card(1, 1))
 
     globals()["Employment"] = Employment
+
+    class Envelope(Relation):
+        flags = TypeFlags(name=labels["envelope"])
+        code: EnvelopeCode = Flag(Key)
+        nested: Role[Employment] = Role(
+            "nested",
+            Employment,
+            cardinality=Card(1, 1),
+        )
+
+    globals()["Envelope"] = Envelope
 
     @dataclass(frozen=True, slots=True)
     class PersonWork:
@@ -183,6 +199,15 @@ def _run(args: argparse.Namespace) -> dict[str, Any]:
             raise AssertionError(f"unexpected wheel constructor: {type(thing).__name__}")
         return {"kind": kind, "iid": thing._iid}
 
+    def relation_player_contract(connection: Database) -> dict[str, str]:
+        try:
+            QuerySession(connection).var(Envelope)
+        except TypeError as error:
+            if "cannot materialize nested relation role" not in str(error):
+                raise AssertionError("wheel rejected F8 with the wrong contract") from error
+            return {"contract": "planning-time-rejection"}
+        raise AssertionError("wheel accepted unsupported nested relation-player planning")
+
     database = Database(
         args.address,
         args.database,
@@ -191,6 +216,12 @@ def _run(args: argparse.Namespace) -> dict[str, Any]:
         http_port=args.http_port,
     )
     database.connect()
+    expected_given = os.environ.get("TYPE_BRIDGE_PARITY_EXPECT_GIVEN")
+    if expected_given is not None:
+        if expected_given not in {"0", "1"}:
+            raise AssertionError("TYPE_BRIDGE_PARITY_EXPECT_GIVEN must be either '0' or '1'")
+        if database.supports_given_stage() is not (expected_given == "1"):
+            raise AssertionError("wheel given-stage capability drifted from the release lane")
     person, query = graph_query(database)
     page = query.page_by(
         person,
@@ -231,6 +262,7 @@ def _run(args: argparse.Namespace) -> dict[str, Any]:
     }
     if semantic_projection != contract["semantic_corpus_projection"]:
         raise AssertionError("wheel semantic projection drifted from the #171 identity manifest")
+    relation_player = relation_player_contract(database)
     with database.transaction("read") as transaction:
         borrowed_person, borrowed_query = graph_query(transaction)
         borrowed = {
@@ -270,6 +302,7 @@ def _run(args: argparse.Namespace) -> dict[str, Any]:
         "count": count,
         "exists": exists,
         "semantic_corpus_projection": semantic_projection,
+        "relation_player": relation_player,
         "borrowed": borrowed,
     }
     _assert_artifact_imports(artifact_root, source_root)

--- a/tests/integration/parity/cross_language.py
+++ b/tests/integration/parity/cross_language.py
@@ -11,7 +11,7 @@ import sys
 import tarfile
 import tempfile
 from datetime import datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 import pytest
@@ -55,6 +55,7 @@ TYPED_QUERY_FIXTURE = Path(__file__).with_name("fixtures") / "typed-query" / "co
 TYPED_PYTHON_ARTIFACT_RUNNER = REPO_ROOT / "scripts" / "ci" / "run_typed_python_artifact.py"
 PARITY_ROOT_WHEEL_ENV = "TYPE_BRIDGE_PARITY_ROOT_WHEEL"
 PARITY_CORE_WHEEL_ENV = "TYPE_BRIDGE_PARITY_CORE_WHEEL"
+PARITY_NODE_PACKAGE_ENV = "TYPE_BRIDGE_PARITY_NODE_PACKAGE"
 
 ENTITY_CLASSES = {
     "parity-person": ParityPerson,
@@ -240,21 +241,38 @@ def read_typed_query_with_packed_node(
 ) -> dict[str, Any]:
     """Run the live typed-query reader from an isolated packed Node artifact.
 
-    This deliberately performs no dependency installation. The already-built
-    package is packed with lifecycle scripts disabled, extracted into a fresh
-    ignored consumer, and resolved only by its public package subpaths.
+    This deliberately performs no dependency installation. Release acceptance
+    supplies the exact immutable tarball through
+    ``TYPE_BRIDGE_PARITY_NODE_PACKAGE``; local/source parity retains the
+    existing lifecycle-disabled ``npm pack`` fallback. Either artifact is
+    extracted into a fresh ignored consumer and resolved only by its public
+    package subpaths.
     """
     if shutil.which("node") is None:
         pytest.skip("node executable is not installed")
-    if shutil.which("npm") is None:
-        pytest.skip("npm executable is not installed")
-    if (
-        not (NODE_PACKAGE_DIR / "dist" / "index.js").exists()
-        or not (NODE_PACKAGE_DIR / "dist" / "typed" / "index.js").exists()
-    ):
-        pytest.skip("compiled Node package not built; run `npm run build:types` in the node crate")
-    if not any(NODE_PACKAGE_DIR.glob("*.node")):
-        pytest.skip("native node module not built; run `npm run build:native` in the node crate")
+
+    supplied_package_raw = os.environ.get(PARITY_NODE_PACKAGE_ENV)
+    supplied_package: Path | None = None
+    if supplied_package_raw is not None:
+        supplied_package = Path(supplied_package_raw).expanduser().resolve()
+        if not supplied_package.is_file() or supplied_package.suffix != ".tgz":
+            raise AssertionError(
+                f"{PARITY_NODE_PACKAGE_ENV} must name one prebuilt .tgz file: {supplied_package}"
+            )
+    else:
+        if shutil.which("npm") is None:
+            pytest.skip("npm executable is not installed")
+        if (
+            not (NODE_PACKAGE_DIR / "dist" / "index.js").exists()
+            or not (NODE_PACKAGE_DIR / "dist" / "typed" / "index.js").exists()
+        ):
+            pytest.skip(
+                "compiled Node package not built; run `npm run build:types` in the node crate"
+            )
+        if not any(NODE_PACKAGE_DIR.glob("*.node")):
+            pytest.skip(
+                "native node module not built; run `npm run build:native` in the node crate"
+            )
 
     repo_tmp = REPO_ROOT / "tmp"
     repo_tmp.mkdir(exist_ok=True)
@@ -267,30 +285,59 @@ def read_typed_query_with_packed_node(
         unpack_root.mkdir()
         (consumer_root / "node_modules" / "@type-bridge").mkdir(parents=True)
 
-        packed = subprocess.run(
-            [
-                "npm",
-                "pack",
-                "--ignore-scripts",
-                "--json",
-                "--pack-destination",
-                str(pack_root),
-            ],
-            check=False,
-            cwd=NODE_PACKAGE_DIR,
-            capture_output=True,
-            text=True,
-        )
-        if packed.returncode != 0:
-            raise AssertionError(
-                f"npm pack failed\nstdout:\n{packed.stdout}\nstderr:\n{packed.stderr}"
+        if supplied_package is None:
+            packed = subprocess.run(
+                [
+                    "npm",
+                    "pack",
+                    "--ignore-scripts",
+                    "--json",
+                    "--pack-destination",
+                    str(pack_root),
+                ],
+                check=False,
+                cwd=NODE_PACKAGE_DIR,
+                capture_output=True,
+                text=True,
             )
-        try:
-            pack_info = json.loads(packed.stdout)[0]
-            packed_paths = {entry["path"] for entry in pack_info["files"]}
-            tarball = pack_root / pack_info["filename"]
-        except (IndexError, KeyError, TypeError, json.JSONDecodeError) as error:
-            raise AssertionError(f"could not parse npm pack output: {packed.stdout}") from error
+            if packed.returncode != 0:
+                raise AssertionError(
+                    f"npm pack failed\nstdout:\n{packed.stdout}\nstderr:\n{packed.stderr}"
+                )
+            try:
+                pack_info = json.loads(packed.stdout)[0]
+                packed_paths = {entry["path"] for entry in pack_info["files"]}
+                tarball = pack_root / pack_info["filename"]
+            except (IndexError, KeyError, TypeError, json.JSONDecodeError) as error:
+                raise AssertionError(f"could not parse npm pack output: {packed.stdout}") from error
+        else:
+            tarball = supplied_package
+            packed_paths: set[str] = set()
+            with tarfile.open(tarball, "r:gz") as archive:
+                for member in archive.getmembers():
+                    if member.name.rstrip("/") == "package":
+                        continue
+                    if not member.name.startswith("package/"):
+                        raise AssertionError(
+                            f"prebuilt Node artifact entry is outside package/: {member.name}"
+                        )
+                    relative = member.name.removeprefix("package/").rstrip("/")
+                    path = PurePosixPath(relative)
+                    if (
+                        not relative
+                        or "\\" in relative
+                        or path.is_absolute()
+                        or path.as_posix() != relative
+                        or any(part in {"", ".", ".."} for part in path.parts)
+                    ):
+                        raise AssertionError(
+                            f"prebuilt Node artifact has an unsafe path: {member.name}"
+                        )
+                    if relative in packed_paths:
+                        raise AssertionError(
+                            f"prebuilt Node artifact has a duplicate path: {relative}"
+                        )
+                    packed_paths.add(relative)
 
         required = {"dist/index.js", "dist/typed/index.js", "dist/typed/index.d.ts"}
         if not required <= packed_paths or not any(path.endswith(".node") for path in packed_paths):

--- a/tests/integration/parity/fixtures/typed-query/contract.json
+++ b/tests/integration/parity/fixtures/typed-query/contract.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "labels": {
     "person_id": "parity-query-person-id",
     "person_name": "parity-query-person-name",
@@ -8,11 +8,13 @@
     "company_id": "parity-query-company-id",
     "company_name": "parity-query-company-name",
     "employment_code": "parity-query-employment-code",
+    "envelope_code": "parity-query-envelope-code",
     "person": "parity-query-person",
     "employee": "parity-query-employee",
     "contractor": "parity-query-contractor",
     "company": "parity-query-company",
-    "employment": "parity-query-employment"
+    "employment": "parity-query-employment",
+    "envelope": "parity-query-envelope"
   },
   "expected": {
     "root_keys": [
@@ -38,7 +40,13 @@
         "acme"
       ]
     },
-    "total": 2
+    "total": 2,
+    "relation_player": {
+      "envelope_code": "F8-1",
+      "employment_code": "E-1",
+      "employee_id": "alice",
+      "employer_id": "acme"
+    }
   },
   "semantic_corpus_projection": {
     "source_fixture": "identity-main",

--- a/tests/integration/parity/fixtures/typed-query/data.tql
+++ b/tests/integration/parity/fixtures/typed-query/data.tql
@@ -29,3 +29,6 @@ $e3 isa parity-query-employment,
 $e4 isa parity-query-employment,
     links (employee: $bob, employer: $acme),
     has parity-query-employment-code "E-4";
+$envelope isa parity-query-envelope,
+    links (nested: $e1),
+    has parity-query-envelope-code "F8-1";

--- a/tests/integration/parity/fixtures/typed-query/schema.tql
+++ b/tests/integration/parity/fixtures/typed-query/schema.tql
@@ -6,6 +6,7 @@ attribute parity-query-specialty, value string;
 attribute parity-query-company-id, value string;
 attribute parity-query-company-name, value string;
 attribute parity-query-employment-code, value string;
+attribute parity-query-envelope-code, value string;
 
 entity parity-query-person,
     owns parity-query-person-id @key,
@@ -22,4 +23,8 @@ entity parity-query-company,
 relation parity-query-employment,
     relates employee @card(1..1),
     relates employer @card(1..1),
-    owns parity-query-employment-code @key;
+    owns parity-query-employment-code @key,
+    plays parity-query-envelope:nested;
+relation parity-query-envelope,
+    relates nested @card(1..1),
+    owns parity-query-envelope-code @key;

--- a/tests/integration/parity/node_typed_query_reader.cjs
+++ b/tests/integration/parity/node_typed_query_reader.cjs
@@ -46,6 +46,7 @@ class Specialty extends attr.String(labels.specialty) {}
 class CompanyId extends attr.String(labels.company_id) {}
 class CompanyName extends attr.String(labels.company_name) {}
 class EmploymentCode extends attr.String(labels.employment_code) {}
+class EnvelopeCode extends attr.String(labels.envelope_code) {}
 
 class Person extends Entity(labels.person, {
   person_id: field(PersonId, Key),
@@ -70,8 +71,19 @@ class Employment extends Relation(labels.employment, {
   employer: role(Company, { cardinality: Card(1, 1) }),
 }) {}
 
+class Envelope extends Relation(labels.envelope, {
+  code: field(EnvelopeCode, Key),
+  nested: role(Employment, { cardinality: Card(1, 1) }),
+}) {}
+
 function registeredSession(connection) {
-  return new QuerySession(connection).registerModels(Employee, Contractor, Company, Employment);
+  return new QuerySession(connection).registerModels(
+    Employee,
+    Contractor,
+    Company,
+    Employment,
+    Envelope,
+  );
 }
 
 function graphQuery(connection) {
@@ -100,15 +112,82 @@ function graphQuery(connection) {
   return { person, personRefs, query };
 }
 
+function relationPlayerQuery(connection) {
+  const session = registeredSession(connection);
+  const envelope = session.var(Envelope, "exact");
+  const employment = session.var(Employment, "exact");
+  const envelopeRefs = references(Envelope);
+  return session
+    .queryNamed({ envelope, selected: employment })
+    .where(
+      envelope.role(envelopeRefs.roles.nested).connects(employment),
+      envelope
+        .field(envelopeRefs.fields.code)
+        .eq(new EnvelopeCode(expected.relation_player.envelope_code)),
+    );
+}
+
 function identity(thing) {
   assert.equal(typeof thing._iid, "string", "hydrated things must carry an IID");
   let kind;
   if (thing instanceof Employee) kind = "employee";
   else if (thing instanceof Contractor) kind = "contractor";
   else if (thing instanceof Company) kind = "company";
+  else if (thing instanceof Envelope) kind = "envelope";
   else if (thing instanceof Employment) kind = "employment";
   else throw new TypeError("unknown typed-query parity constructor");
   return { kind, iid: thing._iid };
+}
+
+function relationPlayerSummary(connection) {
+  const relationExpected = expected.relation_player;
+  const row = relationPlayerQuery(connection).one();
+  const nested = row.envelope.nested;
+  const selected = row.selected;
+
+  assert.ok(row.envelope instanceof Envelope, "envelope must retain its concrete model");
+  assert.ok(nested instanceof Employment, "nested relation must retain its concrete model");
+  assert.ok(selected instanceof Employment, "selected relation must retain its concrete model");
+  assert.equal(nested._iid, selected._iid, "shallow and selected views must share an IID");
+  assert.notStrictEqual(nested, selected, "hydration states must not alias one object");
+  assert.equal(nested.code.value, relationExpected.employment_code);
+  assert.equal(row.envelope.code.value, relationExpected.envelope_code);
+  assert.equal(selected.code.value, relationExpected.employment_code);
+  assert.equal(selected.employee.person_id.value, relationExpected.employee_id);
+  assert.equal(selected.employer.company_id.value, relationExpected.employer_id);
+  assert.equal(nested.employee, undefined);
+  assert.equal(nested.employer, undefined);
+  for (const roleName of ["employee", "employer"]) {
+    assert.deepEqual(Object.getOwnPropertyDescriptor(nested, roleName), {
+      value: undefined,
+      writable: false,
+      enumerable: true,
+      configurable: false,
+    });
+  }
+  assert.ok(Object.isFrozen(nested), "shallow nested relation must be frozen");
+
+  return {
+    contract: "shallow-nonrecursive",
+    envelope: {
+      identity: identity(row.envelope),
+      code: row.envelope.code.value,
+    },
+    shallow: {
+      identity: identity(nested),
+      code: nested.code.value,
+      roles_materialized: false,
+    },
+    selected: {
+      identity: identity(selected),
+      code: selected.code.value,
+      roles_materialized: true,
+      employee: identity(selected.employee),
+      employer: identity(selected.employer),
+    },
+    same_iid: nested._iid === selected._iid,
+    distinct_objects: nested !== selected,
+  };
 }
 
 function summarize(db) {
@@ -156,6 +235,7 @@ function summarize(db) {
     exists_by_person: exists,
   };
   assert.deepEqual(semanticProjection, contract.semantic_corpus_projection);
+  const relationPlayer = relationPlayerSummary(db);
 
   const tx = db.transaction("read");
   let borrowed;
@@ -196,6 +276,7 @@ function summarize(db) {
     count: Number(count),
     exists,
     semantic_corpus_projection: semanticProjection,
+    relation_player: relationPlayer,
     borrowed,
   };
 }

--- a/tests/integration/parity/test_typed_query_live_parity.py
+++ b/tests/integration/parity/test_typed_query_live_parity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from typing import Any
 
@@ -21,6 +22,7 @@ from tests.integration.parity.typed_query_models import (
     ParityQueryContractor,
     ParityQueryEmployee,
     ParityQueryEmployment,
+    ParityQueryEnvelope,
     ParityQueryPerson,
     load_typed_query_contract,
 )
@@ -66,6 +68,15 @@ def _identity(thing: TypeDBType) -> dict[str, str]:
     else:  # pragma: no cover - a materializer defect should fail loudly
         raise TypeError(f"unknown typed-query parity constructor: {type(thing).__name__}")
     return {"kind": kind, "iid": thing._iid}
+
+
+def _python_relation_player_contract(
+    connection: Database | TransactionContext,
+) -> dict[str, str]:
+    session = QuerySession(connection)
+    with pytest.raises(TypeError, match="cannot materialize nested relation role"):
+        session.var(ParityQueryEnvelope)
+    return {"contract": "planning-time-rejection"}
 
 
 def _python_summary(db: Database) -> dict[str, Any]:
@@ -114,6 +125,7 @@ def _python_summary(db: Database) -> dict[str, Any]:
         "exists_by_person": exists,
     }
     assert semantic_projection == contract["semantic_corpus_projection"]
+    relation_player = _python_relation_player_contract(db)
 
     with db.transaction("read") as transaction:
         borrowed_person, borrowed_query = _graph_query(transaction)
@@ -154,14 +166,22 @@ def _python_summary(db: Database) -> dict[str, Any]:
         "count": count,
         "exists": exists,
         "semantic_corpus_projection": semantic_projection,
+        "relation_player": relation_player,
         "borrowed": borrowed,
     }
 
 
 @pytest.mark.integration
-def test_live_typed_query_summary_matches_built_artifacts(clean_db, monkeypatch) -> None:
-    """Source Python and both built artifacts return one live identity graph."""
+def test_live_typed_query_summary_and_f8_contract_match_built_artifacts(
+    clean_db,
+    monkeypatch,
+) -> None:
+    """Built Python rejects F8 while packed Node preserves its shallow V1 result."""
     monkeypatch.delenv("TYPE_BRIDGE_BACKEND", raising=False)
+    expected_given = os.environ.get("TYPE_BRIDGE_PARITY_EXPECT_GIVEN")
+    if expected_given is not None:
+        assert expected_given in {"0", "1"}
+        assert clean_db.supports_given_stage() is (expected_given == "1")
     clean_db.execute_query(SCHEMA_PATH.read_text(encoding="utf-8"), transaction_type="schema")
     clean_db.execute_query(DATA_PATH.read_text(encoding="utf-8"), transaction_type="write")
 
@@ -182,4 +202,13 @@ def test_live_typed_query_summary_matches_built_artifacts(clean_db, monkeypatch)
     )
 
     assert node_result["artifact"] == "packed"
-    assert node_result["summary"] == python_summary
+    node_summary = node_result["summary"]
+    assert python_summary["relation_player"] == {"contract": "planning-time-rejection"}
+    assert node_summary["relation_player"]["contract"] == "shallow-nonrecursive"
+    assert node_summary["relation_player"]["shallow"]["roles_materialized"] is False
+    assert node_summary["relation_player"]["selected"]["roles_materialized"] is True
+    assert node_summary["relation_player"]["same_iid"] is True
+    assert node_summary["relation_player"]["distinct_objects"] is True
+    assert {key: value for key, value in node_summary.items() if key != "relation_player"} == {
+        key: value for key, value in python_summary.items() if key != "relation_player"
+    }

--- a/tests/integration/parity/typed_query_models.py
+++ b/tests/integration/parity/typed_query_models.py
@@ -72,6 +72,10 @@ class ParityQueryEmploymentCode(String):
     flags = AttributeFlags(name=_LABELS["employment_code"])
 
 
+class ParityQueryEnvelopeCode(String):
+    flags = AttributeFlags(name=_LABELS["envelope_code"])
+
+
 class ParityQueryPerson(Entity):
     flags = TypeFlags(name=_LABELS["person"])
     person_id: ParityQueryPersonId = Flag(Key)
@@ -105,6 +109,16 @@ class ParityQueryEmployment(Relation):
     employer: Role[ParityQueryCompany] = Role(
         "employer",
         ParityQueryCompany,
+        cardinality=Card(1, 1),
+    )
+
+
+class ParityQueryEnvelope(Relation):
+    flags = TypeFlags(name=_LABELS["envelope"])
+    code: ParityQueryEnvelopeCode = Flag(Key)
+    nested: Role[ParityQueryEmployment] = Role(
+        "nested",
+        ParityQueryEmployment,
         cardinality=Card(1, 1),
     )
 

--- a/tests/unit/infra/test_release_artifact_gates.py
+++ b/tests/unit/infra/test_release_artifact_gates.py
@@ -2,10 +2,17 @@
 
 from __future__ import annotations
 
+import io
 import json
 import re
+import subprocess
+import tarfile
 import tomllib
 from pathlib import Path
+
+import pytest
+
+from tests.integration.parity import cross_language
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 CI_WORKFLOW = REPO_ROOT / ".github/workflows/ci.yml"
@@ -195,18 +202,20 @@ def test_registry_publication_waits_for_global_release_candidate_gates() -> None
     node_acceptance = job_block(workflow, "accept-node-package")
 
     assert needs_line(crates_publish) == (
-        "    needs: [validate-release-identity, accept-python-artifacts, accept-node-package]"
+        "    needs: [validate-release-identity, accept-python-artifacts, "
+        "accept-node-package, accept-live-artifact-parity]"
     )
     assert needs_line(node_publish) == (
-        "    needs: [validate-release-identity, accept-python-artifacts, accept-node-package]"
+        "    needs: [validate-release-identity, accept-python-artifacts, "
+        "accept-node-package, accept-live-artifact-parity]"
     )
     assert needs_line(core_publish) == (
         "    needs: [validate-release-identity, build-core-wheels, build-core-sdist, "
-        "accept-python-artifacts, accept-node-package]"
+        "accept-python-artifacts, accept-node-package, accept-live-artifact-parity]"
     )
     assert needs_line(root_publish) == (
         "    needs: [validate-release-identity, build-python, accept-python-artifacts, "
-        "accept-node-package, publish-core-pypi]"
+        "accept-node-package, publish-core-pypi, accept-live-artifact-parity]"
     )
     assert "publish-crates" not in needs_line(python_acceptance)
     assert "publish-crates" not in needs_line(node_acceptance)
@@ -221,6 +230,163 @@ def test_node_native_crate_configures_napi_platform_linking() -> None:
     assert (crate_root / "build.rs").read_text(encoding="utf-8") == (
         "fn main() {\n    napi_build::setup();\n}\n"
     )
+
+
+def test_live_release_parity_consumes_exact_artifacts_before_every_publish() -> None:
+    """The live F8 gate must execute uploaded candidates without rebuilding."""
+    workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    acceptance = job_block(workflow, "accept-live-artifact-parity")
+
+    assert needs_line(acceptance) == (
+        "    needs: [build-core-wheels, build-python, pack-node-package]"
+    )
+    assert re.findall(
+        r'^          - python-version: "([^"]+)"\n'
+        r'            typedb-server: "([^"]+)"\n'
+        r'            expect-given: "([01])"$',
+        acceptance,
+        re.MULTILINE,
+    ) == [
+        ("3.12", "typedb/typedb:3.8.3", "0"),
+        ("3.13.5", "typedb/typedb:3.11.5", "0"),
+        ("3.14", "typedb/typedb:3.12.1", "1"),
+    ]
+    assert "image: ${{ matrix.typedb-server }}" in acceptance
+    assert "python-version: ${{ matrix.python-version }}" in acceptance
+    assert "- 1729:1729" in acceptance
+    assert "- 8000:8000" in acceptance
+    assert "curl --fail --silent http://localhost:8000/v1/version" in acceptance
+
+    for artifact in (
+        "core-wheels-linux-x86_64",
+        "python-dist",
+        "node-package",
+    ):
+        assert f"name: {artifact}" in acceptance
+    assert "type_bridge_core-*linux*x86_64.whl" in acceptance
+    assert "TYPE_BRIDGE_PARITY_CORE_WHEEL" in acceptance
+    assert "TYPE_BRIDGE_PARITY_ROOT_WHEEL" in acceptance
+    assert "TYPE_BRIDGE_PARITY_NODE_PACKAGE" in acceptance
+    assert 'TYPE_BRIDGE_PARITY_STRICT: "1"' in acceptance
+    assert "TYPE_BRIDGE_PARITY_EXPECT_GIVEN: ${{ matrix.expect-given }}" in acceptance
+    assert 'USE_DOCKER: "false"' in acceptance
+
+    assert "uv venv" in acceptance
+    assert "uv pip install" in acceptance
+    assert 'for module_name in ("type_bridge", "type_bridge_core")' in acceptance
+    assert "leaked to the source checkout" in acceptance
+    assert "escaped the exact-wheel environment" in acceptance
+    assert "test_live_typed_query_summary_and_f8_contract_match_built_artifacts" in acceptance
+    assert "--import-mode=importlib" in acceptance
+    assert "release-live-parity.xml" in acceptance
+    assert '"tests": 1' in acceptance
+    assert '"failures": 0' in acceptance
+    assert '"errors": 0' in acceptance
+    assert '"skipped": 0' in acceptance
+
+    for forbidden in (
+        "uv sync",
+        "uv build",
+        "maturin",
+        "npm ci",
+        "npm pack",
+        "npm run build:native",
+        "npm run build:types",
+        "cargo build",
+        "actions/upload-artifact",
+    ):
+        assert forbidden not in acceptance
+
+    helper = (REPO_ROOT / "tests/integration/parity/cross_language.py").read_text(encoding="utf-8")
+    assert 'PARITY_NODE_PACKAGE_ENV = "TYPE_BRIDGE_PARITY_NODE_PACKAGE"' in helper
+    assert "if supplied_package is None:" in helper
+    assert '"npm",\n                    "pack"' in helper
+
+    source_reader = (
+        REPO_ROOT / "tests/integration/parity/test_typed_query_live_parity.py"
+    ).read_text(encoding="utf-8")
+    wheel_reader = (REPO_ROOT / "tests/compat/typed_python/live.py").read_text(encoding="utf-8")
+    node_reader = (REPO_ROOT / "tests/integration/parity/node_typed_query_reader.cjs").read_text(
+        encoding="utf-8"
+    )
+    assert "TYPE_BRIDGE_PARITY_EXPECT_GIVEN" in source_reader
+    assert "TYPE_BRIDGE_PARITY_EXPECT_GIVEN" in wheel_reader
+    assert "session.var(ParityQueryEnvelope)" in source_reader
+    assert "QuerySession(connection).var(Envelope)" in wheel_reader
+    assert "cannot materialize nested relation role" in source_reader
+    assert "cannot materialize nested relation role" in wheel_reader
+    assert ".eq(new EnvelopeCode(expected.relation_player.envelope_code))" in node_reader
+
+    for publisher in (
+        "publish-crates",
+        "publish-node-npm",
+        "publish-core-pypi",
+        "publish-python-pypi",
+    ):
+        assert "accept-live-artifact-parity" in needs_line(job_block(workflow, publisher))
+
+
+def test_live_node_reader_consumes_supplied_tarball_without_npm_pack(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The release path extracts its supplied tarball and never invokes npm."""
+    artifact = tmp_path / "type-bridge-node-test.tgz"
+    members = {
+        "package/dist/index.js": b"module.exports = {};\n",
+        "package/dist/typed/index.js": b"module.exports = {};\n",
+        "package/dist/typed/index.d.ts": b"export {};\n",
+        "package/type_bridge_node.linux-x64-gnu.node": b"native\n",
+    }
+    with tarfile.open(artifact, "w:gz") as archive:
+        for name, content in members.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(content)
+            archive.addfile(info, io.BytesIO(content))
+
+    monkeypatch.setenv(cross_language.PARITY_NODE_PACKAGE_ENV, str(artifact))
+
+    def fake_which(name: str) -> str | None:
+        assert name == "node", "the supplied-artifact path must not inspect npm"
+        return "/usr/bin/node"
+
+    def fake_run(
+        command: list[str],
+        *,
+        check: bool,
+        cwd: Path,
+        env: dict[str, str],
+        capture_output: bool,
+        text: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        assert command == ["node", str(cross_language.PACKED_TYPED_QUERY_READER)]
+        assert check is False
+        assert capture_output is True
+        assert text is True
+        installed = cwd / "node_modules" / "@type-bridge" / "node"
+        assert (installed / "dist/index.js").is_file()
+        assert (installed / "dist/typed/index.js").is_file()
+        assert (installed / "dist/typed/index.d.ts").is_file()
+        assert (installed / "type_bridge_node.linux-x64-gnu.node").is_file()
+        assert env["TYPE_BRIDGE_PACKED_CONSUMER_ROOT"] == str(cwd)
+        assert env["TYPEDB_ADDRESS"] == "localhost:1729"
+        assert env["TYPEDB_HTTP_PORT"] == "8000"
+        assert env["TYPE_BRIDGE_PARITY_DATABASE"] == "artifact-parity"
+        assert "TYPE_BRIDGE_NODE_NATIVE_PATH" not in env
+        payload = {"artifact": "packed", "summary": {"relation_player": "shallow"}}
+        return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
+
+    monkeypatch.setattr(cross_language.shutil, "which", fake_which)
+    monkeypatch.setattr(cross_language.subprocess, "run", fake_run)
+
+    assert cross_language.read_typed_query_with_packed_node(
+        "localhost:1729",
+        "artifact-parity",
+        http_port=8000,
+    ) == {
+        "artifact": "packed",
+        "summary": {"relation_player": "shallow"},
+    }
 
 
 def test_npm_publication_uses_the_accepted_tarball() -> None:
@@ -342,7 +508,10 @@ def test_npm_publication_uses_the_accepted_tarball() -> None:
     assert "npm pack" not in acceptance
     assert "actions/upload-artifact" not in acceptance
 
-    assert "accept-node-package" in needs_line(publish)
+    assert needs_line(publish) == (
+        "    needs: [validate-release-identity, accept-python-artifacts, "
+        "accept-node-package, accept-live-artifact-parity]"
+    )
     assert "name: node-package" in publish
     assert publish.count("scripts/ci/validate_node_release_package.py") == 2
     assert "--repository-package type-bridge-core/crates/node/package.json" in publish

--- a/tests/unit/typed_query/test_named_collected.py
+++ b/tests/unit/typed_query/test_named_collected.py
@@ -392,15 +392,14 @@ def test_query_session_rejects_python_only_entity_and_relation_roots() -> None:
         diagnostic_session().subtypes(PythonOnlyWorkRelation)
 
 
-def test_query_session_accepts_shallow_nested_relation_player_plan() -> None:
+def test_query_session_rejects_nested_relation_player_before_execution() -> None:
     session = diagnostic_session()
-    envelope = session.var(WorkEnvelope)
-    nested = session.var(WorkNestedRelation)
-    connected = envelope.role(WorkEnvelope.nested).connects(nested)
 
-    query = session.query(envelope).match(nested).where(connected)
+    with pytest.raises(TypeError, match="cannot materialize nested relation role"):
+        session.var(WorkEnvelope)
 
-    _assert_connection_required(query.one)
+    assert session._model_constructors() == {}
+    assert session._native_registry().snapshot() == []
 
 
 def test_existing_query_constructor_cannot_be_replaced_by_same_label_class() -> None:

--- a/tests/unit/typed_query/test_results.py
+++ b/tests/unit/typed_query/test_results.py
@@ -658,7 +658,7 @@ def test_materializer_fails_if_constructor_does_not_retain_validated_iid() -> No
     assert raised.value.code == "model_iid_assignment_mismatch"
 
 
-def test_nested_relation_role_player_materializes_nonrecursive_reference() -> None:
+def test_nested_relation_role_player_fails_closed_during_materialization() -> None:
     nested = _RolePlayer(
         "0x20",
         "result-nested-relation",
@@ -675,13 +675,7 @@ def test_nested_relation_role_player_materializes_nonrecursive_reference() -> No
         [_Role("nested", [nested])],
     )
 
-    envelope = _checked_instance(
-        _materialize_one(_native(_Result([_Row([_Slot(relation)])])), _models(), None),
-        ResultEnvelope,
-    )
-    materialized_nested = _checked_instance(envelope.nested, ResultNestedRelation)
+    with pytest.raises(TypedQueryMaterializationError) as raised:
+        _materialize_one(_native(_Result([_Row([_Slot(relation)])])), _models(), None)
 
-    assert envelope._iid == "0x30"
-    assert materialized_nested._iid == "0x20"
-    assert materialized_nested.identifier == ResultIdentity("nested-1")
-    assert materialized_nested.member is None
+    assert raised.value.code == "nested_relation_role_player_unsupported"

--- a/type-bridge-core/crates/node/tests/compat/legacy-package/typed-consumer.ts
+++ b/type-bridge-core/crates/node/tests/compat/legacy-package/typed-consumer.ts
@@ -35,6 +35,9 @@ class PackedEmployment extends Relation("packed-typed-employment", {
   employee: role(PackedPerson),
   employer: role(PackedCompany),
 }) {}
+class PackedEnvelope extends Relation("packed-typed-envelope", {
+  nested: role(PackedEmployment),
+}) {}
 
 type Equal<Left, Right> =
   (<Value>() => Value extends Left ? 1 : 2) extends
@@ -62,9 +65,11 @@ function assertPackedStaticSurface(
   const packedPerson = databaseSession.var(PackedPerson);
   const packedCompany = databaseSession.var(PackedCompany);
   const packedEmployment = databaseSession.var(PackedEmployment);
+  const packedEnvelope = databaseSession.var(PackedEnvelope);
   const personReferences = references(PackedPerson);
   const companyReferences = references(PackedCompany);
   const employmentReferences = references(PackedEmployment);
+  const envelopeReferences = references(PackedEnvelope);
 
   const UnionEntity = Entity(typeNameOrFlags, {});
   const UnionRelation = Relation(typeNameOrFlags, {});
@@ -88,6 +93,30 @@ function assertPackedStaticSurface(
       companies: packedCompany.collect().distinct(),
     })
     .pageBy(packedPerson, { limit: 10 });
+
+  const relationPlayerRow = databaseSession
+    .queryNamed({ envelope: packedEnvelope, selected: packedEmployment })
+    .where(
+      packedEnvelope
+        .role(envelopeReferences.roles.nested)
+        .connects(packedEmployment),
+    )
+    .one();
+  type SelectedEmployment = typeof relationPlayerRow.selected;
+  type ShallowEmployment = Exclude<
+    (typeof relationPlayerRow.envelope)["nested"],
+    readonly unknown[]
+  >;
+  type SelectedEmployeeIsComplete = Expect<
+    Equal<SelectedEmployment["employee"], PackedPerson | readonly PackedPerson[]>
+  >;
+  type SelectedEmployerIsComplete = Expect<
+    Equal<SelectedEmployment["employer"], PackedCompany | readonly PackedCompany[]>
+  >;
+  type ShallowEmployeeIsAbsent = Expect<Equal<ShallowEmployment["employee"], undefined>>;
+  type ShallowEmployerIsAbsent = Expect<Equal<ShallowEmployment["employer"], undefined>>;
+  type ShallowOwnedKeyIsPresent = Expect<Equal<ShallowEmployment["name"], PackedName>>;
+  type ShallowIidIsPresent = Expect<Equal<ShallowEmployment["_iid"], string | null>>;
 
   const single = databaseSession.query(packedPerson).where(
     packedPerson.field(personReferences.fields.name).startsWith("A"),
@@ -136,6 +165,7 @@ function assertPackedStaticSurface(
   void exactPage;
   void exactTotal;
   void workPage;
+  void relationPlayerRow;
   void UnionEntity;
   void UnionRelation;
   void UnionChildEntity;

--- a/type_bridge/typed/results.py
+++ b/type_bridge/typed/results.py
@@ -229,6 +229,12 @@ def _materialize_role_player(
             "role_player_python_type_mismatch",
             f"concrete role player {model.__name__} is not compatible with its Python role",
         )
+    if issubclass(model, Relation):
+        _fail(
+            "nested_relation_role_player_unsupported",
+            "Python typed queries cannot materialize a relation used as a role player "
+            "without a cycle-safe result contract",
+        )
     values = _materialize_attributes(player, model)
     try:
         instance = model(**values)

--- a/type_bridge/typed/session.py
+++ b/type_bridge/typed/session.py
@@ -387,6 +387,7 @@ class QuerySession:
     ) -> None:
         if model in seen:
             return
+        _reject_nested_relation_player_model(model)
         if model in _FRAMEWORK_MODEL_ROOTS:
             seen.add(model)
             return
@@ -439,6 +440,22 @@ class QuerySession:
             if not subtype.is_base():
                 self._register_descriptor_closure(subtype, seen, subtype_roots)
             self._register_loaded_subtypes(subtype, seen, subtype_roots)
+
+
+def _reject_nested_relation_player_model(model: type[TypeDBType]) -> None:
+    """Reject Python result shapes that require recursive relation hydration."""
+    if not issubclass(model, Relation):
+        return
+    for relation_type in reversed(model.__mro__):
+        roles = relation_type.__dict__.get("_roles", {})
+        for role in roles.values():
+            for player in role.player_entity_types:
+                if isinstance(player, type) and issubclass(player, Relation):
+                    raise TypeError(
+                        "Python typed queries cannot materialize nested relation role "
+                        f"{model.__name__}.{role.role_name} with relation player "
+                        f"{player.__name__}; a cycle-safe result contract is required"
+                    )
 
 
 def _named_declaration(


### PR DESCRIPTION
## Summary

- preserve released Python `Role[Relation]` declarations and CRUD behavior
- reject nested relation-player Python typed-query shapes during descriptor
  planning, before provider I/O
- fail closed if unsupported relation-player evidence reaches Python result
  materialization
- gate every registry publisher on live execution of the exact candidate
  wheels and packed Node tarball
- use TypeDB 3.12.1 for the current Python 3.14 / driver-band-9 release lane

## Contract decision

This PR deliberately does not publish `RelationRole`, `ShallowRelationRef`, or
a second public `Role` generic. Python cannot currently represent a nested
relation player as a complete relation without lying about unmaterialized
roles, so its initial contract is planning-time rejection.

The already-released Node binding keeps its nonrecursive
`ShallowRelationInstance` result. The live artifact regression proves both
binding-specific outcomes against the same relation-player fixture.

## Key changes

- add Python planner and defensive materializer F8 gates
- extend the shared typed-query fixture with a relation playing a relation role
- prove source and wheel Python reject before execution
- prove the packed Node artifact returns a frozen shallow relation with the
  same IID as the separately selected complete relation
- consume uploaded release candidates without rebuilding or repacking them
- make crates.io, npm, core PyPI, and root PyPI publication depend on the live
  artifact gate

## Verification

- `./scripts/check.sh python` — Ruff, formatting, both Pyright trees, static
  negative query checks, and 2,109 Python unit tests passed
- focused F8/result/release-gate tests — 39 passed
- `npm run typecheck -- --pretty false` — passed
- `npm run test:unit` — 124 passed
- `npm run smoke:legacy-package` — packed 1.5.8 consumer passed
- rebuilt the root wheel, abi3 core wheel, and Node tarball, then ran the exact
  artifacts live against `typedb/typedb:3.12.1` — 1 passed
- workflow YAML, fixture JSON, and packed Node reader syntax checks passed

Parts of #170
