### PR TITLE
fix(migration): plan and apply added sub types correctly (#190)

### DIFF
--- a/type-bridge-core/crates/migration/src/author/map.rs
+++ b/type-bridge-core/crates/migration/src/author/map.rs
@@ -8,8 +8,8 @@
 //!    attribute, staged plain ownerships, data backfill, annotation
 //!    tightening)
 //! 2. modified attribute type definitions (`RunTypeql` define/redefine)
-//! 3. added entities
-//! 4. added relations
+//! 3. added entities (parents before children)
+//! 4. added relations (parents before children)
 //! 5. modified entities (ownerships, then header changes)
 //! 6. modified relations (ownerships, roles, role players, cardinality,
 //!    then header changes)
@@ -28,8 +28,12 @@ use std::collections::BTreeSet;
 use std::collections::BTreeMap;
 
 use type_bridge_orm::schema::diff::{AttributeTypeChanges, SchemaDiff};
-use type_bridge_orm::schema::generator::{attribute_constraint_definition, card_annotation};
-use type_bridge_orm::schema::info::{OwnedAttributeEntry, SchemaInfo};
+use type_bridge_orm::schema::generator::{
+    attribute_constraint_definition, card_annotation, topological_sort,
+};
+use type_bridge_orm::schema::info::{
+    EntitySchemaEntry, OwnedAttributeEntry, RelationSchemaEntry, SchemaInfo,
+};
 
 use crate::error::MigrationError;
 use crate::spec::OperationSpec;
@@ -98,23 +102,36 @@ pub fn map_schema_diff(
         }
     }
 
+    // Added types are emitted parents-before-children and reduced to their
+    // own declarations: each `Add*` lowers to a singleton define with no
+    // parent in scope, so a child emitted first would reference an undefined
+    // supertype, and a flattened entry would redeclare inherited
+    // capabilities, which TypeDB rejects (#190).
+    let mut added_entities = BTreeMap::new();
     for entity_name in &diff.added_entities {
         let entity = target
             .entities
             .get(entity_name)
             .ok_or_else(|| missing("added entity", entity_name, "target"))?;
+        added_entities.insert(entity_name.clone(), entity);
+    }
+    for entity_name in topological_sort(&added_entities, |e| e.parent_type.as_deref()) {
         operations.push(OperationSpec::AddEntity {
-            entity: entity.clone(),
+            entity: declared_entity_entry(added_entities[&entity_name], target),
         });
     }
 
+    let mut added_relations = BTreeMap::new();
     for relation_name in &diff.added_relations {
         let relation = target
             .relations
             .get(relation_name)
             .ok_or_else(|| missing("added relation", relation_name, "target"))?;
+        added_relations.insert(relation_name.clone(), relation);
+    }
+    for relation_name in topological_sort(&added_relations, |r| r.parent_type.as_deref()) {
         operations.push(OperationSpec::AddRelation {
-            relation: relation.clone(),
+            relation: declared_relation_entry(added_relations[&relation_name], target),
         });
     }
 
@@ -607,6 +624,65 @@ fn type_annotation_change(
     })
 }
 
