### PR TITLE
chore(release): prepare TypeBridge 2.0.0 (#188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,44 @@ All notable changes to TypeBridge will be documented in this file.
 
 ## [Unreleased]
 
-### Changed
+## [2.0.0] - 2026-07-31
 
-- **Fail-fast schema-annotation compatibility** - all ORM schema-query
-  boundaries now reject `@doc`/`@meta` before provider dispatch when the known
-  TypeDB server is older than 3.12. One-shot execution rejects before opening
-  a transaction, while caller-owned schema transactions reject before their
-  provider query. The 3.12 generated-projection fixture remains annotation
-  preserving and runs only in the 3.12 TLS lane; older lanes continue to prove
-  transport compatibility.
+### New Features
 
+- **Canonical Split-YAML schema and multi-language projections (#188)** -
+  TypeBridge V2 workspaces now make versioned
+  `typebridge.schema-set/v1` manifests and `typebridge.schema/v2` fragments
+  the canonical schema authority. The strict, bounded YAML subset rejects
+  unknown or duplicate facts, unsupported future shapes, unsafe paths, and
+  nondeterministic discovery before provider I/O. Rust resolves the complete
+  document set once and projects the same declared meaning into Python,
+  TypeScript/Node, and Rust bindings. The workspace CLI validates schemas
+  offline with `schema check`, generates every configured SDK with
+  `schema generate`, and emits the deterministic authority consumed by V2
+  executors with `schema export-declared`.
+- **Offline history-based migrations and workspace CLI (#188)** - Rust now
+  authors immutable `migrations/v2` programs from the desired schema and
+  committed history, orders and verifies the chain, detects drift, and never
+  infers destructive approval. The `type-bridge migration` CLI exposes
+  `make`, `plan`, `apply`, `verify`, and `adopt` against named workspace
+  environments. Legacy adoption validates the complete dependency graph,
+  applied ledger, original checksums, portable sidecars, and snapshot
+  authority; it records a writer cutover and canonical
+  `adopted-genesis.typeql` without re-executing legacy operations such as
+  `RunPython`. Failed adoption remains retryable, while retained legacy
+  readers and historical artifacts stay available.
+- **Authenticated local/remote Query V2 and standalone executor (#188)** -
+  the same Rust-owned canonical plan, invocation, schema/profile validation,
+  capability checks, limits, and structured diagnostics now govern direct
+  execution and the standalone server's `/v2/capabilities` and `/v2/query`
+  routes. Prepared remote requests bind the executor identity, nonce,
+  fingerprint, expiry, capability set, and response budget before provider
+  transaction construction; signed successes and failures are authenticated
+  before hydration. The capability advertisement is an explicit trust input
+  that callers obtain over authenticated TLS or pin out of band. One awaited
+  remote terminal performs exactly one caller-owned exchange with no built-in
+  discovery, credential, HTTP-client, retry, traversal, or follow-up hydration
+  behavior.
 - **Complete V2 query authoring and remote model facade (#195)** - Python now
   exposes the complete low-level Rust plan builder from
   `type_bridge.query_v2`, with the equivalent Node API at
@@ -43,6 +71,34 @@ All notable changes to TypeBridge will be documented in this file.
   contract. Bounds and expansion budgets fail during construction before
   provider I/O, and Rust lowers the full range into one query without
   client-side traversal.
+- **Public generated Rust application client** - `type-bridge` and generated
+  schema crates now expose owner-branded entity/relation CRUD, exact and
+  subtype reads, complete replacement, reusable write/read transactions,
+  typed expressions and reductions, selected/collected pages, bounded
+  reachability, and identical local/one-exchange remote materialization. The
+  generated crate has only one direct TypeBridge dependency and the complete
+  consumer contract is accepted on Rust 1.88. Public `ErrorCategory`, stable
+  codes, structured paths, and validation phases now survive both direct and
+  remote adapters; caller-owned transports use `Error::remote` for classified
+  transport failures.
+- **Hardened server OCI distribution** -
+  `ghcr.io/ds1sqe/type-bridge-server:2.0.0` is built once for `linux/amd64`
+  and `linux/arm64` from digest-pinned bases with the locked V2-capable server.
+  Exact layouts run as UID/GID 10001 with a read-only root, no capabilities,
+  and no-new-privileges; acceptance covers V1 compatibility, authenticated V2,
+  and the external generated Rust application. Stable publication imports the
+  accepted manifests without rebuilding, verifies all aliases and digests,
+  and attaches keyless signatures, SPDX SBOMs, provenance, and scan evidence.
+
+### Changed
+
+- **Fail-fast schema-annotation compatibility** - all ORM schema-query
+  boundaries now reject `@doc`/`@meta` before provider dispatch when the known
+  TypeDB server is older than 3.12. One-shot execution rejects before opening
+  a transaction, while caller-owned schema transactions reject before their
+  provider query. The 3.12 generated-projection fixture remains annotation
+  preserving and runs only in the 3.12 TLS lane; older lanes continue to prove
+  transport compatibility.
 - **Legacy TypeDB server notices (#189)** - each successful TypeDB 3.8/3.10
   connection now emits one filterable compatibility notice while continuing
   normally: Python uses `TypeDBServerDeprecationWarning`, Node uses standard
@@ -97,16 +153,6 @@ All notable changes to TypeBridge will be documented in this file.
   other removal or calendar cutoff — there is no 3.0.0 removal plan;
   deployments retaining any scheduled surface can pin
   `type-bridge>=2,<2.1`.
-- **Public generated Rust application client** - `type-bridge` and generated
-  schema crates now expose owner-branded entity/relation CRUD, exact and
-  subtype reads, complete replacement, reusable write/read transactions,
-  typed expressions and reductions, selected/collected pages, bounded
-  reachability, and identical local/one-exchange remote materialization. The
-  generated crate has only one direct TypeBridge dependency and the complete
-  consumer contract is accepted on Rust 1.88. Public `ErrorCategory`, stable
-  codes, structured paths, and validation phases now survive both direct and
-  remote adapters; caller-owned transports use `Error::remote` for classified
-  transport failures.
 - **Rust V2 source/Git distribution boundary** - the internal V2 semantic,
   migration, projection, workspace, and CLI crates remain first-party
   workspace packages with `publish = false`; they are not crates.io release
@@ -115,14 +161,6 @@ All notable changes to TypeBridge will be documented in this file.
   revision instead of publishing a broken crates.io package. The release gate
   blocks Cargo mutation and names the exact source/Git SDK in the closed
   artifact set.
-- **Hardened server OCI distribution** -
-  `ghcr.io/ds1sqe/type-bridge-server:2.0.0` is built once for `linux/amd64`
-  and `linux/arm64` from digest-pinned bases with the locked V2-capable server.
-  Exact layouts run as UID/GID 10001 with a read-only root, no capabilities,
-  and no-new-privileges; acceptance covers V1 compatibility, authenticated V2,
-  and the external generated Rust application. Stable publication imports the
-  accepted manifests without rebuilding, verifies all aliases and digests,
-  and attaches keyless signatures, SPDX SBOMs, provenance, and scan evidence.
 - **Direct Python driver 3.12.1** - CPython 3.14 dependency markers, native
   artifact probes, and live compatibility cells now use the current 3.12.1
   Python driver patch; CPython 3.12–3.13 retains the released multi-line
@@ -153,6 +191,21 @@ All notable changes to TypeBridge will be documented in this file.
   Namespacing is solely a Cargo package-identity mechanism that permits all
   protocol bands in one native graph. TypeDB remains the original upstream
   owner, and its Apache-2.0/MPL-2.0 licenses are preserved.
+
+### Documentation
+
+- **Multi-surface documentation and contributor workflow (#200)** - the
+  public README and MkDocs site now present TypeBridge as one Rust semantic
+  engine exposed through Python, TypeScript/Node, generated Rust, schema and
+  migration tooling, immutable queries, and the standalone server. The
+  README is kept below 200 lines with a runnable schema-before-CRUD quick
+  start and an accessible repository-owned hero that renders on package
+  pages. Stable detailed URLs now sit behind focused SDK, modeling, data,
+  schema, operations, Python API, and maintainer routes.
+  `DEVELOPMENT.md` is the canonical contributor guide, with regular
+  cross-platform `AGENTS.md` and `CLAUDE.md` pointers; stale test totals and
+  directory snapshots are removed, and `docs/SKILL.md` now validates and
+  routes workflows across every supported product surface.
 
 ## [1.5.11] - 2026-07-19
 

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -36,7 +36,7 @@ abi3 wheels do not require the variable.
 ### Project Dependencies
 
 The project requires:
-- `type-bridge-core==2.0.0rc0`: same-version Rust runtime for ORM connectivity and query execution;
+- `type-bridge-core==2.0.0`: same-version Rust runtime for ORM connectivity and query execution;
   the facade and native semantic engine release in exact lockstep
 - `pydantic>=2.12.4`: For validation and type coercion
 - `isodate==0.7.2`: For Duration type support (ISO 8601)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "type-bridge"
-version = "2.0.0rc0"
+version = "2.0.0"
 description = "Typed Python, TypeScript, and Rust application tooling for TypeDB"
 readme = "README.md"
 requires-python = ">=3.12,<3.15"
@@ -14,7 +14,7 @@ authors = [
 ]
 keywords = ["typedb", "orm", "database", "typeql", "graph-database"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
@@ -30,7 +30,7 @@ dependencies = [
     "jinja2>=3.1.0",
     "typer>=0.15.0",
     # The facade and native semantic engine are one release unit.
-    "type-bridge-core==2.0.0rc0",
+    "type-bridge-core==2.0.0",
     "typing-extensions>=4.12",
 ]
 

--- a/tests/compat/typed_python/README.md
+++ b/tests/compat/typed_python/README.md
@@ -10,8 +10,8 @@ third-party runtime dependencies and an explicit Pyright executable:
 
 ```bash
 python scripts/ci/run_typed_python_artifact.py \
-  --root-wheel /artifacts/type_bridge-2.0.0rc0-py3-none-any.whl \
-  --core-wheel /artifacts/type_bridge_core-2.0.0rc0-*.whl \
+  --root-wheel /artifacts/type_bridge-2.0.0-py3-none-any.whl \
+  --core-wheel /artifacts/type_bridge_core-2.0.0-*.whl \
   --python /prepared/venv/bin/python \
   --pyright /prepared/venv/bin/pyright
 ```

--- a/tests/unit/compat/test_python_release_artifact_validator.py
+++ b/tests/unit/compat/test_python_release_artifact_validator.py
@@ -32,7 +32,7 @@ def load_module(name: str, path: Path) -> ModuleType:
 
 
 validator = load_module("validate_python_release_artifacts", VALIDATOR_PATH)
-VERSION = "2.0.0rc0"
+VERSION = "2.0.0"
 SPECS = validator.load_package_specs(ROOT, VERSION)
 CORE_PLATFORMS = {
     "linux-x86_64": "manylinux_2_17_x86_64",
@@ -634,9 +634,9 @@ def test_core_wheel_rejects_elf_newer_than_manylinux_policy(tmp_path: Path) -> N
     "extra_member",
     [
         "hostile/__init__.py",
-        "type_bridge-2.0.0rc0.data/purelib/hostile.py",
-        "type_bridge-2.0.0rc0.data/platlib/hostile.py",
-        "type_bridge-2.0.0rc0.data/scripts/hostile",
+        "type_bridge-2.0.0.data/purelib/hostile.py",
+        "type_bridge-2.0.0.data/platlib/hostile.py",
+        "type_bridge-2.0.0.data/scripts/hostile",
     ],
 )
 def test_root_wheel_rejects_unexpected_install_payload(
@@ -1050,10 +1050,10 @@ def test_repository_version_must_match_release_tag() -> None:
 @pytest.mark.parametrize(
     "replacement",
     (
-        "type-bridge-core>=2.0.0rc0",
-        "type-bridge-core==2.0.0rc0; python_version >= '3.12'",
-        "TYPE-BRIDGE-CORE==2.0.0rc0",
-        "type_bridge_core==2.0.0rc0",
+        "type-bridge-core>=2.0.0",
+        "type-bridge-core==2.0.0; python_version >= '3.12'",
+        "TYPE-BRIDGE-CORE==2.0.0",
+        "type_bridge_core==2.0.0",
     ),
 )
 def test_artifact_gate_rejects_noncanonical_root_core_requirements(
@@ -1063,7 +1063,7 @@ def test_artifact_gate_rejects_noncanonical_root_core_requirements(
     manifest, _ = copy_root_python_contract(tmp_path)
     manifest.write_text(
         manifest.read_text(encoding="utf-8").replace(
-            "type-bridge-core==2.0.0rc0",
+            "type-bridge-core==2.0.0",
             replacement,
             1,
         ),
@@ -1080,8 +1080,8 @@ def test_artifact_gate_rejects_duplicate_normalized_root_core_requirements(
     manifest, _ = copy_root_python_contract(tmp_path)
     manifest.write_text(
         manifest.read_text(encoding="utf-8").replace(
-            '"type-bridge-core==2.0.0rc0",',
-            '"type-bridge-core==2.0.0rc0",\n    "type.bridge.core==2.0.0rc0",',
+            '"type-bridge-core==2.0.0",',
+            '"type-bridge-core==2.0.0",\n    "type.bridge.core==2.0.0",',
             1,
         ),
         encoding="utf-8",
@@ -1095,7 +1095,7 @@ def test_artifact_gate_binds_import_visible_python_version(tmp_path: Path) -> No
     _, package_init = copy_root_python_contract(tmp_path)
     package_init.write_text(
         package_init.read_text(encoding="utf-8").replace(
-            '__version__ = "2.0.0rc0"',
+            '__version__ = "2.0.0"',
             '__version__ = "2.0.0rc1"',
             1,
         ),

--- a/tests/unit/compat/test_release_identity_validator.py
+++ b/tests/unit/compat/test_release_identity_validator.py
@@ -45,9 +45,9 @@ validator.LEGACY_VENDOR_DESCRIPTIONS[SYNTHETIC_PROTOCOL_NAME] = (
 def validate(**overrides: object) -> dict[str, Any]:
     """Run the gate against repository authorities by default."""
     arguments: dict[str, object] = {
-        "tag": "v2.0.0-rc.0",
+        "tag": "v2.0.0",
         "artifact_contract": validator.ARTIFACT_CONTRACT_PYTHON_NPM_ONLY,
-        "release_channel": validator.RELEASE_CHANNEL_CANDIDATE,
+        "release_channel": validator.RELEASE_CHANNEL_STABLE,
         "workspace_manifest": ROOT / "type-bridge-core/Cargo.toml",
         "root_python_manifest": ROOT / "pyproject.toml",
         "core_python_manifest": ROOT / "type-bridge-core/pyproject.toml",
@@ -144,19 +144,19 @@ def replace_both_native_notices(workspace: Path, old: str, new: str) -> None:
         notice.write_text(source.replace(old, new, 1))
 
 
-def test_repository_python_npm_candidate_identity_is_complete() -> None:
+def test_repository_python_npm_stable_identity_is_complete() -> None:
     report = validate()
 
     assert report["status"] == "ok"
     assert report["artifact_contract"] == "python-npm-only"
     assert report["crates_io_mutation"] is False
-    assert report["release_channel"] == "candidate"
-    assert report["tag"] == "v2.0.0-rc.0"
-    assert report["version"] == "2.0.0-rc.0"
-    assert report["python_version"] == "2.0.0rc0"
-    assert report["python_core_requirement"] == "type-bridge-core==2.0.0rc0"
-    assert report["python_package_version"] == "2.0.0rc0"
-    assert report["node_package_lock_version"] == "2.0.0-rc.0"
+    assert report["release_channel"] == "stable"
+    assert report["tag"] == "v2.0.0"
+    assert report["version"] == "2.0.0"
+    assert report["python_version"] == "2.0.0"
+    assert report["python_core_requirement"] == "type-bridge-core==2.0.0"
+    assert report["python_package_version"] == "2.0.0"
+    assert report["node_package_lock_version"] == "2.0.0"
     assert set(report["cargo_licenses"].values()) == {
         "MIT",
         "Apache-2.0",
@@ -315,7 +315,7 @@ def test_v2_crate_manifest_remains_first_party_and_unpublished(
     )["package"]
 
     assert manifest["name"] == package_name
-    assert manifest["version"] == "2.0.0-rc.0"
+    assert manifest["version"] == "2.0.0"
     assert manifest["publish"] is False
 
 
@@ -335,7 +335,7 @@ def test_binding_crate_manifest_remains_first_party_and_unpublished(
     )["package"]
 
     assert manifest["name"] == package_name
-    assert manifest["version"] == "2.0.0-rc.0"
+    assert manifest["version"] == "2.0.0"
     assert manifest["publish"] is False
 
 
@@ -633,11 +633,11 @@ def test_release_artifact_contract_must_be_known() -> None:
 @pytest.mark.parametrize(
     "replacement",
     (
-        "type-bridge-core>=2.0.0rc0",
-        "type-bridge-core==2.0.0rc0; python_version >= '3.12'",
-        "Type-Bridge-Core==2.0.0rc0",
-        "type_bridge_core==2.0.0rc0",
-        "type.bridge.core==2.0.0rc0",
+        "type-bridge-core>=2.0.0",
+        "type-bridge-core==2.0.0; python_version >= '3.12'",
+        "Type-Bridge-Core==2.0.0",
+        "type_bridge_core==2.0.0",
+        "type.bridge.core==2.0.0",
     ),
 )
 def test_root_python_core_requirement_must_be_canonical_exact_and_unmarked(
@@ -646,9 +646,9 @@ def test_root_python_core_requirement_must_be_canonical_exact_and_unmarked(
 ) -> None:
     manifest, package_init = copy_root_python_authorities(tmp_path)
     source = manifest.read_text(encoding="utf-8")
-    assert "type-bridge-core==2.0.0rc0" in source
+    assert "type-bridge-core==2.0.0" in source
     manifest.write_text(
-        source.replace("type-bridge-core==2.0.0rc0", replacement, 1),
+        source.replace("type-bridge-core==2.0.0", replacement, 1),
         encoding="utf-8",
     )
 
@@ -663,9 +663,9 @@ def test_root_python_core_requirement_cannot_be_duplicated_under_an_alias(
     source = manifest.read_text(encoding="utf-8")
     manifest.write_text(
         source.replace(
-            '"type-bridge-core==2.0.0rc0",',
-            '"type-bridge-core==2.0.0rc0",\n'
-            "    \"TYPE_BRIDGE_CORE==2.0.0rc0; python_version >= '3.12'\",",
+            '"type-bridge-core==2.0.0",',
+            '"type-bridge-core==2.0.0",\n'
+            "    \"TYPE_BRIDGE_CORE==2.0.0; python_version >= '3.12'\",",
             1,
         ),
         encoding="utf-8",
@@ -679,8 +679,8 @@ def test_import_visible_python_version_must_match_manifest_and_tag(tmp_path: Pat
     manifest, package_init = copy_root_python_authorities(tmp_path)
     package_init.write_text(
         package_init.read_text(encoding="utf-8").replace(
-            '__version__ = "2.0.0rc0"',
-            '__version__ = "2.0.0rc1"',
+            '__version__ = "2.0.0"',
+            '__version__ = "2.0.1"',
             1,
         ),
         encoding="utf-8",
@@ -737,8 +737,8 @@ def test_first_party_cargo_version_drift_hard_fails(tmp_path: Path) -> None:
     manifest = workspace.parent / "crates/orm/Cargo.toml"
     manifest.write_text(
         manifest.read_text().replace(
-            'version = "2.0.0-rc.0"',
-            'version = "2.0.0-rc.1"',
+            'version = "2.0.0"',
+            'version = "2.0.1"',
             1,
         )
     )
@@ -752,8 +752,8 @@ def test_unpublished_binding_crate_version_drift_hard_fails(tmp_path: Path) -> N
     manifest = workspace.parent / "crates/python/Cargo.toml"
     manifest.write_text(
         manifest.read_text().replace(
-            'version = "2.0.0-rc.0"',
-            'version = "2.0.0-rc.1"',
+            'version = "2.0.0"',
+            'version = "2.0.1"',
             1,
         )
     )
@@ -1622,7 +1622,7 @@ def test_public_crate_path_dependency_requires_a_release_version(tmp_path: Path)
     manifest = workspace.parent / "crates/server/Cargo.toml"
     manifest.write_text(
         manifest.read_text().replace(
-            'type-bridge-contract = { path = "../contract", version = "2.0.0-rc.0", optional = true }',
+            'type-bridge-contract = { path = "../contract", version = "2.0.0", optional = true }',
             'type-bridge-contract = { path = "../contract", optional = true }',
             1,
         )
@@ -1637,7 +1637,7 @@ def test_python_npm_contract_rejects_a_missing_known_blocker_edge(
 ) -> None:
     workspace = copy_workspace_manifests(tmp_path)
     manifest = workspace.parent / "crates/core/Cargo.toml"
-    dependency = 'type-bridge-contract = { path = "../contract", version = "2.0.0-rc.0" }\n'
+    dependency = 'type-bridge-contract = { path = "../contract", version = "2.0.0" }\n'
     source = manifest.read_text()
     assert dependency in source
     manifest.write_text(source.replace(dependency, "", 1))
@@ -1656,8 +1656,8 @@ def test_public_crate_cannot_depend_on_an_unpublished_workspace_crate(
     manifest = workspace.parent / "crates/migration/Cargo.toml"
     manifest.write_text(
         manifest.read_text().replace(
-            'type-bridge-schema-compat = { path = "../schema-compat", version = "2.0.0-rc.0" }',
-            'type-bridge-schema-compat = { package = "type-bridge-cli", path = "../cli", version = "2.0.0-rc.0" }',
+            'type-bridge-schema-compat = { path = "../schema-compat", version = "2.0.0" }',
+            'type-bridge-schema-compat = { package = "type-bridge-cli", path = "../cli", version = "2.0.0" }',
             1,
         )
     )

--- a/tests/unit/infra/test_python_v2_platform_artifact.py
+++ b/tests/unit/infra/test_python_v2_platform_artifact.py
@@ -31,7 +31,7 @@ def smoke_args(
         root_dist_dir=root_dist_dir,
         core_dist_dir=core_dist_dir,
         work_dir=tmp_path / "work",
-        expected_version="2.0.0rc0",
+        expected_version="2.0.0",
         source_root=source_root,
         declared_schema=declared_schema,
     )
@@ -39,11 +39,11 @@ def smoke_args(
 
 def test_one_wheel_requires_exactly_one_direct_regular_file(tmp_path: Path) -> None:
     wheel_dir = tmp_path / "wheels"
-    expected = touch_wheel(wheel_dir, "type_bridge-2.0.0rc0-py3-none-any.whl")
+    expected = touch_wheel(wheel_dir, "type_bridge-2.0.0-py3-none-any.whl")
 
     assert artifact_smoke.one_wheel(wheel_dir, "type_bridge-*.whl", label="root") == expected
 
-    touch_wheel(wheel_dir, "type_bridge-2.0.0rc0-py2-none-any.whl")
+    touch_wheel(wheel_dir, "type_bridge-2.0.0-py2-none-any.whl")
     with pytest.raises(
         artifact_smoke.ArtifactSmokeError,
         match="Expected exactly one root",
@@ -53,7 +53,7 @@ def test_one_wheel_requires_exactly_one_direct_regular_file(tmp_path: Path) -> N
 
 def test_one_wheel_rejects_symbolic_directory_and_candidate(tmp_path: Path) -> None:
     actual_dir = tmp_path / "actual"
-    wheel = touch_wheel(actual_dir, "type_bridge-2.0.0rc0-py3-none-any.whl")
+    wheel = touch_wheel(actual_dir, "type_bridge-2.0.0-py3-none-any.whl")
     symbolic_dir = tmp_path / "symbolic-dir"
     symbolic_dir.symlink_to(actual_dir, target_is_directory=True)
 
@@ -85,8 +85,8 @@ def test_run_rejects_symbolic_source_inputs_before_environment_creation(
 ) -> None:
     root_dist = tmp_path / "root-dist"
     core_dist = tmp_path / "core-dist"
-    touch_wheel(root_dist, "type_bridge-2.0.0rc0-py3-none-any.whl")
-    touch_wheel(core_dist, "type_bridge_core-2.0.0rc0-cp312-abi3-linux_x86_64.whl")
+    touch_wheel(root_dist, "type_bridge-2.0.0-py3-none-any.whl")
+    touch_wheel(core_dist, "type_bridge_core-2.0.0-cp312-abi3-linux_x86_64.whl")
 
     actual_source = tmp_path / "source"
     actual_source.mkdir()

--- a/tests/unit/infra/test_release_artifact_gates.py
+++ b/tests/unit/infra/test_release_artifact_gates.py
@@ -133,6 +133,8 @@ def test_supported_python_range_is_declared_and_exercised() -> None:
     assert core["project"]["requires-python"] == ">=3.12,<3.15"
     assert expected_versions <= set(root["project"]["classifiers"])
     assert expected_versions <= set(core["project"]["classifiers"])
+    assert "Development Status :: 5 - Production/Stable" in set(root["project"]["classifiers"])
+    assert "Development Status :: 3 - Alpha" not in set(root["project"]["classifiers"])
     assert "typing-extensions>=4.12" in root["project"]["dependencies"]
 
     ci = CI_WORKFLOW.read_text(encoding="utf-8")

--- a/type-bridge-core/Cargo.lock
+++ b/type-bridge-core/Cargo.lock
@@ -3110,7 +3110,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "type-bridge"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 dependencies = [
  "regex",
  "serde_json",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-cli"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 dependencies = [
  "clap",
  "serde_json",
@@ -3146,7 +3146,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-contract"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3156,7 +3156,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-core"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 dependencies = [
  "pyo3",
  "pythonize",
@@ -3175,7 +3175,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-core-lib"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 dependencies = [
  "cap-fs-ext",
  "cap-std",
@@ -3201,7 +3201,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-migration"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 dependencies = [
  "anstream 0.6.21",
  "anstyle",
@@ -3227,7 +3227,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-node"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -3243,7 +3243,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-orm"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 dependencies = [
  "base64",
  "criterion",
@@ -3270,7 +3270,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-orm-derive"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-query"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 dependencies = [
  "type-bridge-contract",
  "type-bridge-schema",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-schema"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -3302,7 +3302,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-schema-codegen"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 dependencies = [
  "type-bridge-contract",
  "type-bridge-schema",
@@ -3310,7 +3310,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-schema-compat"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-schema-migration"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 dependencies = [
  "cap-fs-ext",
  "cap-std",
@@ -3339,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-schema-migration-typedb"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3356,7 +3356,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-server"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 dependencies = [
  "axum 0.8.8",
  "axum-server",
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-toml-transpiler"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 dependencies = [
  "indexmap 2.13.1",
  "serde",
@@ -3468,7 +3468,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-typedb-runtime"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "type-bridge-workspace"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 dependencies = [
  "cap-fs-ext",
  "cap-std",

--- a/type-bridge-core/README.md
+++ b/type-bridge-core/README.md
@@ -15,27 +15,27 @@ type-bridge-core/
     ├── schema-migration*/                  # offline and TypeDB migration execution
     ├── schema-compat/, schema-codegen/     # compatibility input and projections
     ├── typedb-runtime/, orm/, orm-derive/  # provider bands and ORM
-    ├── workspace/, cli/, server/           # workspace and executable products
+    ├── workspace/, cli/, server/, rust/    # workspace, server, and Rust SDK
     ├── python/, node/                      # native bindings
     └── core/, migration/, toml-transpiler/ # released engines and converters
 ```
 
 ## Crate groups
 
-The workspace has 18 first-party crates. `contract`, `schema`, `query`, and the
+The workspace has 19 first-party crates. `contract`, `schema`, `query`, and the
 schema-migration crates own the canonical V2 semantics; `schema-compat` and
 `schema-codegen` project those semantics into released and generated surfaces;
 `typedb-runtime`, `orm`, and `orm-derive` own provider execution; and
-`workspace`, `cli`, `server`, `python`, and `node` expose the product surfaces.
-The released core, migration reader, and TOML converter remain separate
-compatibility boundaries.
+`workspace`, `cli`, `server`, `rust`, `python`, and `node` expose the product
+surfaces. The released core, migration reader, and TOML converter remain
+separate compatibility boundaries.
 
 ## Rust publication boundary
 
 The nine V2 implementation crates are workspace-internal: `contract`,
 `schema`, `query`, `schema-migration`, `schema-migration-typedb`,
 `schema-codegen`, `schema-compat`, `workspace`, and `cli`. Their first-party
-versions track the repository release identity (currently `2.0.0-rc.0`), but every
+versions track the repository release identity (currently `2.0.0`), but every
 manifest remains `publish = false`. They are built into the Python and Node
 products from workspace source and are not crates.io release identities.
 

--- a/type-bridge-core/crates/cli/Cargo.toml
+++ b/type-bridge-core/crates/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "type-bridge-cli"
 description = "TypeBridge V2 workspace command-line interface"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 edition = "2024"
 license.workspace = true
 license-file.workspace = true
@@ -14,15 +14,15 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 tokio = { version = "1", features = ["rt-multi-thread"] }
-type-bridge-contract = { path = "../contract", version = "2.0.0-rc.0" }
-type-bridge-orm = { path = "../orm", version = "2.0.0-rc.0" }
-type-bridge-schema = { path = "../schema", version = "2.0.0-rc.0" }
-type-bridge-migration = { path = "../migration", version = "2.0.0-rc.0" }
-type-bridge-schema-codegen = { path = "../schema-codegen", version = "2.0.0-rc.0" }
-type-bridge-schema-compat = { path = "../schema-compat", version = "2.0.0-rc.0" }
-type-bridge-schema-migration = { path = "../schema-migration", version = "2.0.0-rc.0" }
-type-bridge-schema-migration-typedb = { path = "../schema-migration-typedb", version = "2.0.0-rc.0" }
-type-bridge-workspace = { path = "../workspace", version = "2.0.0-rc.0" }
+type-bridge-contract = { path = "../contract", version = "2.0.0" }
+type-bridge-orm = { path = "../orm", version = "2.0.0" }
+type-bridge-schema = { path = "../schema", version = "2.0.0" }
+type-bridge-migration = { path = "../migration", version = "2.0.0" }
+type-bridge-schema-codegen = { path = "../schema-codegen", version = "2.0.0" }
+type-bridge-schema-compat = { path = "../schema-compat", version = "2.0.0" }
+type-bridge-schema-migration = { path = "../schema-migration", version = "2.0.0" }
+type-bridge-schema-migration-typedb = { path = "../schema-migration-typedb", version = "2.0.0" }
+type-bridge-workspace = { path = "../workspace", version = "2.0.0" }
 
 [lints]
 workspace = true
@@ -32,4 +32,4 @@ serde_json = "1.0"
 sha2 = "0.10"
 tokio = { version = "1", features = ["full"] }
 tempfile = "3"
-type-bridge-typedb-runtime = { path = "../typedb-runtime", version = "2.0.0-rc.0" }
+type-bridge-typedb-runtime = { path = "../typedb-runtime", version = "2.0.0" }

--- a/type-bridge-core/crates/contract/Cargo.toml
+++ b/type-bridge-core/crates/contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-contract"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 edition = "2024"
 description = "Versioned binding-neutral contract primitives for type-bridge"
 license.workspace = true

--- a/type-bridge-core/crates/core/Cargo.toml
+++ b/type-bridge-core/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-core-lib"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 edition = "2024"
 description = "TypeQL AST, schema parser, query compiler, and validation engine for type-bridge"
 license.workspace = true
@@ -13,7 +13,7 @@ default = []
 pyo3 = ["dep:pyo3", "dep:pythonize"]
 
 [dependencies]
-type-bridge-contract = { path = "../contract", version = "2.0.0-rc.0" }
+type-bridge-contract = { path = "../contract", version = "2.0.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"

--- a/type-bridge-core/crates/migration/Cargo.toml
+++ b/type-bridge-core/crates/migration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-migration"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 edition = "2024"
 description = "Migration IR and planning substrate for type-bridge"
 license.workspace = true
@@ -23,10 +23,10 @@ path = "src/bin/type_bridge_migration.rs"
 [dependencies]
 cap-fs-ext = "4.0"
 cap-std = "4.0"
-type-bridge-contract = { path = "../contract", version = "2.0.0-rc.0" }
-type-bridge-core-lib = { path = "../core", version = "2.0.0-rc.0" }
-type-bridge-schema-compat = { path = "../schema-compat", version = "2.0.0-rc.0" }
-type-bridge-orm = { path = "../orm", version = "2.0.0-rc.0", default-features = false, features = ["band7", "band8", "band9"] }
+type-bridge-contract = { path = "../contract", version = "2.0.0" }
+type-bridge-core-lib = { path = "../core", version = "2.0.0" }
+type-bridge-schema-compat = { path = "../schema-compat", version = "2.0.0" }
+type-bridge-orm = { path = "../orm", version = "2.0.0", default-features = false, features = ["band7", "band8", "band9"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4.5", features = ["derive"] }
 network-interface = "2.0.5"

--- a/type-bridge-core/crates/node/Cargo.toml
+++ b/type-bridge-core/crates/node/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "type-bridge-node"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 edition = "2024"
-description = "NAPI bindings exposing the type-bridge Rust ORM runtime to Node.js"
+description = "TypeScript and Node SDK bindings for the TypeBridge shared Rust semantic engine"
 license.workspace = true
 license-file.workspace = true
 repository.workspace = true
@@ -18,10 +18,10 @@ default = []
 contract-test-adapter = []
 
 [dependencies]
-type-bridge-contract = { path = "../contract", version = "2.0.0-rc.0" }
-type-bridge-core-lib = { path = "../core", version = "2.0.0-rc.0" }
-type-bridge-orm = { path = "../orm", version = "2.0.0-rc.0", default-features = false, features = ["band7", "band8", "band9"] }
-type-bridge-schema-compat = { path = "../schema-compat", version = "2.0.0-rc.0" }
+type-bridge-contract = { path = "../contract", version = "2.0.0" }
+type-bridge-core-lib = { path = "../core", version = "2.0.0" }
+type-bridge-orm = { path = "../orm", version = "2.0.0", default-features = false, features = ["band7", "band8", "band9"] }
+type-bridge-schema-compat = { path = "../schema-compat", version = "2.0.0" }
 napi = { version = "2", features = ["napi6"] }
 napi-derive = "2"
 serde = { version = "1.0", features = ["derive"] }

--- a/type-bridge-core/crates/node/README.md
+++ b/type-bridge-core/crates/node/README.md
@@ -1,6 +1,6 @@
 # @type-bridge/node
 
-Node.js NAPI facade for the shared type-bridge Rust ORM runtime.
+TypeScript and Node SDK for the TypeBridge shared Rust semantic engine.
 
 This package is a boundary layer only. Descriptor validation, query
 construction, CRUD execution, hydration, and transaction behavior live in

--- a/type-bridge-core/crates/node/THIRD_PARTY_NOTICES.md
+++ b/type-bridge-core/crates/node/THIRD_PARTY_NOTICES.md
@@ -784,7 +784,7 @@ and fails the byte-for-byte CI freshness check.
 - Node root: `crates/node/Cargo.toml` with default features
 - Release targets: `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `x86_64-apple-darwin`, `aarch64-apple-darwin`, `x86_64-pc-windows-msvc`, `aarch64-pc-windows-msvc`
 - Excluded from this package inventory: build-only and development-only dependencies, plus private TypeBridge-authored crates covered by the MIT section
-- Closure fingerprint: `sha256:ccba63e764e7761cfbd4c7dded6f6d7b8948e02e1026a5df08772b8da87a797e`
+- Closure fingerprint: `sha256:3e8ef4a2890cdd6dc4db25b6e8ae23a553a8b5f43f35d935b06a7ea0aa65fc77`
 
 Every evaluated package's complete cargo-about-resolved SPDX expression is retained
 below. The
@@ -1030,15 +1030,15 @@ bytes actually reproduced in this notice.
 | `tracing-log` | `0.2.0` | Python, Node | `crates.io` | `MIT` | `MIT@sha256:898b1ae9821e98daf8964c8d6c7f61641f5f5aa78ad500020771c0939ee0dea1` |
 | `tracing-subscriber` | `0.3.23` | Python, Node | `crates.io` | `MIT` | `MIT@sha256:898b1ae9821e98daf8964c8d6c7f61641f5f5aa78ad500020771c0939ee0dea1` |
 | `try-lock` | `0.2.5` | Python, Node | `crates.io` | `MIT` | `MIT@sha256:c816a0749cdc6bf062a5111c159723de51b2bfac66a1dac2655abd9e6b1583eb` |
-| `type-bridge-core-lib` | `2.0.0-rc.0` | Python, Node | `workspace:crates/core/Cargo.toml` | `MIT` | `MIT@sha256:b05785f9f18e6716bab63424b11454513b9943a222595b70411009202fc592b5` |
-| `type-bridge-migration` | `2.0.0-rc.0` | Python | `workspace:crates/migration/Cargo.toml` | `MIT` | `MIT@sha256:b05785f9f18e6716bab63424b11454513b9943a222595b70411009202fc592b5` |
-| `type-bridge-orm` | `2.0.0-rc.0` | Python, Node | `workspace:crates/orm/Cargo.toml` | `MIT` | `MIT@sha256:b05785f9f18e6716bab63424b11454513b9943a222595b70411009202fc592b5` |
-| `type-bridge-toml-transpiler` | `2.0.0-rc.0` | Python, Node | `workspace:crates/toml-transpiler/Cargo.toml` | `MIT` | `MIT@sha256:b05785f9f18e6716bab63424b11454513b9943a222595b70411009202fc592b5` |
+| `type-bridge-core-lib` | `2.0.0` | Python, Node | `workspace:crates/core/Cargo.toml` | `MIT` | `MIT@sha256:b05785f9f18e6716bab63424b11454513b9943a222595b70411009202fc592b5` |
+| `type-bridge-migration` | `2.0.0` | Python | `workspace:crates/migration/Cargo.toml` | `MIT` | `MIT@sha256:b05785f9f18e6716bab63424b11454513b9943a222595b70411009202fc592b5` |
+| `type-bridge-orm` | `2.0.0` | Python, Node | `workspace:crates/orm/Cargo.toml` | `MIT` | `MIT@sha256:b05785f9f18e6716bab63424b11454513b9943a222595b70411009202fc592b5` |
+| `type-bridge-toml-transpiler` | `2.0.0` | Python, Node | `workspace:crates/toml-transpiler/Cargo.toml` | `MIT` | `MIT@sha256:b05785f9f18e6716bab63424b11454513b9943a222595b70411009202fc592b5` |
 | `type-bridge-typedb-driver-b7` | `3.8.1` | Python, Node | `workspace:vendor/typedb-driver-b7/Cargo.toml` | `Apache-2.0` | `Apache-2.0@sha256:074e6e32c86a4c0ef8b3ed25b721ca23aca83df277cd88106ef7177c354615ff` |
 | `type-bridge-typedb-driver-b8` | `3.11.5` | Python, Node | `workspace:vendor/typedb-driver-b8/Cargo.toml` | `Apache-2.0` | `Apache-2.0@sha256:074e6e32c86a4c0ef8b3ed25b721ca23aca83df277cd88106ef7177c354615ff` |
 | `type-bridge-typedb-protocol-b7` | `3.7.0` | Python, Node | `workspace:vendor/typedb-protocol-b7/Cargo.toml` | `MPL-2.0` | `MPL-2.0@sha256:3f3d9e0024b1921b067d6f7f88deb4a60cbe7a78e76c64e3f1d7fc3b779b9d04` |
 | `type-bridge-typedb-protocol-b8` | `3.11.0` | Python, Node | `workspace:vendor/typedb-protocol-b8/Cargo.toml` | `MPL-2.0` | `MPL-2.0@sha256:3f3d9e0024b1921b067d6f7f88deb4a60cbe7a78e76c64e3f1d7fc3b779b9d04` |
-| `type-bridge-typedb-runtime` | `2.0.0-rc.0` | Python, Node | `workspace:crates/typedb-runtime/Cargo.toml` | `MIT` | `MIT@sha256:b05785f9f18e6716bab63424b11454513b9943a222595b70411009202fc592b5` |
+| `type-bridge-typedb-runtime` | `2.0.0` | Python, Node | `workspace:crates/typedb-runtime/Cargo.toml` | `MIT` | `MIT@sha256:b05785f9f18e6716bab63424b11454513b9943a222595b70411009202fc592b5` |
 | `typedb-driver` | `3.12.1` | Python, Node | `crates.io` | `Apache-2.0` | `Apache-2.0@sha256:074e6e32c86a4c0ef8b3ed25b721ca23aca83df277cd88106ef7177c354615ff` |
 | `typedb-protocol` | `3.12.0` | Python, Node | `crates.io` | `MPL-2.0` | `MPL-2.0@sha256:3f3d9e0024b1921b067d6f7f88deb4a60cbe7a78e76c64e3f1d7fc3b779b9d04` |
 | `typenum` | `1.20.1` | Python, Node | `crates.io` | `MIT OR Apache-2.0` | `MIT@sha256:a825bd853ab71619a4923d7b4311221427848070ff44d990da39b0b274c1683f` |

--- a/type-bridge-core/crates/node/package-lock.json
+++ b/type-bridge-core/crates/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@type-bridge/node",
-  "version": "2.0.0-rc.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@type-bridge/node",
-      "version": "2.0.0-rc.0",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",

--- a/type-bridge-core/crates/node/package.json
+++ b/type-bridge-core/crates/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@type-bridge/node",
-  "version": "2.0.0-rc.0",
-  "description": "Node.js NAPI facade for the type-bridge Rust ORM runtime",
+  "version": "2.0.0",
+  "description": "TypeScript and Node SDK for the TypeBridge shared Rust semantic engine",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/type-bridge-core/crates/node/tests/fixtures/scope-probe/allowed/package.json
+++ b/type-bridge-core/crates/node/tests/fixtures/scope-probe/allowed/package.json
@@ -2,6 +2,6 @@
   "name": "scope-probe-allowed",
   "description": "Documents typedb-driver ownership without depending on it",
   "dependencies": {
-    "@type-bridge/node": "2.0.0-rc.0"
+    "@type-bridge/node": "2.0.0"
   }
 }

--- a/type-bridge-core/crates/orm-derive/Cargo.toml
+++ b/type-bridge-core/crates/orm-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-orm-derive"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 edition = "2024"
 description = "Derive macros for type-bridge-orm: TypeBridgeEntity, TypeBridgeAttribute, TypeBridgeRelation"
 license.workspace = true
@@ -15,7 +15,7 @@ proc-macro = true
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full", "extra-traits"] }
-type-bridge-core-lib = { path = "../core", version = "2.0.0-rc.0" }
+type-bridge-core-lib = { path = "../core", version = "2.0.0" }
 
 [lints]
 workspace = true

--- a/type-bridge-core/crates/orm/Cargo.toml
+++ b/type-bridge-core/crates/orm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-orm"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Async ORM for TypeDB built on type-bridge-core-lib"
@@ -27,12 +27,12 @@ derive = ["dep:type-bridge-orm-derive"]
 integration-tests = ["derive", "band7", "band8", "band9"]
 
 [dependencies]
-type-bridge-contract = { path = "../contract", version = "2.0.0-rc.0" }
-type-bridge-query = { path = "../query", version = "2.0.0-rc.0" }
-type-bridge-schema = { path = "../schema", version = "2.0.0-rc.0" }
-type-bridge-schema-compat = { path = "../schema-compat", version = "2.0.0-rc.0" }
-type-bridge-core-lib = { path = "../core", version = "2.0.0-rc.0" }
-type-bridge-typedb-runtime = { path = "../typedb-runtime", version = "2.0.0-rc.0", default-features = false, optional = true }
+type-bridge-contract = { path = "../contract", version = "2.0.0" }
+type-bridge-query = { path = "../query", version = "2.0.0" }
+type-bridge-schema = { path = "../schema", version = "2.0.0" }
+type-bridge-schema-compat = { path = "../schema-compat", version = "2.0.0" }
+type-bridge-core-lib = { path = "../core", version = "2.0.0" }
+type-bridge-typedb-runtime = { path = "../typedb-runtime", version = "2.0.0", default-features = false, optional = true }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -44,7 +44,7 @@ rand_core = { version = "0.6", features = ["getrandom"] }
 thiserror = "2"
 tracing = "0.1"
 uuid = { version = "1", features = ["v4"] }
-type-bridge-orm-derive = { path = "../orm-derive", version = "2.0.0-rc.0", optional = true }
+type-bridge-orm-derive = { path = "../orm-derive", version = "2.0.0", optional = true }
 
 [dev-dependencies]
 base64 = "0.22"

--- a/type-bridge-core/crates/python/Cargo.toml
+++ b/type-bridge-core/crates/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-core"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 edition = "2024"
 description = "PyO3 bindings exposing the type-bridge Rust core to Python"
 license.workspace = true
@@ -14,13 +14,13 @@ name = "type_bridge_core"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-type-bridge-core-lib = { path = "../core", version = "2.0.0-rc.0" }
-type-bridge-cli = { path = "../cli", version = "2.0.0-rc.0" }
-type-bridge-contract = { path = "../contract", version = "2.0.0-rc.0" }
-type-bridge-migration = { path = "../migration", version = "2.0.0-rc.0" }
-type-bridge-orm = { path = "../orm", version = "2.0.0-rc.0" }
-type-bridge-schema-compat = { path = "../schema-compat", version = "2.0.0-rc.0" }
-type-bridge-toml-transpiler = { path = "../toml-transpiler", version = "2.0.0-rc.0" }
+type-bridge-core-lib = { path = "../core", version = "2.0.0" }
+type-bridge-cli = { path = "../cli", version = "2.0.0" }
+type-bridge-contract = { path = "../contract", version = "2.0.0" }
+type-bridge-migration = { path = "../migration", version = "2.0.0" }
+type-bridge-orm = { path = "../orm", version = "2.0.0" }
+type-bridge-schema-compat = { path = "../schema-compat", version = "2.0.0" }
+type-bridge-toml-transpiler = { path = "../toml-transpiler", version = "2.0.0" }
 # Keep ordinary Rust test binaries linked to libpython. Maturin enables
 # `pyo3/extension-module` only for extension builds (see ../../pyproject.toml).
 pyo3 = { version = "0.23", features = ["abi3-py312"] }
@@ -30,4 +30,4 @@ serde_json = "1.0"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 
 [dev-dependencies]
-type-bridge-schema = { path = "../schema", version = "2.0.0-rc.0" }
+type-bridge-schema = { path = "../schema", version = "2.0.0" }

--- a/type-bridge-core/crates/query/Cargo.toml
+++ b/type-bridge-core/crates/query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-query"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 edition = "2024"
 description = "Validated query-plan analysis and lowering for type-bridge"
 license.workspace = true
@@ -10,8 +10,8 @@ authors.workspace = true
 publish = false
 
 [dependencies]
-type-bridge-contract = { path = "../contract", version = "2.0.0-rc.0" }
-type-bridge-schema = { path = "../schema", version = "2.0.0-rc.0" }
+type-bridge-contract = { path = "../contract", version = "2.0.0" }
+type-bridge-schema = { path = "../schema", version = "2.0.0" }
 
 [lints]
 workspace = true

--- a/type-bridge-core/crates/rust/Cargo.toml
+++ b/type-bridge-core/crates/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Public client SDK for TypeBridge"
@@ -23,17 +23,17 @@ band9 = ["typedb", "type-bridge-orm/band9"]
 test-harness = []
 
 [dependencies]
-type-bridge-contract = { path = "../contract", version = "2.0.0-rc.0" }
-type-bridge-orm = { path = "../orm", version = "2.0.0-rc.0", default-features = false }
-type-bridge-orm-derive = { path = "../orm-derive", version = "2.0.0-rc.0" }
+type-bridge-contract = { path = "../contract", version = "2.0.0" }
+type-bridge-orm = { path = "../orm", version = "2.0.0", default-features = false }
+type-bridge-orm-derive = { path = "../orm-derive", version = "2.0.0" }
 thiserror = "2"
 regex = "1"
 serde_json = "1"
 
 [dev-dependencies]
-type-bridge-contract = { path = "../contract", version = "2.0.0-rc.0" }
-type-bridge-schema = { path = "../schema", version = "2.0.0-rc.0" }
-type-bridge-schema-codegen = { path = "../schema-codegen", version = "2.0.0-rc.0" }
+type-bridge-contract = { path = "../contract", version = "2.0.0" }
+type-bridge-schema = { path = "../schema", version = "2.0.0" }
+type-bridge-schema-codegen = { path = "../schema-codegen", version = "2.0.0" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 serde_json = "1"
 

--- a/type-bridge-core/crates/schema-codegen/Cargo.toml
+++ b/type-bridge-core/crates/schema-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-schema-codegen"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 edition = "2024"
 description = "Deterministic projection-only schema emitters for type-bridge"
 license.workspace = true
@@ -10,10 +10,10 @@ authors.workspace = true
 publish = false
 
 [dependencies]
-type-bridge-contract = { path = "../contract", version = "2.0.0-rc.0" }
+type-bridge-contract = { path = "../contract", version = "2.0.0" }
 
 [dev-dependencies]
-type-bridge-schema = { path = "../schema", version = "2.0.0-rc.0" }
+type-bridge-schema = { path = "../schema", version = "2.0.0" }
 
 [lints]
 workspace = true

--- a/type-bridge-core/crates/schema-codegen/src/rust/package.toml
+++ b/type-bridge-core/crates/schema-codegen/src/rust/package.toml
@@ -10,7 +10,7 @@ path = "src/lib.rs"
 doctest = false
 
 [dependencies]
-type-bridge = { version = "2.0.0-rc.0", default-features = false }
+type-bridge = { version = "=2.0.0", default-features = false }
 
 [features]
 test-harness = ["type-bridge/test-harness"]

--- a/type-bridge-core/crates/schema-codegen/tests/rust_emitter.rs
+++ b/type-bridge-core/crates/schema-codegen/tests/rust_emitter.rs
@@ -114,7 +114,7 @@ fn emits_exact_deterministic_single_dependency_crate() {
     assert!(tokens.contains("pub const plays_event_container_item"));
     let manifest = String::from_utf8(first.get("Cargo.toml").unwrap().to_vec()).unwrap();
     assert!(manifest.contains("[dependencies]"));
-    assert!(manifest.contains("type-bridge ="));
+    assert!(manifest.contains("type-bridge = { version = \"=2.0.0\", default-features = false }"));
     assert!(manifest.contains("doctest = false"));
     assert!(manifest.contains("rust-version = \"1.88\""));
 }

--- a/type-bridge-core/crates/schema-compat/Cargo.toml
+++ b/type-bridge-core/crates/schema-compat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-schema-compat"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 edition = "2024"
 description = "Released-schema compatibility front-end for type-bridge"
 license.workspace = true
@@ -12,10 +12,10 @@ publish = false
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-type-bridge-contract = { path = "../contract", version = "2.0.0-rc.0" }
-type-bridge-core-lib = { path = "../core", version = "2.0.0-rc.0" }
-type-bridge-schema = { path = "../schema", version = "2.0.0-rc.0" }
-type-bridge-toml-transpiler = { path = "../toml-transpiler", version = "2.0.0-rc.0" }
+type-bridge-contract = { path = "../contract", version = "2.0.0" }
+type-bridge-core-lib = { path = "../core", version = "2.0.0" }
+type-bridge-schema = { path = "../schema", version = "2.0.0" }
+type-bridge-toml-transpiler = { path = "../toml-transpiler", version = "2.0.0" }
 typeql = "=3.12.0"
 
 

--- a/type-bridge-core/crates/schema-migration-typedb/Cargo.toml
+++ b/type-bridge-core/crates/schema-migration-typedb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-schema-migration-typedb"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 edition = "2024"
 description = "TypeDB-backed fenced execution store for type-bridge schema migrations"
 license.workspace = true
@@ -13,13 +13,13 @@ publish = false
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
-type-bridge-contract = { path = "../contract", version = "2.0.0-rc.0" }
-type-bridge-migration = { path = "../migration", version = "2.0.0-rc.0" }
-type-bridge-orm = { path = "../orm", version = "2.0.0-rc.0" }
-type-bridge-query = { path = "../query", version = "2.0.0-rc.0" }
-type-bridge-schema = { path = "../schema", version = "2.0.0-rc.0" }
-type-bridge-schema-compat = { path = "../schema-compat", version = "2.0.0-rc.0" }
-type-bridge-schema-migration = { path = "../schema-migration", version = "2.0.0-rc.0" }
+type-bridge-contract = { path = "../contract", version = "2.0.0" }
+type-bridge-migration = { path = "../migration", version = "2.0.0" }
+type-bridge-orm = { path = "../orm", version = "2.0.0" }
+type-bridge-query = { path = "../query", version = "2.0.0" }
+type-bridge-schema = { path = "../schema", version = "2.0.0" }
+type-bridge-schema-compat = { path = "../schema-compat", version = "2.0.0" }
+type-bridge-schema-migration = { path = "../schema-migration", version = "2.0.0" }
 
 [dev-dependencies]
 tokio = { version = "1.48", features = ["macros", "rt-multi-thread", "time"] }

--- a/type-bridge-core/crates/schema-migration/Cargo.toml
+++ b/type-bridge-core/crates/schema-migration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-schema-migration"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 edition = "2024"
 description = "Canonical schema migration planning for type-bridge"
 license.workspace = true
@@ -16,9 +16,9 @@ fs2 = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
-type-bridge-contract = { path = "../contract", version = "2.0.0-rc.0" }
-type-bridge-query = { path = "../query", version = "2.0.0-rc.0" }
-type-bridge-schema = { path = "../schema", version = "2.0.0-rc.0" }
+type-bridge-contract = { path = "../contract", version = "2.0.0" }
+type-bridge-query = { path = "../query", version = "2.0.0" }
+type-bridge-schema = { path = "../schema", version = "2.0.0" }
 
 [lints]
 workspace = true

--- a/type-bridge-core/crates/schema/Cargo.toml
+++ b/type-bridge-core/crates/schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-schema"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 edition = "2024"
 description = "Canonical schema resolution and projection engine for type-bridge"
 license.workspace = true
@@ -14,7 +14,7 @@ chrono = "=0.4.44"
 chrono-tz = "=0.9.0"
 granit-parser = "=0.0.7"
 serde = { version = "1.0", features = ["derive"] }
-type-bridge-contract = { path = "../contract", version = "2.0.0-rc.0" }
+type-bridge-contract = { path = "../contract", version = "2.0.0" }
 unicode-casefold = "=0.2.0"
 unicode-normalization = "=0.1.25"
 

--- a/type-bridge-core/crates/server/Cargo.toml
+++ b/type-bridge-core/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-server"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 edition = "2024"
 description = "Query-intercepting proxy server for TypeDB with validation and audit logging"
 license.workspace = true
@@ -39,13 +39,13 @@ v2-query = [
 test-helpers = []
 
 [dependencies]
-type-bridge-core-lib = { path = "../core", version = "2.0.0-rc.0" }
-type-bridge-typedb-runtime = { path = "../typedb-runtime", version = "2.0.0-rc.0", default-features = false, optional = true }
-type-bridge-contract = { path = "../contract", version = "2.0.0-rc.0", optional = true }
-type-bridge-query = { path = "../query", version = "2.0.0-rc.0", optional = true }
-type-bridge-orm = { path = "../orm", version = "2.0.0-rc.0", optional = true }
-type-bridge-schema = { path = "../schema", version = "2.0.0-rc.0", optional = true }
-type-bridge-schema-migration-typedb = { path = "../schema-migration-typedb", version = "2.0.0-rc.0", optional = true }
+type-bridge-core-lib = { path = "../core", version = "2.0.0" }
+type-bridge-typedb-runtime = { path = "../typedb-runtime", version = "2.0.0", default-features = false, optional = true }
+type-bridge-contract = { path = "../contract", version = "2.0.0", optional = true }
+type-bridge-query = { path = "../query", version = "2.0.0", optional = true }
+type-bridge-orm = { path = "../orm", version = "2.0.0", optional = true }
+type-bridge-schema = { path = "../schema", version = "2.0.0", optional = true }
+type-bridge-schema-migration-typedb = { path = "../schema-migration-typedb", version = "2.0.0", optional = true }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -73,7 +73,7 @@ name = "v2_smoke_server"
 required-features = ["v2-query"]
 
 [dev-dependencies]
-type-bridge-server = { path = ".", version = "2.0.0-rc.0", features = ["test-helpers", "axum-transport", "v2-query"] }
+type-bridge-server = { path = ".", version = "2.0.0", features = ["test-helpers", "axum-transport", "v2-query"] }
 tempfile = "3"
 http-body-util = "0.1"
 tower = { version = "0.5", features = ["util"] }

--- a/type-bridge-core/crates/toml-transpiler/Cargo.toml
+++ b/type-bridge-core/crates/toml-transpiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-toml-transpiler"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 edition = "2024"
 description = "TOML schema DSL transpiler producing TypeQL define blocks for type-bridge"
 license.workspace = true

--- a/type-bridge-core/crates/typedb-runtime/Cargo.toml
+++ b/type-bridge-core/crates/typedb-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-typedb-runtime"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 edition = "2024"
 description = "Shared TypeDB runtime driver layer for type-bridge"
 license.workspace = true
@@ -19,7 +19,7 @@ band8 = ["dep:type-bridge-typedb-driver-b8", "dep:chrono"]
 band9 = ["dep:typedb-driver", "dep:chrono", "dep:chrono-tz"]
 
 [dependencies]
-type-bridge-core-lib = { path = "../core", version = "2.0.0-rc.0" }
+type-bridge-core-lib = { path = "../core", version = "2.0.0" }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/type-bridge-core/crates/typedb-runtime/tests/tls_live.rs
+++ b/type-bridge-core/crates/typedb-runtime/tests/tls_live.rs
@@ -1,6 +1,7 @@
 //! Opt-in live proofs for custom-root and native-root TLS across HTTP
 //! discovery, gRPC fallback, and the selected TypeDB driver band.
 
+use std::future::Future;
 use std::io::{ErrorKind, Read, Write};
 use std::net::{Shutdown, TcpListener};
 use std::path::PathBuf;
@@ -119,6 +120,19 @@ fn unique_database(prefix: &str) -> String {
         .expect("system time follows the Unix epoch")
         .as_nanos();
     format!("{prefix}_{}_{}", std::process::id(), suffix)
+}
+
+const LIVE_TLS_STAGE_TIMEOUT: Duration = Duration::from_secs(10);
+
+async fn await_live_tls_stage<T>(stage: &'static str, future: impl Future<Output = T>) -> T {
+    tokio::time::timeout(LIVE_TLS_STAGE_TIMEOUT, future)
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "live TLS stage `{stage}` timed out after {} seconds",
+                LIVE_TLS_STAGE_TIMEOUT.as_secs()
+            )
+        })
 }
 
 fn assert_expected_topology(
@@ -317,57 +331,71 @@ async fn custom_root_raw_stop_requires_connection_close_before_delete_live() {
         return;
     };
     let database = unique_database("tb_tls_terminal_close");
-    let runtime = TypeDBRuntime::connect_secure(
-        &context.address,
-        &context.username,
-        &context.password,
-        context.custom_root_options(),
+    let runtime = await_live_tls_stage(
+        "raw-stop/connect",
+        TypeDBRuntime::connect_secure(
+            &context.address,
+            &context.username,
+            &context.password,
+            context.custom_root_options(),
+        ),
     )
     .await
     .expect("custom-root terminal-close runtime connects over TLS");
     assert_expected_topology(&runtime, &context, true);
-    runtime
-        .create_database(&database)
-        .await
-        .expect("terminal-close database is created over TLS");
+    await_live_tls_stage(
+        "raw-stop/create-database",
+        runtime.create_database(&database),
+    )
+    .await
+    .expect("terminal-close database is created over TLS");
 
-    let mut schema = runtime
-        .open_transaction(&database, TxType::Schema)
-        .await
-        .expect("terminal-close schema transaction opens over TLS");
-    schema
-        .query("define entity tls-terminal-close-person;")
-        .await
-        .expect("terminal-close schema is defined over TLS");
-    schema
-        .commit()
+    let mut schema = await_live_tls_stage(
+        "raw-stop/open-schema",
+        runtime.open_transaction(&database, TxType::Schema),
+    )
+    .await
+    .expect("terminal-close schema transaction opens over TLS");
+    await_live_tls_stage(
+        "raw-stop/define-schema",
+        schema.query("define entity tls-terminal-close-person;"),
+    )
+    .await
+    .expect("terminal-close schema is defined over TLS");
+    await_live_tls_stage("raw-stop/commit-schema", schema.commit())
         .await
         .expect("terminal-close schema commits over TLS");
 
-    let mut write = runtime
-        .open_transaction(&database, TxType::Write)
-        .await
-        .expect("terminal-close write transaction opens over TLS");
-    write
-        .query(
+    let mut write = await_live_tls_stage(
+        "raw-stop/open-write",
+        runtime.open_transaction(&database, TxType::Write),
+    )
+    .await
+    .expect("terminal-close write transaction opens over TLS");
+    await_live_tls_stage(
+        "raw-stop/insert",
+        write.query(
             "insert $first isa tls-terminal-close-person; \
              $second isa tls-terminal-close-person; \
              $third isa tls-terminal-close-person;",
-        )
-        .await
-        .expect("terminal-close rows are inserted over TLS");
-    write
-        .commit()
+        ),
+    )
+    .await
+    .expect("terminal-close rows are inserted over TLS");
+    await_live_tls_stage("raw-stop/commit-write", write.commit())
         .await
         .expect("terminal-close rows commit over TLS");
 
-    let mut read = runtime
-        .open_transaction(&database, TxType::Read)
-        .await
-        .expect("terminal-close read transaction opens over TLS");
+    let mut read = await_live_tls_stage(
+        "raw-stop/open-read",
+        runtime.open_transaction(&database, TxType::Read),
+    )
+    .await
+    .expect("terminal-close read transaction opens over TLS");
     let mut stop_after_first = |_item| Ok(RuntimeAnswerControl::Stop);
-    let stats = read
-        .query_bounded(
+    let stats = await_live_tls_stage(
+        "raw-stop/query",
+        read.query_bounded(
             "match $person isa tls-terminal-close-person; select $person;",
             RuntimeAnswerLimits {
                 max_items: 3,
@@ -376,12 +404,13 @@ async fn custom_root_raw_stop_requires_connection_close_before_delete_live() {
                 cancellation: RuntimeAnswerCancellation::default(),
             },
             &mut stop_after_first,
-        )
-        .await
-        .expect("bounded TLS query delivers its first row");
+        ),
+    )
+    .await
+    .expect("bounded TLS query delivers its first row");
     assert_eq!(stats.processed_items, 1);
     assert!(stats.stopped_early);
-    read.close()
+    await_live_tls_stage("raw-stop/close-read", read.close())
         .await
         .expect("raw-stop transaction close is dispatched over TLS");
     drop(read);
@@ -395,8 +424,8 @@ async fn custom_root_raw_stop_requires_connection_close_before_delete_live() {
         .expect("raw-stop TLS runtime connection force-closes");
     drop(runtime);
 
-    tokio::time::timeout(
-        Duration::from_secs(10),
+    await_live_tls_stage(
+        "raw-stop/delete-after-force-close",
         delete_database_secure(
             &context.address,
             &database,
@@ -406,34 +435,42 @@ async fn custom_root_raw_stop_requires_connection_close_before_delete_live() {
         ),
     )
     .await
-    .expect("force-close must not leave TLS database deletion blocked")
     .expect("a fresh TLS connection deletes the database after force-close");
     assert!(
-        !database_exists_secure(
+        !await_live_tls_stage(
+            "raw-stop/verify-deleted",
+            database_exists_secure(
+                &context.address,
+                &database,
+                &context.username,
+                &context.password,
+                context.custom_root_options(),
+            ),
+        )
+        .await
+        .expect("TLS database lookup works after raw-stop cleanup")
+    );
+    await_live_tls_stage(
+        "raw-stop/recreate",
+        ensure_database_exists_secure(
             &context.address,
             &database,
             &context.username,
             &context.password,
             context.custom_root_options(),
-        )
-        .await
-        .expect("TLS database lookup works after raw-stop cleanup")
-    );
-    ensure_database_exists_secure(
-        &context.address,
-        &database,
-        &context.username,
-        &context.password,
-        context.custom_root_options(),
+        ),
     )
     .await
     .expect("the same TLS database name is immediately reusable");
-    delete_database_secure(
-        &context.address,
-        &database,
-        &context.username,
-        &context.password,
-        context.custom_root_options(),
+    await_live_tls_stage(
+        "raw-stop/final-delete",
+        delete_database_secure(
+            &context.address,
+            &database,
+            &context.username,
+            &context.password,
+            context.custom_root_options(),
+        ),
     )
     .await
     .expect("TLS raw-stop fixture cleans up");

--- a/type-bridge-core/crates/workspace/Cargo.toml
+++ b/type-bridge-core/crates/workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "type-bridge-workspace"
-version = "2.0.0-rc.0"
+version = "2.0.0"
 edition = "2024"
 description = "Validated programmatic workspace configuration for type-bridge"
 license.workspace = true
@@ -18,10 +18,10 @@ cap-fs-ext = "4.0"
 cap-std = "4.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-type-bridge-contract = { path = "../contract", version = "2.0.0-rc.0" }
-type-bridge-schema = { path = "../schema", version = "2.0.0-rc.0" }
-type-bridge-schema-compat = { path = "../schema-compat", version = "2.0.0-rc.0" }
-type-bridge-schema-migration = { path = "../schema-migration", version = "2.0.0-rc.0" }
+type-bridge-contract = { path = "../contract", version = "2.0.0" }
+type-bridge-schema = { path = "../schema", version = "2.0.0" }
+type-bridge-schema-compat = { path = "../schema-compat", version = "2.0.0" }
+type-bridge-schema-migration = { path = "../schema-migration", version = "2.0.0" }
 
 [lints]
 workspace = true

--- a/type-bridge-core/pyproject.toml
+++ b/type-bridge-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "type-bridge-core"
-version = "2.0.0rc0"
+version = "2.0.0"
 description = "Shared Rust semantic engine for the TypeBridge application toolkit"
 requires-python = ">=3.12,<3.15"
 license = { text = "MIT" }

--- a/type-bridge-core/python/type_bridge_core/THIRD_PARTY_NOTICES.md
+++ b/type-bridge-core/python/type_bridge_core/THIRD_PARTY_NOTICES.md
@@ -784,7 +784,7 @@ and fails the byte-for-byte CI freshness check.
 - Node root: `crates/node/Cargo.toml` with default features
 - Release targets: `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `x86_64-apple-darwin`, `aarch64-apple-darwin`, `x86_64-pc-windows-msvc`, `aarch64-pc-windows-msvc`
 - Excluded from this package inventory: build-only and development-only dependencies, plus private TypeBridge-authored crates covered by the MIT section
-- Closure fingerprint: `sha256:ccba63e764e7761cfbd4c7dded6f6d7b8948e02e1026a5df08772b8da87a797e`
+- Closure fingerprint: `sha256:3e8ef4a2890cdd6dc4db25b6e8ae23a553a8b5f43f35d935b06a7ea0aa65fc77`
 
 Every evaluated package's complete cargo-about-resolved SPDX expression is retained
 below. The
@@ -1030,15 +1030,15 @@ bytes actually reproduced in this notice.
 | `tracing-log` | `0.2.0` | Python, Node | `crates.io` | `MIT` | `MIT@sha256:898b1ae9821e98daf8964c8d6c7f61641f5f5aa78ad500020771c0939ee0dea1` |
 | `tracing-subscriber` | `0.3.23` | Python, Node | `crates.io` | `MIT` | `MIT@sha256:898b1ae9821e98daf8964c8d6c7f61641f5f5aa78ad500020771c0939ee0dea1` |
 | `try-lock` | `0.2.5` | Python, Node | `crates.io` | `MIT` | `MIT@sha256:c816a0749cdc6bf062a5111c159723de51b2bfac66a1dac2655abd9e6b1583eb` |
-| `type-bridge-core-lib` | `2.0.0-rc.0` | Python, Node | `workspace:crates/core/Cargo.toml` | `MIT` | `MIT@sha256:b05785f9f18e6716bab63424b11454513b9943a222595b70411009202fc592b5` |
-| `type-bridge-migration` | `2.0.0-rc.0` | Python | `workspace:crates/migration/Cargo.toml` | `MIT` | `MIT@sha256:b05785f9f18e6716bab63424b11454513b9943a222595b70411009202fc592b5` |
-| `type-bridge-orm` | `2.0.0-rc.0` | Python, Node | `workspace:crates/orm/Cargo.toml` | `MIT` | `MIT@sha256:b05785f9f18e6716bab63424b11454513b9943a222595b70411009202fc592b5` |
-| `type-bridge-toml-transpiler` | `2.0.0-rc.0` | Python, Node | `workspace:crates/toml-transpiler/Cargo.toml` | `MIT` | `MIT@sha256:b05785f9f18e6716bab63424b11454513b9943a222595b70411009202fc592b5` |
+| `type-bridge-core-lib` | `2.0.0` | Python, Node | `workspace:crates/core/Cargo.toml` | `MIT` | `MIT@sha256:b05785f9f18e6716bab63424b11454513b9943a222595b70411009202fc592b5` |
+| `type-bridge-migration` | `2.0.0` | Python | `workspace:crates/migration/Cargo.toml` | `MIT` | `MIT@sha256:b05785f9f18e6716bab63424b11454513b9943a222595b70411009202fc592b5` |
+| `type-bridge-orm` | `2.0.0` | Python, Node | `workspace:crates/orm/Cargo.toml` | `MIT` | `MIT@sha256:b05785f9f18e6716bab63424b11454513b9943a222595b70411009202fc592b5` |
+| `type-bridge-toml-transpiler` | `2.0.0` | Python, Node | `workspace:crates/toml-transpiler/Cargo.toml` | `MIT` | `MIT@sha256:b05785f9f18e6716bab63424b11454513b9943a222595b70411009202fc592b5` |
 | `type-bridge-typedb-driver-b7` | `3.8.1` | Python, Node | `workspace:vendor/typedb-driver-b7/Cargo.toml` | `Apache-2.0` | `Apache-2.0@sha256:074e6e32c86a4c0ef8b3ed25b721ca23aca83df277cd88106ef7177c354615ff` |
 | `type-bridge-typedb-driver-b8` | `3.11.5` | Python, Node | `workspace:vendor/typedb-driver-b8/Cargo.toml` | `Apache-2.0` | `Apache-2.0@sha256:074e6e32c86a4c0ef8b3ed25b721ca23aca83df277cd88106ef7177c354615ff` |
 | `type-bridge-typedb-protocol-b7` | `3.7.0` | Python, Node | `workspace:vendor/typedb-protocol-b7/Cargo.toml` | `MPL-2.0` | `MPL-2.0@sha256:3f3d9e0024b1921b067d6f7f88deb4a60cbe7a78e76c64e3f1d7fc3b779b9d04` |
 | `type-bridge-typedb-protocol-b8` | `3.11.0` | Python, Node | `workspace:vendor/typedb-protocol-b8/Cargo.toml` | `MPL-2.0` | `MPL-2.0@sha256:3f3d9e0024b1921b067d6f7f88deb4a60cbe7a78e76c64e3f1d7fc3b779b9d04` |
-| `type-bridge-typedb-runtime` | `2.0.0-rc.0` | Python, Node | `workspace:crates/typedb-runtime/Cargo.toml` | `MIT` | `MIT@sha256:b05785f9f18e6716bab63424b11454513b9943a222595b70411009202fc592b5` |
+| `type-bridge-typedb-runtime` | `2.0.0` | Python, Node | `workspace:crates/typedb-runtime/Cargo.toml` | `MIT` | `MIT@sha256:b05785f9f18e6716bab63424b11454513b9943a222595b70411009202fc592b5` |
 | `typedb-driver` | `3.12.1` | Python, Node | `crates.io` | `Apache-2.0` | `Apache-2.0@sha256:074e6e32c86a4c0ef8b3ed25b721ca23aca83df277cd88106ef7177c354615ff` |
 | `typedb-protocol` | `3.12.0` | Python, Node | `crates.io` | `MPL-2.0` | `MPL-2.0@sha256:3f3d9e0024b1921b067d6f7f88deb4a60cbe7a78e76c64e3f1d7fc3b779b9d04` |
 | `typenum` | `1.20.1` | Python, Node | `crates.io` | `MIT OR Apache-2.0` | `MIT@sha256:a825bd853ab71619a4923d7b4311221427848070ff44d990da39b0b274c1683f` |

--- a/type_bridge/__init__.py
+++ b/type_bridge/__init__.py
@@ -60,7 +60,7 @@ from type_bridge.session import (
 )
 from type_bridge.typedb_driver import Credentials, TransactionType, TypeDB, create_driver_options
 
-__version__ = "2.0.0rc0"
+__version__ = "2.0.0"
 
 __all__ = [
     # Database and session


### PR DESCRIPTION
## Summary

Prepare the reviewed TypeBridge 2.0.0 candidate for its stable release gate.
This freezes the stable identities and changelog but does not tag or publish
anything.

## Stable release freeze

- promote the root/core Python packages, npm package, all 19 first-party Rust
  crates, and their internal pins from RC0 to `2.0.0`
- keep the public Rust crate graph source/Git-only: the release identity gate
  still produces no crates.io publication plan
- pin generated Rust SDK projects to exact `type-bridge = "=2.0.0"`
- mark the root Python distribution Production/Stable and align Python, Node,
  Rust, setup, and compatibility metadata
- freeze the complete release notes under
  `## [2.0.0] - 2026-07-31`, leaving `Unreleased` empty
- regenerate the byte-identical Python and Node native dependency notices with
  pinned `cargo-about 0.9.1`
- add named 10-second diagnostics around each async stage of the raw-stop TLS
  lifecycle proof while preserving the unbounded query deadline and the
  close/drop/force-close ordering

The fixed candidate-channel identities in the release workflow and validator
remain unchanged so the RC path stays reproducible.

## Accepted candidate evidence

- Exact merged candidate source:
  `cea5f22a2988c616f9115a4b4197d992929d806c`
- Candidate run:
  https://github.com/ds1sqe/type-bridge/actions/runs/30602452301
- Result: 35 build and acceptance jobs passed; exactly the five mutating
  publisher/release jobs were skipped
- Output: all 19 expected artifact groups, independently downloaded, hashed,
  and audited across Python, Node, six native npm targets, the Rust smoke
  server, and both OCI architectures
- Archive integrity/path safety, package identity, native architecture, OCI
  digest/label/runtime policy, SPDX SBOM, and Trivy acceptance all passed
- No `v2.0.0` tag or GitHub Release existed after candidate acceptance, and
  no registry mutation was reachable

## Verification

- `./scripts/check.sh all` — 28/28 source gates passed
  - complete Rust workspace checks/tests/Clippy
  - generated Rust consumer acceptance on Rust 1.88
  - 2,863 Python unit tests plus Ruff and Pyright
  - Node build/typechecks, 189 unit tests, DTS parity, packed-package smokes,
    and native contract adapter
- focused release identity/artifact/workflow tests — 337 passed
- stable `v2.0.0` source/Git/server-OCI identity validation — passed
- native dependency notice regeneration and freshness check with
  `cargo-about 0.9.1` — passed
- strict MkDocs build — passed; README remains 151 lines
- targeted schema-codegen emitter test — 5 passed
- TLS live test target compile — passed

## After merge

The merge SHA must pass ordinary default-branch CI. Then the workflow is
manually dispatched with `release_channel=stable`; this is another
non-publishing 35-pass/5-skip gate. Only after that evidence is accepted is an
annotated `v2.0.0` tag created. The tag-triggered workflow is the path that
publishes GHCR, npm, core PyPI, root PyPI, and the draft GitHub Release.

Closes #125
Closes #195
Refs #189
Part of #188
