### PR TITLE
fix(release): recover crates.io publication

### DIFF
--- a/.github/workflows/recover-crates-v2.0.1.yml
+++ b/.github/workflows/recover-crates-v2.0.1.yml
@@ -1,0 +1,176 @@
+name: Recover crates.io v2.0.1
+
+on:
+  workflow_dispatch:
+    inputs:
+      recovery_mode:
+        description: Verify first; publish only after the verification run succeeds
+        required: true
+        type: choice
+        default: verify
+        options:
+          - verify
+          - publish
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+env:
+  RELEASE_TAG: v2.0.1
+  RELEASE_REVISION: f0b9fd41bc0a437939bb256062fe6ad47071d632
+  RELEASE_TAG_OBJECT: 42775b4c412a9278e182667d27cf96e09bfc04d7
+  RELEASE_RUN_ID: "30860417007"
+
+jobs:
+  verify-recovery:
+    name: Verify crates.io recovery
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout recovery controls
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Checkout immutable release source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: refs/tags/v2.0.1
+          fetch-depth: 0
+          path: tmp/release-source
+          persist-credentials: false
+
+      - name: Bind recovery to the exact tag and failed release run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          test "$(git -C tmp/release-source cat-file -t "refs/tags/${RELEASE_TAG}")" = tag
+          test "$(git -C tmp/release-source rev-parse "refs/tags/${RELEASE_TAG}")" = \
+            "$RELEASE_TAG_OBJECT"
+          test "$(git -C tmp/release-source rev-parse "refs/tags/${RELEASE_TAG}^{}")" = \
+            "$RELEASE_REVISION"
+
+          tag_ref_json="$(
+            gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${RELEASE_TAG}"
+          )"
+          test "$(jq -r '.object.type' <<<"$tag_ref_json")" = tag
+          test "$(jq -r '.object.sha' <<<"$tag_ref_json")" = "$RELEASE_TAG_OBJECT"
+          tag_json="$(
+            gh api "repos/${GITHUB_REPOSITORY}/git/tags/${RELEASE_TAG_OBJECT}"
+          )"
+          test "$(jq -r '.object.type' <<<"$tag_json")" = commit
+          test "$(jq -r '.object.sha' <<<"$tag_json")" = "$RELEASE_REVISION"
+
+          run_json="$(
+            gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RELEASE_RUN_ID}"
+          )"
+          jq -e \
+            --argjson run_id "$RELEASE_RUN_ID" \
+            --arg revision "$RELEASE_REVISION" \
+            '.id == $run_id and
+             .event == "push" and
+             .head_branch == "v2.0.1" and
+             .head_sha == $revision and
+             .path == ".github/workflows/release.yml" and
+             .run_attempt == 1 and
+             .conclusion == "failure"' \
+            <<<"$run_json" >/dev/null
+
+          jobs_json="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${RELEASE_RUN_ID}/jobs?per_page=100"
+          )"
+          require_job() {
+            local name="$1"
+            local conclusion="$2"
+            jq -e \
+              --arg name "$name" \
+              --arg conclusion "$conclusion" \
+              '[.jobs[] | select(.name == $name and .conclusion == $conclusion)] |
+               length == 1' \
+              <<<"$jobs_json" >/dev/null
+          }
+          require_job "Test" success
+          require_job "Validate release identity" success
+          require_job "Preflight selected release channel" success
+          require_job "Publish Node package to npm" success
+          require_job "Publish Rust crates to crates.io" failure
+
+      - name: Install pinned Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: 1.94.1
+
+      - name: Revalidate exact release identity
+        working-directory: tmp/release-source
+        run: |
+          python scripts/ci/validate_release_identity.py \
+            --artifact-contract cargo-inclusive \
+            --release-channel stable \
+            --tag "$RELEASE_TAG" \
+            --workspace type-bridge-core/Cargo.toml \
+            --root-python pyproject.toml \
+            --root-python-init type_bridge/__init__.py \
+            --core-python type-bridge-core/pyproject.toml \
+            --node-package type-bridge-core/crates/node/package.json \
+            --node-package-lock type-bridge-core/crates/node/package-lock.json \
+            --release-workflow .github/workflows/release.yml
+
+      - name: Package and preflight the exact crates.io graph
+        env:
+          PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
+        run: >-
+          bash scripts/ci/release_crates_graph.sh --preflight
+          tmp/release-source/type-bridge-core
+
+  publish-recovery:
+    name: Publish recovered Rust crates to crates.io
+    if: >-
+      github.ref == 'refs/heads/master' &&
+      inputs.recovery_mode == 'publish' &&
+      needs.verify-recovery.result == 'success'
+    needs: verify-recovery
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout recovery controls
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Checkout immutable release source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: refs/tags/v2.0.1
+          fetch-depth: 0
+          path: tmp/release-source
+          persist-credentials: false
+
+      - name: Revalidate immutable release tag
+        run: |
+          set -euo pipefail
+          test "$(git -C tmp/release-source cat-file -t "refs/tags/${RELEASE_TAG}")" = tag
+          test "$(git -C tmp/release-source rev-parse "refs/tags/${RELEASE_TAG}")" = \
+            "$RELEASE_TAG_OBJECT"
+          test "$(git -C tmp/release-source rev-parse "refs/tags/${RELEASE_TAG}^{}")" = \
+            "$RELEASE_REVISION"
+
+      - name: Install pinned Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: 1.94.1
+
+      - name: Publish exact release graph in dependency order
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
+        run: >-
+          bash scripts/ci/release_crates_graph.sh --publish
+          tmp/release-source/type-bridge-core

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,81 +145,7 @@ jobs:
         working-directory: type-bridge-core
         env:
           PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
