### PR TITLE
fix(rust): preserve classified client errors (#198)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,10 @@ All notable changes to TypeBridge will be documented in this file.
   typed expressions and reductions, selected/collected pages, bounded
   reachability, and identical local/one-exchange remote materialization. The
   generated crate has only one direct TypeBridge dependency and the complete
-  consumer contract is accepted on Rust 1.88.
+  consumer contract is accepted on Rust 1.88. Public `ErrorCategory`, stable
+  codes, structured paths, and validation phases now survive both direct and
+  remote adapters; caller-owned transports use `Error::remote` for classified
+  transport failures.
 - **Rust V2 source/Git distribution boundary** - the internal V2 semantic,
   migration, projection, workspace, and CLI crates remain first-party
   workspace packages with `publish = false`; they are not crates.io release

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -285,6 +285,12 @@ before using generated models. Follow `guide/rust.md` for the exact release
 revision, dependency patch, connection, transaction, CRUD, and remote-query
 forms.
 
+Classify Rust SDK failures through `Error::category()`, `code()`, `path()`,
+and `model_validation_phase()`; do not parse display messages. Preserve those
+fields across direct and remote execution. In a caller-owned
+`RemoteQueryTransport`, wrap transport failures with `Error::remote` and a
+stable lowercase snake-case code.
+
 Use the server container only with the configuration, TLS, declared-schema
 authority, resource limits, and immutable digest described in
 `guide/server-container.md`. The client owns remote transport, authentication,

--- a/docs/development/rust-generated-parity.md
+++ b/docs/development/rust-generated-parity.md
@@ -11,6 +11,12 @@ implemented or an owner explicitly approves a release exclusion.
 
 ## Current status
 
+The inventory also checks every acceptance criterion from
+[#198](https://github.com/ds1sqe/type-bridge/issues/198). All 15 client
+criteria have source-tied live or offline evidence, including dependency
+direction, compile-fail boundaries, public-consumer isolation, distribution
+identity, and equal local/remote values and classified failures.
+
 The isolated generated Rust application has accepted live evidence for:
 
 - entity CRUD and batches;
@@ -20,7 +26,8 @@ The isolated generated Rust application has accepted live evidence for:
 - typed aggregates and grouping;
 - selected named and collected pages;
 - write and reusable read transactions; and
-- identical local and authenticated one-exchange remote materialization.
+- identical local and authenticated one-exchange remote values and classified
+  failures.
 
 Schema generation, compile rejection, and dependency-isolated external
 consumption have accepted offline evidence.
@@ -35,7 +42,10 @@ Rust 1.88, and final source/Git distribution-identity system gates are
 accepted. Exact server OCI acceptance is the sole open system gate: the
 landed candidate SHA must pass both `linux/amd64` and `linux/arm64` workflow
 runtime proofs before the separately authorized stable publication and
-attestation path can close it.
+attestation path can close it. That system-level publication proof belongs to
+the release gate in
+[#188](https://github.com/ds1sqe/type-bridge/issues/188); it is not an
+unimplemented Rust-client criterion in #198.
 
 Run the inventory guard with:
 

--- a/docs/guide/rust.md
+++ b/docs/guide/rust.md
@@ -237,3 +237,36 @@ The transport owns authentication and authenticated TLS. The SDK binds
 capability discovery, schema authority, nonce, request fingerprint, deadline,
 limits, and reply identity before materializing the same generated model
 types used by local execution.
+
+## Classified errors
+
+Handle failures through the stable category, code, and path accessors. Human
+messages are diagnostic text and are not a machine-readable contract:
+
+```rust
+use type_bridge::{Error, ErrorCategory, ModelValidationPhase};
+
+fn inspect(error: &Error) {
+    match error.category() {
+        ErrorCategory::QueryAuthoring => {
+            eprintln!("invalid query {} at {:?}", error.code().unwrap(), error.path());
+        }
+        ErrorCategory::ModelValidation => {
+            assert!(matches!(
+                error.model_validation_phase(),
+                Some(ModelValidationPhase::Input | ModelValidationPhase::Hydration)
+            ));
+        }
+        ErrorCategory::Capability | ErrorCategory::ResourceLimit => {
+            eprintln!("executor rejected {}: {}", error.code().unwrap(), error.message());
+        }
+        _ => eprintln!("{error}"),
+    }
+}
+```
+
+Direct and remote query paths map canonical failures to the same
+`ErrorCategory` and preserve stable codes and structured paths when supplied
+by the engine or remote diagnostic. Implementations of `RemoteQueryTransport`
+should wrap application-owned transport failures with
+`Error::remote("stable_snake_case_code", message, source)`.

--- a/tests/fixtures/rust-generated-parity-inventory.json
+++ b/tests/fixtures/rust-generated-parity-inventory.json
@@ -10,6 +10,178 @@
     "accepted_offline",
     "open"
   ],
+  "client_acceptance": [
+    {
+      "id": "public_rust_client_crate",
+      "status": "accepted_offline",
+      "evidence": [
+        {
+          "path": "type-bridge-core/crates/rust/Cargo.toml",
+          "anchors": ["name = \"type-bridge\"", "name = \"type_bridge\"", "Public client SDK for TypeBridge"]
+        },
+        {
+          "path": "type-bridge-core/crates/rust/src/lib.rs",
+          "anchors": ["Public Rust client library for TypeBridge", "pub use entity_manager", "pub use remote"]
+        }
+      ]
+    },
+    {
+      "id": "dependency_direction",
+      "status": "accepted_offline",
+      "evidence": [
+        {
+          "path": "type-bridge-core/crates/schema-codegen/tests/rust_acceptance.rs",
+          "anchors": ["generated_external_manager_contract_compiles_exact_matrix", "\"type-bridge-orm\"", "assert_eq!(entries.len(), 2)"]
+        },
+        {
+          "path": "tests/unit/compat/test_rust_generated_parity_inventory.py",
+          "anchors": ["test_core_crates_do_not_depend_upward_on_the_public_rust_client", "package == \"type-bridge\""]
+        }
+      ]
+    },
+    {
+      "id": "generated_external_consumer",
+      "status": "accepted_live",
+      "evidence": [
+        {
+          "path": "type-bridge-core/crates/schema-codegen/tests/rust_projection_live.rs",
+          "anchors": ["generated_rust_projection_round_trips_exact_live_models", "dependency-isolated client consumer starts", "test result: ok. 5 passed; 0 failed"]
+        }
+      ]
+    },
+    {
+      "id": "generated_model_contract",
+      "status": "accepted_offline",
+      "evidence": [
+        {
+          "path": "type-bridge-core/crates/schema-codegen/tests/rust_acceptance.rs",
+          "anchors": ["generated_declaration_boundary_matrix_is_scoped", "impl CompleteModel for {name}", "pub enum {name}", "impl SubtypeRootModel for {name}"]
+        }
+      ]
+    },
+    {
+      "id": "exact_and_subtype_results",
+      "status": "accepted_live",
+      "evidence": [
+        {
+          "path": "type-bridge-core/crates/schema-codegen/tests/rust_projection_live/consumer.rs",
+          "anchors": ["generated_inheritance_exact_and_subtype_reads", "employee subtype count", "party subtype count", "F2B-03 public generated entity lifecycle: passed"]
+        }
+      ]
+    },
+    {
+      "id": "inheritance_narrowing",
+      "status": "accepted_offline",
+      "evidence": [
+        {
+          "path": "type-bridge-core/crates/schema-codegen/tests/rust_acceptance.rs",
+          "anchors": ["fn narrow(value: PartyFamily)", "child-before-narrow", "family_child_only_fields_fail_at_compile_time"]
+        }
+      ]
+    },
+    {
+      "id": "relation_role_ownership",
+      "status": "accepted_live",
+      "evidence": [
+        {
+          "path": "type-bridge-core/crates/schema-codegen/tests/rust_acceptance.rs",
+          "anchors": ["query-specialized-away-ancestor-role", "query-role-rejects-non-player"]
+        },
+        {
+          "path": "type-bridge-core/crates/schema-codegen/tests/rust_projection_live/consumer.rs",
+          "anchors": ["generated_relation_query_and_remote_lifecycle", "network update replaces attributes and roles", "F2C-03 public generated relation lifecycle: passed"]
+        }
+      ]
+    },
+    {
+      "id": "typed_crud_and_transactions",
+      "status": "accepted_live",
+      "evidence": [
+        {
+          "path": "type-bridge-core/crates/schema-codegen/tests/rust_projection_live/consumer.rs",
+          "anchors": ["generated_entity_crud_batches_and_scalar_domains", "generated_write_transaction_commit_rollback_and_drop", ".insert_many(vec![", ".put_many(vec![", "F2D public write transaction lifecycle: passed"]
+        }
+      ]
+    },
+    {
+      "id": "owner_bound_query_algebra",
+      "status": "accepted_live",
+      "evidence": [
+        {
+          "path": "type-bridge-core/crates/schema-codegen/tests/rust_projection_live/consumer.rs",
+          "anchors": ["F3-06A", ".first(party_name.asc())", "F5 bounded reachability predicate", "F3 public generated query lifecycle: passed"]
+        }
+      ]
+    },
+    {
+      "id": "selected_result_shapes",
+      "status": "accepted_live",
+      "evidence": [
+        {
+          "path": "type-bridge-core/crates/schema-codegen/tests/rust_projection_live/consumer.rs",
+          "anchors": ["PersonGraph::select", "F4 local collected page", "F4 remote distinct root count", "F4 public selected/read/remote lifecycle: passed"]
+        }
+      ]
+    },
+    {
+      "id": "compile_fail_boundaries",
+      "status": "accepted_offline",
+      "evidence": [
+        {
+          "path": "type-bridge-core/crates/schema-codegen/tests/rust_acceptance.rs",
+          "anchors": ["negative generated consumer unexpectedly compiled", "query-cross-owner-field", "query-specialized-away-ancestor-role", "query-role-rejects-non-player", "query-equality-rejects-wrong-domain"]
+        }
+      ]
+    },
+    {
+      "id": "representative_live_parity",
+      "status": "accepted_live",
+      "evidence": [
+        {
+          "path": "type-bridge-core/crates/schema-codegen/tests/rust_projection_live.rs",
+          "anchors": ["generated_rust_projection_round_trips_exact_live_models", "public generated entity CRUD, batches, and scalar domains: passed", "F5 public relation parity and bounded reachability: passed"]
+        }
+      ]
+    },
+    {
+      "id": "local_remote_values_and_classified_errors",
+      "status": "accepted_live",
+      "evidence": [
+        {
+          "path": "type-bridge-core/crates/schema-codegen/tests/rust_projection_live/consumer.rs",
+          "anchors": ["RemoteDatabase<AppSchema>", "assert_eq!(observed_page, expected_page)", "F4 public selected/read/remote lifecycle: passed"]
+        },
+        {
+          "path": "type-bridge-core/crates/rust/src/remote.rs",
+          "anchors": ["local_and_remote_failures_preserve_classification_codes_and_paths", "missing_remote_capability", "crate::ErrorCategory::Capability"]
+        }
+      ]
+    },
+    {
+      "id": "no_internal_consumer_surfaces",
+      "status": "accepted_offline",
+      "evidence": [
+        {
+          "path": "type-bridge-core/crates/schema-codegen/tests/rust_projection_live.rs",
+          "anchors": ["external_consumer_remains_a_focused_public_api_suite", "forbidden consumer surface", "\"Dynamic\"", "\"type_bridge_orm\"", "\"descriptor\""]
+        }
+      ]
+    },
+    {
+      "id": "distribution_identity",
+      "status": "accepted_offline",
+      "evidence": [
+        {
+          "path": "test.sh",
+          "anchors": ["generated Rust projection acceptance on MSRV 1.88", "+1.88.0"]
+        },
+        {
+          "path": "scripts/ci/validate_release_identity.py",
+          "anchors": ["ARTIFACT_CONTRACT_SOURCE_GIT_SERVER_OCI", "Require the final source/Git Rust SDK plus server-OCI artifact graph."]
+        }
+      ]
+    }
+  ],
   "scenarios": [
     {
       "id": "entity_crud_and_batches",
@@ -275,6 +447,10 @@
         {
           "path": "type-bridge-core/crates/schema-codegen/tests/rust_projection_live/consumer.rs",
           "anchors": ["generated_relation_query_and_remote_lifecycle", "RemoteDatabase<AppSchema>", "F4 remote distinct root count", "assert_eq!(observed_page, expected_page)"]
+        },
+        {
+          "path": "type-bridge-core/crates/rust/src/remote.rs",
+          "anchors": ["local_and_remote_failures_preserve_classification_codes_and_paths", "missing_remote_capability", "crate::ErrorCategory::Capability"]
         }
       ],
       "release_exclusion": null

--- a/tests/unit/compat/test_rust_generated_parity_inventory.py
+++ b/tests/unit/compat/test_rust_generated_parity_inventory.py
@@ -3,11 +3,30 @@
 from __future__ import annotations
 
 import json
+import tomllib
 from pathlib import Path
 from typing import Any
 
 ROOT = Path(__file__).parents[3]
 INVENTORY = ROOT / "tests/fixtures/rust-generated-parity-inventory.json"
+
+REQUIRED_CLIENT_ACCEPTANCE = {
+    "public_rust_client_crate",
+    "dependency_direction",
+    "generated_external_consumer",
+    "generated_model_contract",
+    "exact_and_subtype_results",
+    "inheritance_narrowing",
+    "relation_role_ownership",
+    "typed_crud_and_transactions",
+    "owner_bound_query_algebra",
+    "selected_result_shapes",
+    "compile_fail_boundaries",
+    "representative_live_parity",
+    "local_remote_values_and_classified_errors",
+    "no_internal_consumer_surfaces",
+    "distribution_identity",
+}
 
 REQUIRED_SCENARIOS = {
     "entity_crud_and_batches",
@@ -44,10 +63,57 @@ def _load() -> dict[str, Any]:
     return json.loads(INVENTORY.read_text(encoding="utf-8"))
 
 
+def test_core_crates_do_not_depend_upward_on_the_public_rust_client() -> None:
+    offenders: list[str] = []
+    for manifest in sorted((ROOT / "type-bridge-core/crates").glob("*/Cargo.toml")):
+        if manifest.parent.name == "rust":
+            continue
+        document = tomllib.loads(manifest.read_text(encoding="utf-8"))
+        dependency_tables = [
+            document.get("dependencies", {}),
+            document.get("dev-dependencies", {}),
+            document.get("build-dependencies", {}),
+        ]
+        for target in document.get("target", {}).values():
+            dependency_tables.extend(
+                [
+                    target.get("dependencies", {}),
+                    target.get("dev-dependencies", {}),
+                    target.get("build-dependencies", {}),
+                ]
+            )
+        for dependencies in dependency_tables:
+            for name, specification in dependencies.items():
+                package = specification.get("package") if isinstance(specification, dict) else None
+                if name == "type-bridge" or package == "type-bridge":
+                    offenders.append(f"{manifest.relative_to(ROOT)}:{name}")
+    assert not offenders
+
+
+def _assert_source_evidence(item: dict[str, Any]) -> None:
+    assert item["evidence"], item["id"]
+    for evidence in item["evidence"]:
+        path = ROOT / evidence["path"]
+        assert path.is_file(), path
+        source = path.read_text(encoding="utf-8")
+        assert evidence["anchors"], evidence
+        for anchor in evidence["anchors"]:
+            assert anchor in source, f"{item['id']}: {path}: {anchor}"
+
+
 def test_rust_generated_parity_inventory_is_complete_and_source_tied() -> None:
     inventory = _load()
     assert inventory["format"] == "typebridge.rust-generated-parity-inventory/v1"
     assert inventory["statuses"] == ["accepted_live", "accepted_offline", "open"]
+
+    client_acceptance = inventory["client_acceptance"]
+    assert {criterion["id"] for criterion in client_acceptance} == (REQUIRED_CLIENT_ACCEPTANCE)
+    assert all(
+        criterion["status"] in {"accepted_live", "accepted_offline"}
+        for criterion in client_acceptance
+    )
+    for criterion in client_acceptance:
+        _assert_source_evidence(criterion)
 
     scenarios = inventory["scenarios"]
     assert isinstance(scenarios, list)
@@ -77,14 +143,7 @@ def test_rust_generated_parity_inventory_is_complete_and_source_tied() -> None:
     assert {gate["id"] for gate in gates} == REQUIRED_SYSTEM_GATES
     assert {gate["id"]: gate["status"] for gate in gates} == EXPECTED_SYSTEM_GATE_STATUSES
     for gate in gates:
-        assert gate["evidence"], gate["id"]
-        for evidence in gate["evidence"]:
-            path = ROOT / evidence["path"]
-            assert path.is_file(), path
-            source = path.read_text(encoding="utf-8")
-            assert evidence["anchors"], evidence
-            for anchor in evidence["anchors"]:
-                assert anchor in source, f"{gate['id']}: {path}: {anchor}"
+        _assert_source_evidence(gate)
         if gate["status"] == "open":
             assert gate["open_requirements"], gate["id"]
 

--- a/type-bridge-core/crates/rust/src/error.rs
+++ b/type-bridge-core/crates/rust/src/error.rs
@@ -1,6 +1,67 @@
 //! Error handling for the public TypeBridge client.
 
 use std::error::Error as StdError;
+use std::fmt;
+
+use type_bridge_contract::diagnostic::{Diagnostic, DiagnosticCategory, DiagnosticPathSegment};
+use type_bridge_orm::match_request::{MatchError, MatchErrorCategory};
+
+/// Stable public classification for TypeBridge client failures.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ErrorCategory {
+    /// Connection establishment or connectivity failed.
+    Connection,
+    /// Generated or installed schema authority failed verification.
+    Schema,
+    /// Generated input or provider evidence failed model validation.
+    ModelValidation,
+    /// A typed query was invalid before provider execution.
+    QueryAuthoring,
+    /// The provider failed while executing an accepted query.
+    QueryExecution,
+    /// A transaction lifecycle operation failed.
+    Transaction,
+    /// A remote envelope, reply, transport, or integrity contract failed.
+    Remote,
+    /// The selected provider or remote executor lacks a required capability.
+    Capability,
+    /// A canonical client, provider, or remote resource ceiling was exceeded.
+    ResourceLimit,
+    /// A requested entity or schema element was not found.
+    NotFound,
+    /// An underlying database operation failed outside a narrower category.
+    Database,
+    /// A client invariant failed outside the stable categories above.
+    Other,
+}
+
+impl ErrorCategory {
+    /// Return the stable language-neutral category spelling.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Connection => "connection",
+            Self::Schema => "schema",
+            Self::ModelValidation => "model_validation",
+            Self::QueryAuthoring => "query_authoring",
+            Self::QueryExecution => "query_execution",
+            Self::Transaction => "transaction",
+            Self::Remote => "remote",
+            Self::Capability => "capability",
+            Self::ResourceLimit => "resource_limit",
+            Self::NotFound => "not_found",
+            Self::Database => "database",
+            Self::Other => "other",
+        }
+    }
+}
+
+impl fmt::Display for ErrorCategory {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
 
 /// Stage at which generated-model evidence failed validation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -13,11 +74,25 @@ pub enum ModelValidationPhase {
 
 /// Primary error type for the TypeBridge client SDK.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum Error {
     /// Generated-model evidence did not match the installed schema projection.
     #[error("Model validation failed during {phase:?}: {message}")]
     ModelValidation {
         phase: ModelValidationPhase,
+        code: String,
+        path: Vec<String>,
+        message: String,
+        #[source]
+        source: Option<Box<dyn StdError + Send + Sync + 'static>>,
+    },
+
+    /// A structured engine or remote-contract failure mapped into stable
+    /// client-owned categories, codes, and paths.
+    #[error("{category} error [{code}]: {message}")]
+    Classified {
+        category: ErrorCategory,
+        phase: Option<ModelValidationPhase>,
         code: String,
         path: Vec<String>,
         message: String,
@@ -100,37 +175,155 @@ impl Error {
         }
     }
 
+    pub(crate) fn classified(
+        category: ErrorCategory,
+        phase: Option<ModelValidationPhase>,
+        code: impl Into<String>,
+        path: Vec<String>,
+        message: impl Into<String>,
+        source: Option<Box<dyn StdError + Send + Sync + 'static>>,
+    ) -> Self {
+        Self::Classified {
+            category,
+            phase,
+            code: code.into(),
+            path,
+            message: message.into(),
+            source,
+        }
+    }
+
+    /// Construct one application-owned remote transport failure.
+    ///
+    /// Transport implementations should use a stable lowercase snake-case
+    /// code so callers can handle the failure without parsing its message.
+    #[must_use]
+    pub fn remote(
+        code: impl Into<String>,
+        message: impl Into<String>,
+        source: Option<Box<dyn StdError + Send + Sync + 'static>>,
+    ) -> Self {
+        Self::classified(
+            ErrorCategory::Remote,
+            None,
+            code,
+            Vec::new(),
+            message,
+            source,
+        )
+    }
+
+    pub(crate) fn from_match(error: MatchError, phase: ModelValidationPhase) -> Self {
+        let category = match error.category() {
+            MatchErrorCategory::InvalidPlan => ErrorCategory::QueryAuthoring,
+            MatchErrorCategory::Cardinality | MatchErrorCategory::ResultDecode => {
+                ErrorCategory::ModelValidation
+            }
+            MatchErrorCategory::UnsupportedCapability => ErrorCategory::Capability,
+            MatchErrorCategory::StaleSchema => ErrorCategory::Schema,
+            MatchErrorCategory::ResourceLimit => ErrorCategory::ResourceLimit,
+            MatchErrorCategory::Provider => ErrorCategory::QueryExecution,
+        };
+        let model_phase = (category == ErrorCategory::ModelValidation).then_some(phase);
+        let code = error.code().as_str().to_owned();
+        let path = error
+            .path()
+            .segments()
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+        let message = error.message().to_owned();
+        Self::classified(
+            category,
+            model_phase,
+            code,
+            path,
+            message,
+            Some(Box::new(error)),
+        )
+    }
+
+    pub(crate) fn from_remote_diagnostic(error: Diagnostic) -> Self {
+        let category = match error.category() {
+            DiagnosticCategory::UnsupportedCapability => ErrorCategory::Capability,
+            DiagnosticCategory::ResourceLimit => ErrorCategory::ResourceLimit,
+            DiagnosticCategory::InvalidContract | DiagnosticCategory::Integrity => {
+                ErrorCategory::Remote
+            }
+        };
+        let code = error.code().as_str().to_owned();
+        let path = error
+            .path()
+            .segments()
+            .iter()
+            .map(|segment| match segment {
+                DiagnosticPathSegment::Field(value) => value.clone(),
+                DiagnosticPathSegment::Index(value) => format!("[{value}]"),
+                DiagnosticPathSegment::Identifier(value) => value.clone(),
+            })
+            .collect();
+        let message = error.message().to_owned();
+        Self::classified(category, None, code, path, message, Some(Box::new(error)))
+    }
+
     #[allow(dead_code)]
     pub(crate) fn from_orm(err: type_bridge_orm::OrmError) -> Self {
-        let message = err.to_string();
-        match &err {
-            type_bridge_orm::OrmError::Connection(_) => Self::Connection {
-                message,
-                source: Some(Box::new(err)),
+        match err {
+            type_bridge_orm::OrmError::Match(error) => {
+                Self::from_match(error, ModelValidationPhase::Input)
+            }
+            error @ type_bridge_orm::OrmError::Connection(_) => Self::Connection {
+                message: error.to_string(),
+                source: Some(Box::new(error)),
             },
-            type_bridge_orm::OrmError::QueryExecution(_) => Self::QueryExecution {
-                message,
-                source: Some(Box::new(err)),
+            error @ type_bridge_orm::OrmError::QueryExecution(_) => Self::QueryExecution {
+                message: error.to_string(),
+                source: Some(Box::new(error)),
             },
-            type_bridge_orm::OrmError::Transaction(_) => Self::Transaction {
-                message,
-                source: Some(Box::new(err)),
+            error @ type_bridge_orm::OrmError::Transaction(_) => Self::Transaction {
+                message: error.to_string(),
+                source: Some(Box::new(error)),
             },
-            type_bridge_orm::OrmError::NotFound(_) => Self::NotFound {
-                message,
-                source: Some(Box::new(err)),
+            error @ type_bridge_orm::OrmError::NotFound(_) => Self::NotFound {
+                message: error.to_string(),
+                source: Some(Box::new(error)),
             },
-            type_bridge_orm::OrmError::Hydration { .. } => Self::ModelValidation {
+            error @ type_bridge_orm::OrmError::Hydration { .. } => Self::ModelValidation {
                 phase: ModelValidationPhase::Hydration,
                 code: "invalid_provider_evidence".into(),
                 path: vec![],
-                message,
-                source: Some(Box::new(err)),
+                message: error.to_string(),
+                source: Some(Box::new(error)),
             },
-            _ => Self::Database {
-                message,
-                source: Some(Box::new(err)),
+            error => Self::Database {
+                message: error.to_string(),
+                source: Some(Box::new(error)),
             },
+        }
+    }
+
+    pub(crate) fn from_orm_hydration(err: type_bridge_orm::OrmError) -> Self {
+        match err {
+            type_bridge_orm::OrmError::Match(error) => {
+                Self::from_match(error, ModelValidationPhase::Hydration)
+            }
+            error => Self::from_orm(error),
+        }
+    }
+
+    /// Return the stable public failure category.
+    #[must_use]
+    pub const fn category(&self) -> ErrorCategory {
+        match self {
+            Self::ModelValidation { .. } => ErrorCategory::ModelValidation,
+            Self::Classified { category, .. } => *category,
+            Self::SchemaVerification { .. } => ErrorCategory::Schema,
+            Self::Connection { .. } => ErrorCategory::Connection,
+            Self::QueryExecution { .. } => ErrorCategory::QueryExecution,
+            Self::Transaction { .. } => ErrorCategory::Transaction,
+            Self::NotFound { .. } => ErrorCategory::NotFound,
+            Self::Database { .. } => ErrorCategory::Database,
+            Self::Other { .. } => ErrorCategory::Other,
         }
     }
 
@@ -139,6 +332,7 @@ impl Error {
     pub fn message(&self) -> &str {
         match self {
             Self::ModelValidation { message, .. }
+            | Self::Classified { message, .. }
             | Self::SchemaVerification { message, .. }
             | Self::Connection { message, .. }
             | Self::QueryExecution { message, .. }
@@ -149,20 +343,20 @@ impl Error {
         }
     }
 
-    /// Return the stable model-validation code, when applicable.
+    /// Return the stable machine-readable failure code, when available.
     #[must_use]
     pub fn code(&self) -> Option<&str> {
         match self {
-            Self::ModelValidation { code, .. } => Some(code),
+            Self::ModelValidation { code, .. } | Self::Classified { code, .. } => Some(code),
             _ => None,
         }
     }
 
-    /// Return the owned structured model-validation path, when applicable.
+    /// Return the owned structured diagnostic path, when available.
     #[must_use]
     pub fn path(&self) -> Option<&[String]> {
         match self {
-            Self::ModelValidation { path, .. } => Some(path),
+            Self::ModelValidation { path, .. } | Self::Classified { path, .. } => Some(path),
             _ => None,
         }
     }
@@ -172,6 +366,7 @@ impl Error {
     pub const fn model_validation_phase(&self) -> Option<ModelValidationPhase> {
         match self {
             Self::ModelValidation { phase, .. } => Some(*phase),
+            Self::Classified { phase, .. } => *phase,
             _ => None,
         }
     }
@@ -179,3 +374,36 @@ impl Error {
 
 /// Convenience Result type for the TypeBridge client.
 pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[cfg(test)]
+mod tests {
+    use super::{Error, ErrorCategory};
+
+    #[test]
+    fn public_error_categories_and_remote_constructor_are_stable() {
+        let categories = [
+            (ErrorCategory::Connection, "connection"),
+            (ErrorCategory::Schema, "schema"),
+            (ErrorCategory::ModelValidation, "model_validation"),
+            (ErrorCategory::QueryAuthoring, "query_authoring"),
+            (ErrorCategory::QueryExecution, "query_execution"),
+            (ErrorCategory::Transaction, "transaction"),
+            (ErrorCategory::Remote, "remote"),
+            (ErrorCategory::Capability, "capability"),
+            (ErrorCategory::ResourceLimit, "resource_limit"),
+            (ErrorCategory::NotFound, "not_found"),
+            (ErrorCategory::Database, "database"),
+            (ErrorCategory::Other, "other"),
+        ];
+        for (category, spelling) in categories {
+            assert_eq!(category.as_str(), spelling);
+            assert_eq!(category.to_string(), spelling);
+        }
+
+        let error = Error::remote("remote_transport", "connection reset", None);
+        assert_eq!(error.category(), ErrorCategory::Remote);
+        assert_eq!(error.code(), Some("remote_transport"));
+        assert_eq!(error.path(), Some(&[][..]));
+        assert_eq!(error.message(), "connection reset");
+    }
+}

--- a/type-bridge-core/crates/rust/src/lib.rs
+++ b/type-bridge-core/crates/rust/src/lib.rs
@@ -25,7 +25,7 @@ mod transaction;
 pub mod value;
 
 pub use entity_manager::{EntityManager, EntitySubtypeManager};
-pub use error::{Error, ModelValidationPhase, Result};
+pub use error::{Error, ErrorCategory, ModelValidationPhase, Result};
 pub use query::{
     Binding, BoundField, BoundRole, Collected, Exact, GroupedQuery, NamedSelection, Order,
     OrderedOperand, Page, PageOptions, Predicate, Query, QueryOperand, QuerySession, RowsOptions,

--- a/type-bridge-core/crates/rust/src/query.rs
+++ b/type-bridge-core/crates/rust/src/query.rs
@@ -2044,7 +2044,7 @@ impl<'s, 'db, S: Schema, Shape: SelectedShape<S>> Query<'s, 'db, S, Shape> {
     ) -> Result<Vec<Shape::Output>> {
         let rows = match result
             .for_request(validated)
-            .map_err(|error| Error::from_orm(error.into()))?
+            .map_err(|error| Error::from_orm_hydration(error.into()))?
         {
             MatchResult::Rows { rows } => rows,
             _ => {
@@ -2067,7 +2067,7 @@ impl<'s, 'db, S: Schema, Shape: SelectedShape<S>> Query<'s, 'db, S, Shape> {
     ) -> Result<Page<Shape::Output>> {
         let (entries, window, total) = match result
             .for_request(validated)
-            .map_err(|error| Error::from_orm(error.into()))?
+            .map_err(|error| Error::from_orm_hydration(error.into()))?
         {
             MatchResult::Page {
                 entries,
@@ -2115,7 +2115,7 @@ impl<'s, 'db, S: Schema, Shape: SelectedShape<S>> Query<'s, 'db, S, Shape> {
                     .await;
             }
         };
-        Ok((validated, result.map_err(Error::from_orm)?))
+        Ok((validated, result.map_err(Error::from_orm_hydration)?))
     }
 }
 
@@ -2227,7 +2227,7 @@ impl<'s, 'db, S: Schema, Shape: SelectedShape<S>> Query<'s, 'db, S, Shape> {
         let (validated, result) = self.execute(validated).await?;
         match result
             .for_request(&validated)
-            .map_err(|error| Error::from_orm(error.into()))?
+            .map_err(|error| Error::from_orm_hydration(error.into()))?
         {
             MatchResult::Count { value, .. } => Ok(*value),
             _ => Err(Error::model_validation(
@@ -2247,7 +2247,7 @@ impl<'s, 'db, S: Schema, Shape: SelectedShape<S>> Query<'s, 'db, S, Shape> {
         let (validated, result) = self.execute(validated).await?;
         match result
             .for_request(&validated)
-            .map_err(|error| Error::from_orm(error.into()))?
+            .map_err(|error| Error::from_orm_hydration(error.into()))?
         {
             MatchResult::Exists { value, .. } => Ok(*value),
             _ => Err(Error::model_validation(
@@ -2323,7 +2323,7 @@ impl<'s, 'db, S: Schema, B: Selectable<S>> Query<'s, 'db, S, B> {
     ) -> Result<Vec<type_bridge_orm::match_request::ReductionRow>> {
         match result
             .for_request(validated)
-            .map_err(|error| Error::from_orm(error.into()))?
+            .map_err(|error| Error::from_orm_hydration(error.into()))?
         {
             MatchResult::Reduction { rows, .. } => Ok(rows.clone()),
             _ => Err(Error::model_validation(

--- a/type-bridge-core/crates/rust/src/query/tests.rs
+++ b/type-bridge-core/crates/rust/src/query/tests.rs
@@ -959,7 +959,10 @@ async fn query_facade_rejects_cross_owner_fields_and_zero_limits_before_io() {
             },
         )
         .unwrap_err();
-    assert!(error.to_string().contains("cross_owner_field"));
+    assert_eq!(error.category(), crate::ErrorCategory::QueryAuthoring);
+    assert_eq!(error.code(), Some("cross_owner_field"));
+    assert_eq!(error.path(), Some(&[][..]));
+    assert_eq!(error.model_validation_phase(), None);
 
     let mut foreign_session = db.query().unwrap();
     let foreign = foreign_session.exact::<Record>().unwrap();

--- a/type-bridge-core/crates/rust/src/remote.rs
+++ b/type-bridge-core/crates/rust/src/remote.rs
@@ -208,17 +208,25 @@ impl<S: Schema> RemoteDatabase<S> {
             &runtime.advertisement,
             runtime.limits,
         )
-        .map_err(remote_model_error)?;
+        .map_err(remote_model_input_error)?;
         let request = pending.request_bytes().to_vec();
         let response = runtime.transport.exchange(&request).await?;
-        let claimed = pending.claim_reply().map_err(remote_model_error)?;
+        let claimed = pending
+            .claim_reply()
+            .map_err(remote_model_hydration_error)?;
         if response.len() > claimed.response_snapshot_limit() {
-            return Err(Error::Other {
-                message: "remote query reply exceeds the authenticated response ceiling".into(),
-                source: None,
-            });
+            return Err(Error::classified(
+                crate::ErrorCategory::ResourceLimit,
+                None,
+                "remote_response_limit",
+                Vec::new(),
+                "remote query reply exceeds the authenticated response ceiling",
+                None,
+            ));
         }
-        let (request, result, _registry) = claimed.decode(&response).map_err(remote_model_error)?;
+        let (request, result, _registry) = claimed
+            .decode(&response)
+            .map_err(remote_model_hydration_error)?;
         Ok((request, result))
     }
 }
@@ -234,16 +242,24 @@ fn remote_not_bound() -> Error {
 }
 
 fn remote_diagnostic(error: type_bridge_contract::diagnostic::Diagnostic) -> Error {
-    Error::Other {
-        message: error.to_string(),
-        source: Some(Box::new(error)),
+    Error::from_remote_diagnostic(error)
+}
+
+fn remote_model_input_error(error: RemoteModelQueryV2Error) -> Error {
+    match error {
+        RemoteModelQueryV2Error::Diagnostic(error) => Error::from_remote_diagnostic(error),
+        RemoteModelQueryV2Error::Match(error) => {
+            Error::from_match(error, crate::ModelValidationPhase::Input)
+        }
     }
 }
 
-fn remote_model_error(error: RemoteModelQueryV2Error) -> Error {
-    Error::Other {
-        message: error.to_string(),
-        source: Some(Box::new(error)),
+fn remote_model_hydration_error(error: RemoteModelQueryV2Error) -> Error {
+    match error {
+        RemoteModelQueryV2Error::Diagnostic(error) => Error::from_remote_diagnostic(error),
+        RemoteModelQueryV2Error::Match(error) => {
+            Error::from_match(error, crate::ModelValidationPhase::Hydration)
+        }
     }
 }
 
@@ -252,6 +268,9 @@ mod tests {
     use std::sync::Mutex;
 
     use type_bridge_contract::codec::to_canonical_json;
+    use type_bridge_contract::diagnostic::{
+        Diagnostic, DiagnosticCategory, DiagnosticCode, DiagnosticPathSegment,
+    };
     use type_bridge_contract::fingerprint::SemanticProfileId;
     use type_bridge_contract::migration_assertion::BindingId;
     use type_bridge_contract::projection::{BindingTarget, ProjectionConfig};
@@ -262,6 +281,8 @@ mod tests {
         RemoteResultKindV2, query_remote_v2_required_capabilities,
     };
     use type_bridge_contract::schema::{DocumentId, encode_declared_schema};
+    use type_bridge_orm::OrmError;
+    use type_bridge_orm::match_request::SessionHandle;
     use type_bridge_orm::query_v2_remote::RemoteReplySigningKey;
     use type_bridge_schema::{SchemaDocumentSet, normalize_documents, project, resolve};
     use type_bridge_schema_codegen::RustEmitter;
@@ -311,6 +332,45 @@ mod tests {
         fn into_encoded_create(self) -> std::result::Result<EncodedCreate, ValidationError> {
             Ok(EncodedCreate::new(Person::TYPE_ID_JSON, vec![], vec![]))
         }
+    }
+
+    #[test]
+    fn local_and_remote_failures_preserve_classification_codes_and_paths() {
+        let session = SessionHandle::new(Arc::new(DescriptorRegistry::new()));
+        let match_error = match session.exact("missing") {
+            Err(OrmError::Match(error)) => error,
+            Err(other) => panic!("unexpected ORM error: {other:?}"),
+            Ok(_) => panic!("missing descriptor unexpectedly resolved"),
+        };
+        let local = Error::from_orm(OrmError::Match(match_error.clone()));
+        let remote = remote_model_input_error(RemoteModelQueryV2Error::Match(match_error));
+
+        assert_eq!(local.category(), crate::ErrorCategory::QueryAuthoring);
+        assert_eq!(remote.category(), local.category());
+        assert_eq!(remote.code(), Some("unknown_descriptor"));
+        assert_eq!(remote.code(), local.code());
+        assert_eq!(remote.path(), local.path());
+        assert_eq!(
+            remote.model_validation_phase(),
+            local.model_validation_phase()
+        );
+
+        let diagnostic = Diagnostic::new(
+            DiagnosticCategory::UnsupportedCapability,
+            DiagnosticCode::new("missing_remote_capability").unwrap(),
+            "the remote executor does not advertise one required capability",
+        )
+        .at(DiagnosticPathSegment::Field("capabilities".into()))
+        .at(DiagnosticPathSegment::Index(2));
+        let classified = remote_diagnostic(diagnostic);
+
+        assert_eq!(classified.category(), crate::ErrorCategory::Capability);
+        assert_eq!(classified.code(), Some("missing_remote_capability"));
+        assert_eq!(
+            classified.path(),
+            Some(&["capabilities".to_owned(), "[2]".to_owned()][..])
+        );
+        assert_eq!(classified.model_validation_phase(), None);
     }
 
     fn package() -> SchemaPackage<TestSchema> {

--- a/type-bridge-core/crates/schema-codegen/tests/rust_projection_live/consumer.rs
+++ b/type-bridge-core/crates/schema-codegen/tests/rust_projection_live/consumer.rs
@@ -56,13 +56,14 @@ impl RemoteQueryTransport for HttpTransport {
                 .windows(b"typebridge.query-remote-capabilities/v1".len())
                 .any(|window| window == b"typebridge.query-remote-capabilities/v1")
             {
-                return Err(type_bridge::Error::Other {
-                    message: format!(
+                return Err(type_bridge::Error::remote(
+                    "remote_capability_advertisement",
+                    format!(
                         "remote capability discovery returned a non-advertisement: {}",
                         String::from_utf8_lossy(&bytes)
                     ),
-                    source: None,
-                });
+                    None,
+                ));
             }
             Ok(bytes)
         })
@@ -90,10 +91,11 @@ impl RemoteQueryTransport for HttpTransport {
 }
 
 fn transport_error(error: reqwest::Error) -> type_bridge::Error {
-    type_bridge::Error::Other {
-        message: error.to_string(),
-        source: Some(Box::new(error)),
-    }
+    type_bridge::Error::remote(
+        "remote_transport",
+        error.to_string(),
+        Some(Box::new(error)),
+    )
 }
 
 fn connection_options() -> ConnectionOptions {


### PR DESCRIPTION
## Summary

Close the remaining public generated-model Rust client gap found after #199:
canonical query failures and remote diagnostics were flattened into generic
database/client errors, losing their public classification, stable code, and
structured path.

This change preserves that evidence through direct and remote adapters and
turns all 15 acceptance criteria from #198 into a checked, source-tied ledger.

## Key changes

- Add a non-exhaustive public `ErrorCategory` contract and classified error
  representation with stable category spellings.
- Preserve canonical match-error and remote-diagnostic codes, paths, and
  input-versus-hydration validation phases.
- Classify remote response ceilings and give caller-owned transports
  `Error::remote` for stable transport failures.
- Add regression tests for pre-I/O query-authoring failures, local/remote
  classification parity, remote diagnostic paths, and public category
  spellings.
- Check every #198 criterion against live or offline source evidence,
  including an explicit upward-dependency guard.
- Update the Rust guide, parity guide, changelog, and TypeBridge skill with
  the public diagnostic workflow.

## Verification

- `./scripts/check.sh rust` — 7/7 source-tree Rust gates passed.
- `cargo test -p type-bridge --lib --tests --no-default-features` — 116 passed.
- `cargo test -p type-bridge-schema-codegen --test rust_acceptance` — 26 passed.
- `cargo clippy -p type-bridge --all-targets -- -D warnings` — passed.
- `uv run pytest -q tests/unit/compat/test_rust_generated_parity_inventory.py`
  — 3 passed.
- `uv run --extra docs mkdocs build --strict --site-dir tmp/site-review-198`
  — passed.
- TypeBridge skill validation, focused Ruff checks, Cargo formatting, and
  diff whitespace — passed.

Exact amd64/arm64 server-image candidate acceptance remains the release-level
gate in #188 and is intentionally not dispatched by this PR.

Closes #198
