### PR TITLE
fix(release): isolate legacy Python compatibility consumer (#188)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -453,7 +453,7 @@ jobs:
           set -euo pipefail
           released_root_dir="$GITHUB_WORKSPACE/tmp/released-python-root"
           dependency_wheelhouse="$GITHUB_WORKSPACE/tmp/released-root-dependencies"
-          compat_venv="$GITHUB_WORKSPACE/tmp/released-root-candidate-core"
+          compat_venv="$RUNNER_TEMP/released-root-candidate-core"
           mkdir -p "$released_root_dir" "$dependency_wheelhouse"
           python -m pip download \
             --disable-pip-version-check \

--- a/tests/unit/infra/test_release_artifact_gates.py
+++ b/tests/unit/infra/test_release_artifact_gates.py
@@ -470,6 +470,8 @@ def test_published_v1_root_is_exercised_against_candidate_core_offline() -> None
     assert "--verify-pypi-authority" in reverse
     assert "type_bridge_core-*linux*x86_64.whl" in reverse
     assert "Dependency wheelhouse unexpectedly contains type-bridge-core" in reverse
+    assert 'compat_venv="$RUNNER_TEMP/released-root-candidate-core"' in reverse
+    assert 'compat_venv="$GITHUB_WORKSPACE/' not in reverse
     assert 'uv pip install --python "$compat_venv/bin/python" \\\n            --no-index' in reverse
     pair_install = reverse[reverse.rindex("uv pip install") :]
     assert "--no-deps" in pair_install


### PR DESCRIPTION
## Summary

- keep the published-V1/candidate-core compatibility consumer physically
  outside the source checkout by placing its prepared virtual environment under
  `RUNNER_TEMP`
- preserve the frozen probe's strict rule that every path resolving into the
  checkout is a source leak
- add a workflow contract test that requires the external location and rejects
  the failed `GITHUB_WORKSPACE` layout

## Candidate evidence

Candidate run
[`30595442987`](https://github.com/ds1sqe/type-bridge/actions/runs/30595442987)
was pinned to `e362cdfea3d84d00c73407a930acadd5ee71cd45`.

- 31 jobs passed, including all Node, OCI, wheel-build, identity, and live
  Python/TypeDB parity lanes
- the three Python artifact acceptance jobs failed before compatibility
  behavior because the probe correctly classified their virtualenv under
  `$GITHUB_WORKSPACE/tmp` as part of the checkout
- the exact `2.0.0rc0` artifacts pass the unchanged frozen probe when installed
  under the system temporary directory
- all six preflight/publication jobs were skipped; no tag, registry package,
  container, or GitHub Release was created

The failed run cannot be rerun with this fix because GitHub reruns retain the
original workflow SHA. A fresh candidate run on the merge SHA is the next
release gate.

## Verification

- `uv run pytest -q tests/unit/compat/test_legacy_python_runner.py tests/unit/infra/test_release_artifact_gates.py` — 72 passed
- `uv run pytest -q` — 2,934 passed, 1 skipped
- `./scripts/check.sh python` — 9 checks passed, including Ruff, formatting,
  both Pyright trees, negative typing contracts, schema-codegen acceptance, and
  2,863 unit tests

Refs #188