-        run: |
-          set -euo pipefail
-
-          bash ../scripts/ci/publish_crate_idempotently.sh \
-            --verify-preexisting type-bridge-typedb-protocol-b7
-          bash ../scripts/ci/publish_crate_idempotently.sh \
-            --verify-preexisting type-bridge-typedb-driver-b7
-
-          patches=(
-            --config 'patch.crates-io.type-bridge-contract.path="crates/contract"'
-            --config 'patch.crates-io.type-bridge-core-lib.path="crates/core"'
-            --config 'patch.crates-io.type-bridge-schema.path="crates/schema"'
-            --config 'patch.crates-io.type-bridge-query.path="crates/query"'
-            --config 'patch.crates-io.type-bridge-schema-migration.path="crates/schema-migration"'
-            --config 'patch.crates-io.type-bridge-toml-transpiler.path="crates/toml-transpiler"'
-            --config 'patch.crates-io.type-bridge-schema-compat.path="crates/schema-compat"'
-            --config 'patch.crates-io.type-bridge-schema-codegen.path="crates/schema-codegen"'
-            --config 'patch.crates-io.type-bridge-orm-derive.path="crates/orm-derive"'
-            --config 'patch.crates-io.type-bridge-typedb-protocol-b7.path="vendor/typedb-protocol-b7"'
-            --config 'patch.crates-io.type-bridge-typedb-driver-b7.path="vendor/typedb-driver-b7"'
-            --config 'patch.crates-io.type-bridge-typedb-protocol-b8.path="vendor/typedb-protocol-b8"'
-            --config 'patch.crates-io.type-bridge-typedb-driver-b8.path="vendor/typedb-driver-b8"'
-            --config 'patch.crates-io.type-bridge-typedb-runtime.path="crates/typedb-runtime"'
-            --config 'patch.crates-io.type-bridge-orm.path="crates/orm"'
-            --config 'patch.crates-io.type-bridge-migration.path="crates/migration"'
-            --config 'patch.crates-io.type-bridge-schema-migration-typedb.path="crates/schema-migration-typedb"'
-            --config 'patch.crates-io.type-bridge-workspace.path="crates/workspace"'
-            --config 'patch.crates-io.type-bridge-cli.path="crates/cli"'
-            --config 'patch.crates-io.type-bridge.path="crates/rust"'
-          )
-          for crate in \
-            type-bridge-contract \
-            type-bridge-core-lib \
-            type-bridge-schema \
-            type-bridge-query \
-            type-bridge-schema-migration \
-            type-bridge-toml-transpiler \
-            type-bridge-schema-compat \
-            type-bridge-schema-codegen \
-            type-bridge-orm-derive \
-            type-bridge-typedb-protocol-b8 \
-            type-bridge-typedb-driver-b8 \
-            type-bridge-typedb-runtime \
-            type-bridge-orm \
-            type-bridge-migration \
-            type-bridge-schema-migration-typedb \
-            type-bridge-workspace \
-            type-bridge-cli \
-            type-bridge
-          do
-            cargo package --locked --allow-dirty --all-features -p "$crate" "${patches[@]}"
-          done
-
-          for crate in \
-            type-bridge-contract \
-            type-bridge-core-lib \
-            type-bridge-schema \
-            type-bridge-query \
-            type-bridge-schema-migration \
-            type-bridge-toml-transpiler \
-            type-bridge-schema-compat \
-            type-bridge-schema-codegen \
-            type-bridge-orm-derive \
-            type-bridge-typedb-protocol-b8 \
-            type-bridge-typedb-driver-b8 \
-            type-bridge-typedb-runtime \
-            type-bridge-orm \
-            type-bridge-migration \
-            type-bridge-schema-migration-typedb \
-            type-bridge-workspace \
-            type-bridge-cli \
-            type-bridge
-          do
-            bash ../scripts/ci/publish_crate_idempotently.sh --preflight "$crate"
-          done
+        run: bash ../scripts/ci/release_crates_graph.sh --preflight
 
       # Bind Python, npm, Cargo, and OCI artifacts to one release identity.
       - name: Validate identity and legacy TypeDB package provenance