+/// Reduce a flattened entity entry to its own declarations by dropping
+/// attributes the parent already owns.
+///
+/// `SchemaInfo` entries carry the inheritance-resolved effective set. A
+/// full-schema define block skips inherited capabilities by consulting the
+/// parent entry, but the singleton `AddEntity` lowering has no parent in
+/// scope — anything left in the entry is emitted verbatim, and TypeDB
+/// rejects redeclaring an inherited capability on a subtype (#190).
+fn declared_entity_entry(entity: &EntitySchemaEntry, target: &SchemaInfo) -> EntitySchemaEntry {
+    let mut entity = entity.clone();
+    if let Some(parent) = entity
+        .parent_type
+        .as_deref()
+        .and_then(|p| target.entities.get(p))
+    {
+        let parent_attrs: BTreeSet<&str> = parent
+            .owned_attributes
+            .iter()
+            .map(|a| a.attr_name.as_str())
+            .collect();
+        entity
+            .owned_attributes
+            .retain(|a| !parent_attrs.contains(a.attr_name.as_str()));
+    }
+    entity
+}
+
+/// Relation counterpart of [`declared_entity_entry`]: drops attributes and
+/// roles the parent relation already declares.
+fn declared_relation_entry(
+    relation: &RelationSchemaEntry,
+    target: &SchemaInfo,
+) -> RelationSchemaEntry {
+    let mut relation = relation.clone();
+    if let Some(parent) = relation
+        .parent_type
+        .as_deref()
+        .and_then(|p| target.relations.get(p))
+    {
+        let parent_attrs: BTreeSet<&str> = parent
+            .owned_attributes
+            .iter()
+            .map(|a| a.attr_name.as_str())
+            .collect();
+        let parent_roles: BTreeSet<&str> = parent
+            .roles
+            .iter()
+            .map(|r| r.role_name.as_str())
+            .collect();
+        relation
+            .owned_attributes
+            .retain(|a| !parent_attrs.contains(a.attr_name.as_str()));
+        relation
+            .roles
+            .retain(|r| !parent_roles.contains(r.role_name.as_str()));
+    }
+    relation
+}
+
 fn missing(what: &str, name: &str, schema: &str) -> MigrationError {
     MigrationError::AuthoringInput {
         message: format!("diff lists {what} {name:?} but the {schema} schema does not define it"),
@@ -882,6 +958,102 @@ mod tests {
         assert_eq!(
             kinds(&operations),
             vec!["add_attribute", "add_entity", "add_relation"]
+        );
+    }
+
+    #[test]
+    fn added_sub_entities_emit_parent_first_with_declared_attributes_only() {
+        // "ape" sorts before its parent "zebra", and the flattened child
+        // entry carries the inherited key attribute (#190).
+        let base = SchemaInfo::default();
+        let mut child = entity("ape", vec![owned("name", vec![Annotation::Key])]);
+        child.parent_type = Some("zebra".to_string());
+        let target = schema(
+            vec![
+                child,
+                entity("zebra", vec![owned("name", vec![Annotation::Key])]),
+            ],
+            vec![],
+            vec![attribute("name")],
+        );
+
+        let operations = map(&base, &target);
+
+        assert_eq!(
+            kinds(&operations),
+            vec!["add_attribute", "add_entity", "add_entity"]
+        );
+        let OperationSpec::AddEntity { entity: first } = &operations[1] else {
+            panic!("expected AddEntity: {:?}", operations[1]);
+        };
+        let OperationSpec::AddEntity { entity: second } = &operations[2] else {
+            panic!("expected AddEntity: {:?}", operations[2]);
+        };
+        assert_eq!(first.type_name, "zebra");
+        assert_eq!(second.type_name, "ape");
+        assert_eq!(second.parent_type.as_deref(), Some("zebra"));
+        assert!(
+            second.owned_attributes.is_empty(),
+            "inherited attributes must not be redeclared: {:?}",
+            second.owned_attributes
+        );
+    }
+
+    #[test]
+    fn added_sub_entity_with_preexisting_parent_drops_inherited_attributes() {
+        let parent = entity("zebra", vec![owned("name", vec![Annotation::Key])]);
+        let base = schema(vec![parent.clone()], vec![], vec![attribute("name")]);
+        let mut child = entity("ape", vec![owned("name", vec![Annotation::Key])]);
+        child.parent_type = Some("zebra".to_string());
+        let target = schema(vec![child, parent], vec![], vec![attribute("name")]);
+
+        let operations = map(&base, &target);
+
+        assert_eq!(kinds(&operations), vec!["add_entity"]);
+        let OperationSpec::AddEntity { entity } = &operations[0] else {
+            panic!("expected AddEntity: {:?}", operations[0]);
+        };
+        assert_eq!(entity.parent_type.as_deref(), Some("zebra"));
+        assert!(entity.owned_attributes.is_empty());
+    }
+
+    #[test]
+    fn added_sub_relations_emit_parent_first_with_declared_roles_only() {
+        // "contract" sorts before its parent "work", and the flattened child
+        // entry carries the inherited role (#190).
+        let base = SchemaInfo::default();
+        let parent = relation("work", vec![role("employee", &["person"])], vec![]);
+        let mut child = relation(
+            "contract",
+            vec![
+                role("employee", &["person"]),
+                role("contractor", &["person"]),
+            ],
+            vec![],
+        );
+        child.parent_type = Some("work".to_string());
+        let target = schema(vec![entity("person", vec![])], vec![child, parent], vec![]);
+
+        let operations = map(&base, &target);
+
+        assert_eq!(
+            kinds(&operations),
+            vec!["add_entity", "add_relation", "add_relation"]
+        );
+        let OperationSpec::AddRelation { relation: first } = &operations[1] else {
+            panic!("expected AddRelation: {:?}", operations[1]);
+        };
+        let OperationSpec::AddRelation { relation: second } = &operations[2] else {
+            panic!("expected AddRelation: {:?}", operations[2]);
+        };
+        assert_eq!(first.type_name, "work");
+        assert_eq!(second.type_name, "contract");
+        assert_eq!(second.parent_type.as_deref(), Some("work"));
+        let role_names: Vec<&str> = second.roles.iter().map(|r| r.role_name.as_str()).collect();
+        assert_eq!(
+            role_names,
+            vec!["contractor"],
+            "inherited roles must not be redeclared"
         );
     }
 

--- a/type-bridge-core/crates/migration/src/plan.rs
+++ b/type-bridge-core/crates/migration/src/plan.rs
@@ -1295,6 +1295,27 @@ delete $a has email "ops@example.com";"#,
     }
 
     #[test]
+    fn add_entity_with_parent_outside_singleton_schema_lowers_without_panic() {
+        // Lowering AddEntity builds a singleton SchemaInfo containing only the
+        // child; the parent named by `sub` lives outside it. Planning must not
+        // panic and the define step must keep the `sub` clause (#190).
+        let mut child = entity_entry("person");
+        child.parent_type = Some("animal".to_string());
+        let g = graph(vec![migration(
+            "0001_sub_entity",
+            vec![OperationSpec::AddEntity { entity: child }],
+            vec![],
+        )]);
+
+        let result = plan(&g, &[], None).expect("plan should succeed");
+        let steps = &result.to_apply[0].steps;
+
+        assert_eq!(steps.len(), 1);
+        assert!(steps[0].forward.contains("entity person sub animal,"));
+        assert_eq!(steps[0].reverse.as_deref(), Some("undefine\nperson;"));
+    }
+
+    #[test]
     fn typed_ownership_operations_lower_to_schema_steps() {
         let g = graph(vec![migration(
             "0001_ownership",

--- a/type-bridge-core/crates/orm/src/schema/generator.rs
+++ b/type-bridge-core/crates/orm/src/schema/generator.rs
@@ -408,7 +408,11 @@ fn build_relation_header(relation: &RelationSchemaEntry) -> String {
 }
 
 /// Topological sort: parents before children, deterministic order within each level.
-fn topological_sort<T, F>(map: &BTreeMap<String, T>, get_parent: F) -> Vec<String>
+///
+/// Only keys of `map` appear in the result; a parent naming a type outside
+/// the map (e.g. defined in an earlier migration) is ignored rather than
+/// emitted.
+pub fn topological_sort<T, F>(map: &BTreeMap<String, T>, get_parent: F) -> Vec<String>
 where
     F: Fn(&T) -> Option<&str>,
 {
@@ -428,9 +432,13 @@ where
             return;
         }
         visited.insert(name.to_string());
-        if let Some(entry) = map.get(name)
-            && let Some(parent) = get_parent(entry)
-        {
+        // A parent may name a type outside this map (e.g. the singleton
+        // SchemaInfo built by migration lowering); such names are not part
+        // of this ordering and must not be emitted.
+        let Some(entry) = map.get(name) else {
+            return;
+        };
+        if let Some(parent) = get_parent(entry) {
             visit(parent, map, get_parent, visited, result);
         }
         result.push(name.to_string());
@@ -853,6 +861,57 @@ mod tests {
             mammal_pos < cat_pos,
             "parent (mammal) should appear before child (cat): {result}"
         );
+    }
+
+    #[test]
+    fn entity_with_parent_outside_schema_keeps_sub_clause() {
+        // Migration lowering builds singleton SchemaInfos whose entries may
+        // reference parents defined elsewhere; generation must not panic and
+        // must preserve the `sub` clause (#190).
+        let mut info = SchemaInfo::default();
+        info.entities.insert(
+            "person".into(),
+            EntitySchemaEntry {
+                type_name: "person".into(),
+                is_abstract: false,
+                parent_type: Some("animal".into()),
+                owned_attributes: vec![],
+                plays_cardinalities: BTreeMap::new(),
+                doc: None,
+                meta: Default::default(),
+            },
+        );
+
+        let result = generate_define_block(&info);
+
+        assert!(result.contains("entity person sub animal;"), "{result}");
+        assert!(!result.contains("entity animal"), "{result}");
+    }
+
+    #[test]
+    fn relation_with_parent_outside_schema_keeps_sub_clause() {
+        let mut info = SchemaInfo::default();
+        info.relations.insert(
+            "part-time-employment".into(),
+            RelationSchemaEntry {
+                type_name: "part-time-employment".into(),
+                is_abstract: false,
+                parent_type: Some("employment".into()),
+                owned_attributes: vec![],
+                roles: vec![],
+                plays_cardinalities: BTreeMap::new(),
+                doc: None,
+                meta: Default::default(),
+            },
+        );
+
+        let result = generate_define_block(&info);
+
+        assert!(
+            result.contains("relation part-time-employment sub employment;"),
+            "{result}"
+        );
+        assert!(!result.contains("relation employment"), "{result}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Planning any migration that added an entity or relation with a parent
panicked at `generator.rs:76` with `no entry found for key`. Fixing the
panic alone only moved the failure to apply time (verified against
live TypeDB servers): the singleton define redeclared inherited
capabilities (rejected with SVL42), and alphabetical emission could
place a child before its newly added parent. All three defects on the
path are fixed.

## Changes

- `topological_sort::visit` no longer pushes names that have no entry in
  the map, so a foreign parent named by `sub` cannot enter the ordering;
  the child keeps its `sub` clause.
- `map_schema_diff` emits added entities/relations parents-first via the
  same (now exported) `topological_sort`.
- `map_schema_diff` reduces `AddEntity`/`AddRelation` payloads to
  declared-only capabilities, dropping attributes and roles the parent
  already declares, since the singleton lowering has no parent context
  to skip inherited capabilities itself.
- Regression tests at generator, authoring, and plan level.

## Test plan

- `cargo test -p type-bridge-orm -p type-bridge-migration` (734 passed)
- `./scripts/check.sh rust` (fmt, clippy `-D warnings`, tests)
- Issue repro prints `plan ok`; the emitted define step for the child is
  `entity Person sub Animal;` with the key attribute inherited rather
  than redeclared.
- Live apply of the full emitted plan (attribute, parent entity, child
  `sub` entity) verified against every supported server line plus the
  newest release: 3.8.3 and 3.10.4 (band-7), 3.11.1 and 3.11.5
  (band-8), 3.12.0, and 3.12.1 (current `latest`). All steps commit
  cleanly on each; the resulting schema shows `sub Animal` with the
  ownership inherited.

Closes #190