### PR TITLE
fix(release): back off crates.io publication (#210)

### DIFF
--- a/scripts/ci/publish_crate_idempotently.sh
+++ b/scripts/ci/publish_crate_idempotently.sh
@@ -29,8 +29,11 @@ cargo_bin="${CARGO_BIN:-cargo}"
 curl_bin="${CURL_BIN:-curl}"
 python_bin="${PYTHON_BIN:-python3}"
 sha256_bin="${SHA256_BIN:-sha256sum}"
+sleep_bin="${SLEEP_BIN:-sleep}"
 verify_attempts="${CRATES_IO_VERIFY_ATTEMPTS:-12}"
 verify_delay="${CRATES_IO_VERIFY_DELAY_SECONDS:-5}"
+publish_attempts="${CRATES_IO_PUBLISH_ATTEMPTS:-5}"
+publish_backoff="${CRATES_IO_PUBLISH_INITIAL_BACKOFF_SECONDS:-10}"
 
 if [[ ! "$crate" =~ ^[A-Za-z0-9_-]+$ ]]; then
   echo "Invalid crate name: $crate" >&2
@@ -46,6 +49,14 @@ if [[ ! "$verify_attempts" =~ ^[1-9][0-9]*$ ]]; then
 fi
 if [[ ! "$verify_delay" =~ ^[0-9]+$ ]]; then
   echo "CRATES_IO_VERIFY_DELAY_SECONDS must be a non-negative integer" >&2
+  exit 2
+fi
+if [[ ! "$publish_attempts" =~ ^[1-9][0-9]*$ || "$publish_attempts" -gt 10 ]]; then
+  echo "CRATES_IO_PUBLISH_ATTEMPTS must be an integer from 1 through 10" >&2
+  exit 2
+fi
+if [[ ! "$publish_backoff" =~ ^[0-9]+$ || "$publish_backoff" -gt 600 ]]; then
+  echo "CRATES_IO_PUBLISH_INITIAL_BACKOFF_SECONDS must be an integer from 0 through 600" >&2
   exit 2
 fi
 
@@ -246,7 +257,7 @@ require_matching_registry_checksum() {
       echo "crates.io API did not expose verifiable ${crate}@${version} after ${verify_attempts} attempts (last status ${fetch_status})" >&2
       return 1
     fi
-    sleep "$verify_delay"
+    "$sleep_bin" "$verify_delay"
   done
 }
 
@@ -268,7 +279,7 @@ require_matching_registry_index_checksum() {
       echo "crates.io sparse index did not expose verifiable ${crate}@${version} after ${verify_attempts} attempts (last status ${fetch_status})" >&2
       return 1
     fi
-    sleep "$verify_delay"
+    "$sleep_bin" "$verify_delay"
   done
 }
 
@@ -289,16 +300,23 @@ if [[ "$mode" == "publish" || "$mode" == "cutoff-state" ]]; then
   # so an existing immutable version can be compared before any upload attempt.
   "$cargo_bin" package --locked -p "$crate" >/dev/null
 fi
-if [[ ! -f "$crate_file" || -L "$crate_file" ]]; then
-  echo "Packaged crate is missing or non-regular: $crate_file" >&2
-  exit 1
-fi
-checksum_output="$($sha256_bin "$crate_file")"
-candidate_checksum="${checksum_output%%[[:space:]]*}"
-if [[ ! "$candidate_checksum" =~ ^[0-9a-f]{64}$ ]]; then
-  echo "Could not calculate a lowercase SHA-256 for $crate_file" >&2
-  exit 1
-fi
+
+calculate_candidate_checksum() {
+  local checksum_output candidate
+  if [[ ! -f "$crate_file" || -L "$crate_file" ]]; then
+    echo "Packaged crate is missing or non-regular: $crate_file" >&2
+    return 1
+  fi
+  checksum_output="$($sha256_bin "$crate_file")"
+  candidate="${checksum_output%%[[:space:]]*}"
+  if [[ ! "$candidate" =~ ^[0-9a-f]{64}$ ]]; then
+    echo "Could not calculate a lowercase SHA-256 for $crate_file" >&2
+    return 1
+  fi
+  printf '%s\n' "$candidate"
+}
+
+candidate_checksum="$(calculate_candidate_checksum)"
 
 # A candidate key is safe only if both crates.io authorities agree that it is
 # absent, or both expose the exact candidate checksum as a non-yanked version.
@@ -313,6 +331,15 @@ preflight_candidate_key() {
     index_status=0
   else
     index_status=$?
+  fi
+
+  # The graph preflight uses local patches so every unpublished dependent crate
+  # can be packaged before registry mutation. Those patches add metadata to the
+  # archive's generated Cargo.lock. Once a key exists, rebuild it through the
+  # exact unpatched publish path before comparing immutable bytes.
+  if [[ "$mode" == "preflight" && ("$api_status" -eq 0 || "$index_status" -eq 0) ]]; then
+    "$cargo_bin" package --locked -p "$crate" >/dev/null
+    candidate_checksum="$(calculate_candidate_checksum)"
   fi
 
   if [[ "$api_status" -eq 4 && "$index_status" -eq 4 ]]; then
@@ -359,12 +386,25 @@ if [[ "$mode" == "preflight" ]]; then
   exit 0
 fi
 
-if publish_output="$($cargo_bin publish --locked --registry crates-io -p "$crate" 2>&1)"; then
-  printf '%s\n' "$publish_output"
-  require_matching_registry_checksum "$candidate_checksum"
-  require_matching_registry_index_checksum "$candidate_checksum"
-  exit 0
-fi
+for ((publish_attempt = 1; publish_attempt <= publish_attempts; publish_attempt++)); do
+  if publish_output="$($cargo_bin publish --locked --registry crates-io -p "$crate" 2>&1)"; then
+    printf '%s\n' "$publish_output"
+    require_matching_registry_checksum "$candidate_checksum"
+    require_matching_registry_index_checksum "$candidate_checksum"
+    exit 0
+  fi
+  if ! grep -qiE "status 429|429 Too Many Requests" <<<"$publish_output"; then
+    break
+  fi
+  printf '%s\n' "$publish_output" >&2
+  if (( publish_attempt == publish_attempts )); then
+    echo "${crate}@${version} remained rate-limited after ${publish_attempts} publish attempts" >&2
+    exit 1
+  fi
+  echo "${crate}@${version} was rate-limited; retrying publish in ${publish_backoff}s (attempt $((publish_attempt + 1))/${publish_attempts})." >&2
+  "$sleep_bin" "$publish_backoff"
+  publish_backoff=$((publish_backoff * 2))
+done
 
 printf '%s\n' "$publish_output" >&2
 if ! grep -qiE \

--- a/tests/unit/infra/test_crates_io_publish_helper.py
+++ b/tests/unit/infra/test_crates_io_publish_helper.py
@@ -40,6 +40,8 @@ def run_helper(
     crate: str = "demo-crate",
     version: str = "1.2.3",
     registry_checksum: str = CANDIDATE_CHECKSUM,
+    publish_backoff: str = "0",
+    initial_archive_bytes: bytes = CANDIDATE_BYTES,
 ) -> tuple[subprocess.CompletedProcess[str], list[str], list[str]]:
     """Run the helper against deterministic cargo and crates.io doubles."""
     workspace = tmp_path / "workspace"
@@ -48,13 +50,15 @@ def run_helper(
     tools.mkdir()
     command_log = tmp_path / "cargo-commands"
     curl_log = tmp_path / "curl-urls"
+    sleep_log = tmp_path / "sleep-delays"
     api_state = tmp_path / "api-state"
     index_state = tmp_path / "index-state"
+    publish_state = tmp_path / "publish-state"
 
     if mode == "preflight":
         archive = workspace / f"target/package/{crate}-{version}.crate"
         archive.parent.mkdir(parents=True)
-        archive.write_bytes(CANDIDATE_BYTES)
+        archive.write_bytes(initial_archive_bytes)
 
     cargo = executable(
         tools / "cargo",
@@ -80,6 +84,28 @@ case "${1:-}" in
           "$CRATE_NAME" "$CRATE_VERSION" >&2
         exit 101
         ;;
+      rate-limited-once | rate-limited-twice)
+        publish_count=0
+        if [[ -f "$PUBLISH_STATE_FILE" ]]; then
+          publish_count="$(<"$PUBLISH_STATE_FILE")"
+        fi
+        printf '%s\\n' "$((publish_count + 1))" > "$PUBLISH_STATE_FILE"
+        limit=1
+        if [[ "$CARGO_PUBLISH_MODE" == "rate-limited-twice" ]]; then
+          limit=2
+        fi
+        if (( publish_count < limit )); then
+          printf '%s\\n' \
+            'status 429 Too Many Requests: published too many new crates' >&2
+          exit 101
+        fi
+        printf 'published %s\\n' "$CRATE_NAME"
+        ;;
+      rate-limited)
+        printf '%s\\n' \
+          'status 429 Too Many Requests: published too many new crates' >&2
+        exit 101
+        ;;
       *)
         printf '%s\\n' 'unexpected cargo publish invocation' >&2
         exit 42
@@ -91,6 +117,14 @@ case "${1:-}" in
     exit 43
     ;;
 esac
+""",
+    )
+    sleep = executable(
+        tools / "sleep",
+        """#!/usr/bin/env bash
+set -euo pipefail
+[[ $# -eq 1 ]]
+printf '%s\\n' "$1" >> "$SLEEP_LOG"
 """,
     )
     curl = executable(
@@ -215,13 +249,18 @@ fi
             "COMMAND_LOG": str(command_log),
             "CRATE_NAME": crate,
             "CRATE_VERSION": version,
+            "CRATES_IO_PUBLISH_ATTEMPTS": "3",
+            "CRATES_IO_PUBLISH_INITIAL_BACKOFF_SECONDS": publish_backoff,
             "CRATES_IO_VERIFY_ATTEMPTS": "3",
             "CRATES_IO_VERIFY_DELAY_SECONDS": "0",
             "CURL_BIN": str(curl),
             "CURL_LOG": str(curl_log),
             "INDEX_SEQUENCE": index_sequence,
             "INDEX_STATE_FILE": str(index_state),
+            "PUBLISH_STATE_FILE": str(publish_state),
             "REGISTRY_CHECKSUM": registry_checksum,
+            "SLEEP_BIN": str(sleep),
+            "SLEEP_LOG": str(sleep_log),
         }
     )
     arguments = ["bash", str(PUBLISH_HELPER)]
@@ -325,6 +364,39 @@ def test_successful_publish_polls_exact_sparse_index_version(tmp_path: Path) -> 
     assert "Verified crates.io sparse-index checksum" in result.stdout
 
 
+def test_rate_limited_publish_backs_off_then_verifies_both_authorities(
+    tmp_path: Path,
+) -> None:
+    result, commands, _ = run_helper(
+        tmp_path,
+        api_sequence="missing,matching",
+        index_sequence="missing,matching",
+        publish_mode="rate-limited-twice",
+        publish_backoff="10",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert commands.count("publish --locked --registry crates-io -p demo-crate") == 3
+    assert "was rate-limited; retrying publish in 10s (attempt 2/3)" in result.stderr
+    assert "was rate-limited; retrying publish in 20s (attempt 3/3)" in result.stderr
+    assert (tmp_path / "sleep-delays").read_text().splitlines() == ["10", "20"]
+    assert "Verified crates.io API checksum" in result.stdout
+    assert "Verified crates.io sparse-index checksum" in result.stdout
+
+
+def test_rate_limited_publish_stops_after_bounded_attempts(tmp_path: Path) -> None:
+    result, commands, _ = run_helper(
+        tmp_path,
+        api_sequence="missing",
+        index_sequence="missing",
+        publish_mode="rate-limited",
+    )
+
+    assert result.returncode != 0
+    assert commands.count("publish --locked --registry crates-io -p demo-crate") == 3
+    assert "remained rate-limited after 3 publish attempts" in result.stderr
+
+
 def test_preflight_absent_key_hashes_existing_archive_without_publish(tmp_path: Path) -> None:
     result, commands, _ = run_helper(
         tmp_path,
@@ -338,6 +410,22 @@ def test_preflight_absent_key_hashes_existing_archive_without_publish(tmp_path: 
     assert "Verified crates.io key is absent" in result.stdout
 
 
+def test_preflight_repackages_existing_key_through_exact_publish_path(
+    tmp_path: Path,
+) -> None:
+    result, commands, _ = run_helper(
+        tmp_path,
+        api_sequence="matching",
+        index_sequence="matching",
+        mode="preflight",
+        initial_archive_bytes=b"patched graph archive\n",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert commands == ["pkgid -p demo-crate", "package --locked -p demo-crate"]
+    assert "already published with identical non-yanked bytes" in result.stdout
+
+
 def test_preflight_rejects_inconsistent_api_and_index_visibility(tmp_path: Path) -> None:
     result, commands, _ = run_helper(
         tmp_path,
@@ -347,7 +435,7 @@ def test_preflight_rejects_inconsistent_api_and_index_visibility(tmp_path: Path)
     )
 
     assert result.returncode != 0
-    assert commands == ["pkgid -p demo-crate"]
+    assert commands == ["pkgid -p demo-crate", "package --locked -p demo-crate"]
     assert "API did not expose verifiable" in result.stderr
 
 


### PR DESCRIPTION
## Summary

Resume the partially published crates.io v2.0.1 graph safely after crates.io
rate-limited the recovery run.

## Key changes

- Retry only explicit HTTP 429 Cargo publish failures with bounded exponential
  backoff: 10s, 20s, 40s, and 80s before the fifth attempt.
- Keep all non-rate-limit publication failures immediately fatal.
- During partial-state preflight, rebuild existing keys through the exact
  unpatched publish path before comparing immutable checksums.
- Preserve patched whole-graph packaging for crates whose dependencies are not
  published yet.
- Add executable regression tests for exponential backoff, bounded failure,
  and partial-registry archive verification.

## Verification

- Full Python unit suite: 2,905 passed.
- Cargo helper suite: 26 passed.
- Exact current-controls plus detached-v2.0.1 preflight passed against live
  partial state: seven new crates byte-matched, both historical b7 checksums
  matched, and eleven remaining keys were absent.
- Shell syntax, Ruff, Ruff format, and diff checks passed.

Refs #210