@@ -301,31 +227,8 @@ jobs:
         working-directory: type-bridge-core
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: |
-          set -euo pipefail
-          cp ../scripts/ci/publish_crate_idempotently.sh "$RUNNER_TEMP/publish-crate.sh"
-          chmod +x "$RUNNER_TEMP/publish-crate.sh"
-
-          "$RUNNER_TEMP/publish-crate.sh type-bridge-contract"
-          "$RUNNER_TEMP/publish-crate.sh type-bridge-core-lib"
-          "$RUNNER_TEMP/publish-crate.sh type-bridge-schema"
-          "$RUNNER_TEMP/publish-crate.sh type-bridge-query"
-          "$RUNNER_TEMP/publish-crate.sh type-bridge-schema-migration"
-          "$RUNNER_TEMP/publish-crate.sh type-bridge-toml-transpiler"
-          "$RUNNER_TEMP/publish-crate.sh type-bridge-schema-compat"
-          "$RUNNER_TEMP/publish-crate.sh type-bridge-schema-codegen"
-          "$RUNNER_TEMP/publish-crate.sh type-bridge-orm-derive"
-          "$RUNNER_TEMP/publish-crate.sh type-bridge-typedb-protocol-b7"
-          "$RUNNER_TEMP/publish-crate.sh type-bridge-typedb-driver-b7"
-          "$RUNNER_TEMP/publish-crate.sh type-bridge-typedb-protocol-b8"
-          "$RUNNER_TEMP/publish-crate.sh type-bridge-typedb-driver-b8"
-          "$RUNNER_TEMP/publish-crate.sh type-bridge-typedb-runtime"
-          "$RUNNER_TEMP/publish-crate.sh type-bridge-orm"
-          "$RUNNER_TEMP/publish-crate.sh type-bridge-migration"
-          "$RUNNER_TEMP/publish-crate.sh type-bridge-schema-migration-typedb"
-          "$RUNNER_TEMP/publish-crate.sh type-bridge-workspace"
-          "$RUNNER_TEMP/publish-crate.sh type-bridge-cli"
-          "$RUNNER_TEMP/publish-crate.sh type-bridge"
+          PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
+        run: bash ../scripts/ci/release_crates_graph.sh --publish
 
   # Build type-bridge-core wheels for all platforms
   build-core-wheels:

--- a/scripts/ci/release_crates_graph.sh
+++ b/scripts/ci/release_crates_graph.sh
@@ -52,11 +52,33 @@ release_crates=(
   type-bridge-cli
   type-bridge
 )
+publish_crates=(
+  type-bridge-contract
+  type-bridge-core-lib
+  type-bridge-schema
+  type-bridge-query
+  type-bridge-schema-migration
+  type-bridge-toml-transpiler
+  type-bridge-schema-compat
+  type-bridge-schema-codegen
+  type-bridge-orm-derive
+  type-bridge-typedb-protocol-b7
+  type-bridge-typedb-driver-b7
+  type-bridge-typedb-protocol-b8
+  type-bridge-typedb-driver-b8
+  type-bridge-typedb-runtime
+  type-bridge-orm
+  type-bridge-migration
+  type-bridge-schema-migration-typedb
+  type-bridge-workspace
+  type-bridge-cli
+  type-bridge
+)
 
 cd -- "$core_workspace"
 
 if [[ "$mode" == "--publish" ]]; then
-  for crate in "${historical_crates[@]}" "${release_crates[@]}"; do
+  for crate in "${publish_crates[@]}"; do
     bash "$helper" "$crate"
   done
   exit 0

--- a/scripts/ci/release_crates_graph.sh
+++ b/scripts/ci/release_crates_graph.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Preflight or publish the complete crates.io release graph in dependency order.
+set -euo pipefail
+
+usage() {
+  echo "usage: release_crates_graph.sh (--preflight|--publish) [CORE_WORKSPACE]" >&2
+  exit 2
+}
+
+[[ $# -ge 1 && $# -le 2 ]] || usage
+mode="$1"
+case "$mode" in
+  --preflight | --publish) ;;
+  *) usage ;;
+esac
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/../.." && pwd)"
+core_workspace="${2:-$repo_root/type-bridge-core}"
+[[ -d "$core_workspace" && ! -L "$core_workspace" ]] || {
+  echo "Cargo workspace is missing or not a directory: $core_workspace" >&2
+  exit 1
+}
+core_workspace="$(cd -- "$core_workspace" && pwd)"
+helper="$script_dir/publish_crate_idempotently.sh"
+[[ -f "$helper" && ! -L "$helper" ]] || {
+  echo "Cargo publication helper is missing or not a regular file: $helper" >&2
+  exit 1
+}
+
+historical_crates=(
+  type-bridge-typedb-protocol-b7
+  type-bridge-typedb-driver-b7
+)
+release_crates=(
+  type-bridge-contract
+  type-bridge-core-lib
+  type-bridge-schema
+  type-bridge-query
+  type-bridge-schema-migration
+  type-bridge-toml-transpiler
+  type-bridge-schema-compat
+  type-bridge-schema-codegen
+  type-bridge-orm-derive
+  type-bridge-typedb-protocol-b8
+  type-bridge-typedb-driver-b8
+  type-bridge-typedb-runtime
+  type-bridge-orm
+  type-bridge-migration
+  type-bridge-schema-migration-typedb
+  type-bridge-workspace
+  type-bridge-cli
+  type-bridge
+)
+
+cd -- "$core_workspace"
+
+if [[ "$mode" == "--publish" ]]; then
+  for crate in "${historical_crates[@]}" "${release_crates[@]}"; do
+    bash "$helper" "$crate"
+  done
+  exit 0
+fi
+
+for crate in "${historical_crates[@]}"; do
+  bash "$helper" --verify-preexisting "$crate"
+done
+
+patches=(
+  --config 'patch.crates-io.type-bridge-contract.path="crates/contract"'
+  --config 'patch.crates-io.type-bridge-core-lib.path="crates/core"'
+  --config 'patch.crates-io.type-bridge-schema.path="crates/schema"'
+  --config 'patch.crates-io.type-bridge-query.path="crates/query"'
+  --config 'patch.crates-io.type-bridge-schema-migration.path="crates/schema-migration"'
+  --config 'patch.crates-io.type-bridge-toml-transpiler.path="crates/toml-transpiler"'
+  --config 'patch.crates-io.type-bridge-schema-compat.path="crates/schema-compat"'
+  --config 'patch.crates-io.type-bridge-schema-codegen.path="crates/schema-codegen"'
+  --config 'patch.crates-io.type-bridge-orm-derive.path="crates/orm-derive"'
+  --config 'patch.crates-io.type-bridge-typedb-protocol-b7.path="vendor/typedb-protocol-b7"'
+  --config 'patch.crates-io.type-bridge-typedb-driver-b7.path="vendor/typedb-driver-b7"'
+  --config 'patch.crates-io.type-bridge-typedb-protocol-b8.path="vendor/typedb-protocol-b8"'
+  --config 'patch.crates-io.type-bridge-typedb-driver-b8.path="vendor/typedb-driver-b8"'
+  --config 'patch.crates-io.type-bridge-typedb-runtime.path="crates/typedb-runtime"'
+  --config 'patch.crates-io.type-bridge-orm.path="crates/orm"'
+  --config 'patch.crates-io.type-bridge-migration.path="crates/migration"'
+  --config 'patch.crates-io.type-bridge-schema-migration-typedb.path="crates/schema-migration-typedb"'
+  --config 'patch.crates-io.type-bridge-workspace.path="crates/workspace"'
+  --config 'patch.crates-io.type-bridge-cli.path="crates/cli"'
+  --config 'patch.crates-io.type-bridge.path="crates/rust"'
+)
+cargo_command=("${CARGO_BIN:-cargo}")
+if [[ -n "${CARGO_TOOLCHAIN:-}" ]]; then
+  [[ "$CARGO_TOOLCHAIN" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+    echo "CARGO_TOOLCHAIN must be an exact numeric Rust version" >&2
+    exit 2
+  }
+  cargo_command+=("+$CARGO_TOOLCHAIN")
+fi
+for crate in "${release_crates[@]}"; do
+  "${cargo_command[@]}" package \
+    --locked --allow-dirty --all-features -p "$crate" "${patches[@]}"
+done
+for crate in "${release_crates[@]}"; do
+  bash "$helper" --preflight "$crate"
+done

--- a/scripts/ci/validate_release_identity.py
+++ b/scripts/ci/validate_release_identity.py
@@ -97,6 +97,7 @@ PACKAGED_RELEASE_CRATES = tuple(
 )
 PACKAGING_PATCH_CRATES = PUBLISHED_CRATES
 EXPECTED_NEW_CRATES = tuple(crate for crate in PUBLISHED_CRATES if crate not in PREEXISTING_CRATES)
+RELEASE_CRATES_GRAPH = PurePosixPath("scripts/ci/release_crates_graph.sh")
 TYPEDB_RUNTIME_PACKAGE = "type-bridge-typedb-runtime"
 TYPEDB_BAND7_DEPENDENCY = "type-bridge-typedb-driver-b7"
 TYPEDB_BAND8_DEPENDENCY = "type-bridge-typedb-driver-b8"
@@ -1537,95 +1538,78 @@ def cargo_workspace_packages(workspace_manifest: Path) -> tuple[CargoPackage, ..
     return tuple(packages)
 
 
-def workflow_publish_sequence(workflow: Path) -> tuple[str, ...]:
-    """Return the literal ordered crate arguments passed to the publish helper."""
+def _workflow_release_graph_source(workflow: Path) -> str:
+    """Return the graph script bound to the ordinary release workflow."""
     if not workflow.is_file() or workflow.is_symlink():
         raise ValidationError(f"Release workflow is missing or non-regular: {workflow}")
     source = workflow.read_text(encoding="utf-8")
-    return tuple(re.findall(r'publish-crate\.sh ([A-Za-z0-9_-]+)["\']?', source))
+    for mode in ("--preflight", "--publish"):
+        command = f"bash ../{RELEASE_CRATES_GRAPH.as_posix()} {mode}"
+        if source.count(command) != 1:
+            raise ValidationError(
+                f"Release workflow must invoke the Cargo graph exactly once with {mode}"
+            )
+    graph = workflow.resolve().parents[2] / RELEASE_CRATES_GRAPH
+    if not graph.is_file() or graph.is_symlink():
+        raise ValidationError(f"Cargo release graph is missing or non-regular: {graph}")
+    return graph.read_text(encoding="utf-8")
+
+
+def _bash_crate_array(source: str, name: str) -> tuple[str, ...]:
+    """Return one strict, literal Bash array of crate names."""
+    matches = tuple(
+        re.finditer(
+            rf"(?m)^{re.escape(name)}=\(\n(?P<body>(?:  [A-Za-z0-9_-]+\n)+)\)$",
+            source,
+        )
+    )
+    if len(matches) != 1:
+        raise ValidationError(f"Cargo release graph must define exactly one {name} array")
+    return tuple(line.strip() for line in matches[0].group("body").splitlines())
+
+
+def workflow_publish_sequence(workflow: Path) -> tuple[str, ...]:
+    """Return the authoritative ordered crate publication sequence."""
+    source = _workflow_release_graph_source(workflow)
+    loop = 'for crate in "${publish_crates[@]}"; do\n    bash "$helper" "$crate"'
+    if source.count(loop) != 1:
+        raise ValidationError("Cargo release graph publish loop is malformed")
+    return _bash_crate_array(source, "publish_crates")
 
 
 def workflow_preflight_sequences(workflow: Path) -> tuple[tuple[str, ...], tuple[str, ...]]:
     """Return the local-patch and full-package sequences from release preflight."""
-    if not workflow.is_file() or workflow.is_symlink():
-        raise ValidationError(f"Release workflow is missing or non-regular: {workflow}")
-    source = workflow.read_text(encoding="utf-8")
-    command = 'cargo package --locked --allow-dirty --all-features -p "$crate" "${patches[@]}"'
-    lines = source.splitlines()
-    command_lines = [index for index, line in enumerate(lines) if command in line]
-    if len(command_lines) != 1:
-        raise ValidationError(
-            "Release workflow must contain exactly one full cargo-package preflight loop"
-        )
-    command_line = command_lines[0]
-    try:
-        do_line = max(index for index in range(command_line) if lines[index].strip() == "do")
-        for_line = max(
-            index for index in range(do_line) if lines[index].strip() == "for crate in \\"
-        )
-    except ValueError as error:
-        raise ValidationError("Cargo-package preflight loop is malformed") from error
-
-    packages: list[str] = []
-    for line in lines[for_line + 1 : do_line]:
-        token = line.strip()
-        if token.endswith("\\"):
-            token = token[:-1].rstrip()
-        if re.fullmatch(r"[A-Za-z0-9_-]+", token) is None:
-            raise ValidationError(f"Cargo-package preflight contains an invalid crate: {token!r}")
-        packages.append(token)
+    source = _workflow_release_graph_source(workflow)
+    package_loop = (
+        'for crate in "${release_crates[@]}"; do\n'
+        '  "${cargo_command[@]}" package \\\n'
+        '    --locked --allow-dirty --all-features -p "$crate" "${patches[@]}"'
+    )
+    if source.count(package_loop) != 1:
+        raise ValidationError("Cargo release graph package-preflight loop is malformed")
     patches = tuple(re.findall(r"patch\.crates-io\.([A-Za-z0-9_-]+)\.path=", source))
-    return patches, tuple(packages)
+    return patches, _bash_crate_array(source, "release_crates")
 
 
 def workflow_registry_preflight_sequences(
     workflow: Path,
 ) -> tuple[tuple[str, ...], tuple[str, ...]]:
     """Return checksum-only and expected-new crates.io key preflights."""
-    if not workflow.is_file() or workflow.is_symlink():
-        raise ValidationError(f"Release workflow is missing or non-regular: {workflow}")
-    source = workflow.read_text(encoding="utf-8")
-    preexisting = tuple(re.findall(r"--verify-preexisting ([A-Za-z0-9_-]+)", source))
-    command = 'bash ../scripts/ci/publish_crate_idempotently.sh --preflight "$crate"'
-    lines = source.splitlines()
-    command_lines = [index for index, line in enumerate(lines) if command in line]
-    if len(command_lines) != 1:
-        raise ValidationError(
-            "Release workflow must contain exactly one crates.io key-preflight loop"
-        )
-    preexisting_marker = "--verify-preexisting "
-    package_marker = (
-        'cargo package --locked --allow-dirty --all-features -p "$crate" "${patches[@]}"'
+    source = _workflow_release_graph_source(workflow)
+    historical_loop = (
+        'for crate in "${historical_crates[@]}"; do\n  bash "$helper" --verify-preexisting "$crate"'
     )
-    if (
-        source.count(preexisting_marker) != len(PREEXISTING_CRATES)
-        or source.count(package_marker) != 1
-    ):
-        raise ValidationError("Release workflow crates.io preflight markers are malformed")
-    if not (
-        source.rindex(preexisting_marker) < source.index(package_marker) < source.index(command)
-    ):
-        raise ValidationError(
-            "Release workflow crates.io preflights are not ordered before publication"
-        )
-    command_line = command_lines[0]
-    try:
-        do_line = max(index for index in range(command_line) if lines[index].strip() == "do")
-        for_line = max(
-            index for index in range(do_line) if lines[index].strip() == "for crate in \\"
-        )
-    except ValueError as error:
-        raise ValidationError("Crates.io key-preflight loop is malformed") from error
-
-    candidates: list[str] = []
-    for line in lines[for_line + 1 : do_line]:
-        token = line.strip()
-        if token.endswith("\\"):
-            token = token[:-1].rstrip()
-        if re.fullmatch(r"[A-Za-z0-9_-]+", token) is None:
-            raise ValidationError(f"Crates.io key-preflight contains an invalid crate: {token!r}")
-        candidates.append(token)
-    return preexisting, tuple(candidates)
+    candidate_loop = (
+        'for crate in "${release_crates[@]}"; do\n  bash "$helper" --preflight "$crate"'
+    )
+    if source.count(historical_loop) != 1 or source.count(candidate_loop) != 1:
+        raise ValidationError("Cargo release graph crates.io preflight loops are malformed")
+    if not source.index(historical_loop) < source.index(candidate_loop):
+        raise ValidationError("Cargo release graph crates.io preflight loops are reordered")
+    return (
+        _bash_crate_array(source, "historical_crates"),
+        _bash_crate_array(source, "release_crates"),
+    )
 
 
 def validate_native_notice_workflow(workflow: Path) -> None:

--- a/tests/unit/compat/test_release_identity_validator.py
+++ b/tests/unit/compat/test_release_identity_validator.py
@@ -114,6 +114,17 @@ def copy_workspace_manifests(tmp_path: Path) -> Path:
     return target_root / "Cargo.toml"
 
 
+def copy_release_graph_authorities(tmp_path: Path) -> tuple[Path, Path]:
+    """Copy the ordinary workflow and the Cargo graph it authorizes."""
+    workflow = tmp_path / ".github/workflows/release.yml"
+    graph = tmp_path / "scripts/ci/release_crates_graph.sh"
+    workflow.parent.mkdir(parents=True)
+    graph.parent.mkdir(parents=True)
+    shutil.copyfile(ROOT / ".github/workflows/release.yml", workflow)
+    shutil.copyfile(ROOT / "scripts/ci/release_crates_graph.sh", graph)
+    return workflow, graph
+
+
 def replace_lock_package_text(
     workspace: Path,
     package: str,
@@ -318,6 +329,48 @@ def test_repository_workflow_uses_the_cargo_inclusive_contract() -> None:
     assert "--artifact-contract cargo-inclusive" in source
     validator.workflow_preflight_sequences(workflow)
     validator.workflow_registry_preflight_sequences(workflow)
+
+
+def test_release_workflow_must_bind_the_centralized_cargo_graph(tmp_path: Path) -> None:
+    workflow, _ = copy_release_graph_authorities(tmp_path)
+    workflow.write_text(
+        workflow.read_text().replace(
+            "bash ../scripts/ci/release_crates_graph.sh --publish",
+            "echo cargo publish omitted",
+            1,
+        )
+    )
+
+    with pytest.raises(validator.ValidationError, match="exactly once with --publish"):
+        validator.workflow_publish_sequence(workflow)
+
+
+def test_centralized_cargo_publish_order_cannot_drift(tmp_path: Path) -> None:
+    workflow, graph = copy_release_graph_authorities(tmp_path)
+    source = graph.read_text()
+    first = "publish_crates=(\n  type-bridge-contract\n  type-bridge-core-lib\n"
+    assert source.count(first) == 1
+    graph.write_text(
+        source.replace(
+            first,
+            "publish_crates=(\n  type-bridge-core-lib\n  type-bridge-contract\n",
+            1,
+        )
+    )
+
+    with pytest.raises(validator.ValidationError, match="incomplete or reordered"):
+        validate(release_workflow=workflow)
+
+
+def test_centralized_cargo_preflight_loop_cannot_be_bypassed(tmp_path: Path) -> None:
+    workflow, graph = copy_release_graph_authorities(tmp_path)
+    source = graph.read_text()
+    marker = 'bash "$helper" --preflight "$crate"'
+    assert source.count(marker) == 1
+    graph.write_text(source.replace(marker, 'echo "preflight omitted for $crate"', 1))
+
+    with pytest.raises(validator.ValidationError, match="preflight loops are malformed"):
+        validator.workflow_registry_preflight_sequences(workflow)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/infra/test_crates_io_publish_helper.py
+++ b/tests/unit/infra/test_crates_io_publish_helper.py
@@ -11,7 +11,9 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 PUBLISH_HELPER = REPO_ROOT / "scripts/ci/publish_crate_idempotently.sh"
+RELEASE_GRAPH = REPO_ROOT / "scripts/ci/release_crates_graph.sh"
 RELEASE_WORKFLOW = REPO_ROOT / ".github/workflows/release.yml"
+RECOVERY_WORKFLOW = REPO_ROOT / ".github/workflows/recover-crates-v2.0.1.yml"
 CUTOFF_WITNESS = "type-bridge-core-lib"
 CANDIDATE_BYTES = b"candidate crate bytes\n"
 CANDIDATE_CHECKSUM = hashlib.sha256(CANDIDATE_BYTES).hexdigest()
@@ -496,6 +498,81 @@ def test_cargo_inclusive_release_workflow_invokes_the_cargo_helper() -> None:
     workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
 
     assert "--artifact-contract cargo-inclusive" in workflow
-    assert PUBLISH_HELPER.name in workflow
+    assert RELEASE_GRAPH.name in workflow
     assert "--cutoff-state" not in workflow
     assert "publish-crates:" in workflow
+
+
+def test_cargo_publish_job_passes_each_crate_as_a_separate_argument(tmp_path: Path) -> None:
+    """Execute the production graph script against a non-publishing helper double."""
+    workspace = tmp_path / "workspace"
+    core = workspace / "type-bridge-core"
+    scripts = workspace / "scripts" / "ci"
+    invocation_log = tmp_path / "invocations"
+    core.mkdir(parents=True)
+    scripts.mkdir(parents=True)
+    graph = executable(
+        scripts / RELEASE_GRAPH.name,
+        RELEASE_GRAPH.read_text(encoding="utf-8"),
+    )
+    executable(
+        scripts / PUBLISH_HELPER.name,
+        """#!/usr/bin/env bash
+set -euo pipefail
+[[ $# -eq 1 ]]
+printf '%s\\n' "$1" >> "$INVOCATION_LOG"
+""",
+    )
+
+    result = subprocess.run(
+        ["bash", str(graph), "--publish", str(core)],
+        cwd=workspace,
+        env={
+            **os.environ,
+            "INVOCATION_LOG": str(invocation_log),
+        },
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert invocation_log.read_text(encoding="utf-8").splitlines() == [
+        "type-bridge-typedb-protocol-b7",
+        "type-bridge-typedb-driver-b7",
+        "type-bridge-contract",
+        "type-bridge-core-lib",
+        "type-bridge-schema",
+        "type-bridge-query",
+        "type-bridge-schema-migration",
+        "type-bridge-toml-transpiler",
+        "type-bridge-schema-compat",
+        "type-bridge-schema-codegen",
+        "type-bridge-orm-derive",
+        "type-bridge-typedb-protocol-b8",
+        "type-bridge-typedb-driver-b8",
+        "type-bridge-typedb-runtime",
+        "type-bridge-orm",
+        "type-bridge-migration",
+        "type-bridge-schema-migration-typedb",
+        "type-bridge-workspace",
+        "type-bridge-cli",
+        "type-bridge",
+    ]
+
+
+def test_crates_recovery_is_closed_to_the_exact_failed_release() -> None:
+    workflow = RECOVERY_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "push:" not in workflow
+    assert "github.ref == 'refs/heads/master'" in workflow
+    assert "refs/tags/v2.0.1" in workflow
+    assert "f0b9fd41bc0a437939bb256062fe6ad47071d632" in workflow
+    assert "42775b4c412a9278e182667d27cf96e09bfc04d7" in workflow
+    assert 'RELEASE_RUN_ID: "30860417007"' in workflow
+    assert '.path == ".github/workflows/release.yml"' in workflow
+    assert 'require_job "Publish Rust crates to crates.io" failure' in workflow
+    assert "--preflight" in workflow
+    assert "inputs.recovery_mode == 'publish'" in workflow
+    assert "needs.verify-recovery.result == 'success'" in workflow
+    assert "CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}" in workflow
+    assert "--publish" in workflow

--- a/tests/unit/infra/test_crates_io_publish_helper.py
+++ b/tests/unit/infra/test_crates_io_publish_helper.py
@@ -537,8 +537,6 @@ printf '%s\\n' "$1" >> "$INVOCATION_LOG"
 
     assert result.returncode == 0, result.stderr
     assert invocation_log.read_text(encoding="utf-8").splitlines() == [
-        "type-bridge-typedb-protocol-b7",
-        "type-bridge-typedb-driver-b7",
         "type-bridge-contract",
         "type-bridge-core-lib",
         "type-bridge-schema",
@@ -548,6 +546,8 @@ printf '%s\\n' "$1" >> "$INVOCATION_LOG"
         "type-bridge-schema-compat",
         "type-bridge-schema-codegen",
         "type-bridge-orm-derive",
+        "type-bridge-typedb-protocol-b7",
+        "type-bridge-typedb-driver-b7",
         "type-bridge-typedb-protocol-b8",
         "type-bridge-typedb-driver-b8",
         "type-bridge-typedb-runtime",

--- a/tests/unit/infra/test_latest_typedb_driver_pin.py
+++ b/tests/unit/infra/test_latest_typedb_driver_pin.py
@@ -751,7 +751,7 @@ def test_release_workflow_binds_the_driver_cutoff_before_cargo_publication() -> 
     assert validation < committed < preflight < cargo_publish
     assert "  preflight-publication:" not in workflow
     assert "--cutoff-state" not in workflow
-    assert "publish_crate_idempotently" in workflow
+    assert "release_crates_graph" in workflow
     assert "cargo publish" not in workflow
     assert (
         "needs: [validate-release-identity, accept-python-artifacts, "

--- a/tests/unit/infra/test_release_artifact_gates.py
+++ b/tests/unit/infra/test_release_artifact_gates.py
@@ -20,6 +20,7 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 CI_WORKFLOW = REPO_ROOT / ".github/workflows/ci.yml"
 RELEASE_WORKFLOW = REPO_ROOT / ".github/workflows/release.yml"
 CRATE_PUBLISH_HELPER = REPO_ROOT / "scripts/ci/publish_crate_idempotently.sh"
+CRATE_RELEASE_GRAPH = REPO_ROOT / "scripts/ci/release_crates_graph.sh"
 FRESH_RUNTIME_PROBE = REPO_ROOT / "scripts/ci/validate_fresh_typedb_runtime_package.sh"
 RUST_RELEASE_ARTIFACT_VALIDATOR = REPO_ROOT / "scripts/ci/validate_rust_release_artifacts.py"
 RECOVERY_VALIDATOR = REPO_ROOT / "scripts/ci/validate_release_recovery.py"
@@ -37,8 +38,8 @@ MUTATING_RELEASE_JOBS = (
 CARGO_PUBLICATION_MARKERS = (
     "publish-crates:",
     "CARGO_REGISTRY_TOKEN",
-    "publish_crate_idempotently",
-    "cargo package",
+    "release_crates_graph",
+    '"${cargo_command[@]}" package',
     "patch.crates-io",
     "--verify-preexisting",
     "type-bridge-typedb-protocol-b8",
@@ -877,8 +878,9 @@ def test_candidate_guard_gate_rejects_hidden_preflight_publication() -> None:
 @pytest.mark.parametrize("marker", CARGO_PUBLICATION_MARKERS)
 def test_cargo_inclusive_release_contains_each_required_path(marker: str) -> None:
     workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    graph = CRATE_RELEASE_GRAPH.read_text(encoding="utf-8")
 
-    assert marker in workflow
+    assert marker in workflow or marker in graph
 
 
 def test_python_npm_publication_is_serial_after_global_candidate_gates() -> None:


### PR DESCRIPTION
## Summary

Recover the failed v2.0.1 crates.io publication without moving the immutable tag or touching the already-published npm package.

## Key changes

- move Cargo graph preflight and publication into one locally executable, dependency-ordered script
- replace the broken inline production shell invocation
- add a crates.io-only recovery workflow pinned to tag v2.0.1, source revision f0b9fd4, tag object 42775b4c, and failed run 30860417007
- default recovery to verify mode and require its full package/registry preflight before publish mode can mutate crates.io
- execute the production graph script against a non-publishing helper double in regression tests

## Verification

- exact local graph preflight with Cargo 1.94.1: all 18 new tarballs packaged and verified; both historical checksums matched; all new registry keys absent
- release infrastructure tests: 153 passed
- Ruff and shell syntax checks passed

## Recovery procedure

After merge, dispatch Recover crates.io v2.0.1 in verify mode. Only after that succeeds, dispatch the same workflow in publish mode.