### PR TITLE
fix(release): clean crate archives before repackaging

### DIFF
--- a/scripts/ci/publish_crate_idempotently.sh
+++ b/scripts/ci/publish_crate_idempotently.sh
@@ -295,10 +295,25 @@ if [[ "$mode" == "verify-preexisting" ]]; then
 fi
 
 crate_file="target/package/${crate}-${version}.crate"
+
+package_candidate() {
+  # Cargo can overwrite a shorter archive without truncating a longer archive
+  # left by the patched graph preflight. Remove only this resolved package file
+  # first so stale trailing bytes cannot change the immutable checksum.
+  if [[ -e "$crate_file" || -L "$crate_file" ]]; then
+    if [[ ! -f "$crate_file" || -L "$crate_file" ]]; then
+      echo "Refusing to replace non-regular packaged crate: $crate_file" >&2
+      return 1
+    fi
+    rm -f -- "$crate_file"
+  fi
+  "$cargo_bin" package --locked -p "$crate" >/dev/null
+}
+
 if [[ "$mode" == "publish" || "$mode" == "cutoff-state" ]]; then
   # `cargo publish` packages the same clean tree. Materialize that payload first
   # so an existing immutable version can be compared before any upload attempt.
-  "$cargo_bin" package --locked -p "$crate" >/dev/null
+  package_candidate
 fi
 
 calculate_candidate_checksum() {
@@ -338,7 +353,7 @@ preflight_candidate_key() {
   # archive's generated Cargo.lock. Once a key exists, rebuild it through the
   # exact unpatched publish path before comparing immutable bytes.
   if [[ "$mode" == "preflight" && ("$api_status" -eq 0 || "$index_status" -eq 0) ]]; then
-    "$cargo_bin" package --locked -p "$crate" >/dev/null
+    package_candidate
     candidate_checksum="$(calculate_candidate_checksum)"
   fi
 

--- a/tests/unit/infra/test_crates_io_publish_helper.py
+++ b/tests/unit/infra/test_crates_io_publish_helper.py
@@ -71,8 +71,13 @@ case "${1:-}" in
     ;;
   package)
     mkdir -p target/package
+    archive="target/package/${CRATE_NAME}-${CRATE_VERSION}.crate"
+    if [[ -e "$archive" || -L "$archive" ]]; then
+      printf '%s\\n' 'cargo package received a stale candidate archive' >&2
+      exit 44
+    fi
     printf '%s\\n' 'candidate crate bytes' > \
-      "target/package/${CRATE_NAME}-${CRATE_VERSION}.crate"
+      "$archive"
     ;;
   publish)
     case "$CARGO_PUBLISH_MODE" in
@@ -418,7 +423,7 @@ def test_preflight_repackages_existing_key_through_exact_publish_path(
         api_sequence="matching",
         index_sequence="matching",
         mode="preflight",
-        initial_archive_bytes=b"patched graph archive\n",
+        initial_archive_bytes=CANDIDATE_BYTES + b"stale patched archive tail\n",
     )
 
     assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

Prevent stale bytes from a larger patched Cargo archive from corrupting the
checksum of the smaller unpatched recovery candidate.

## Root cause

Cargo overwrote the patched archive without truncating it. The resulting crate
contained a valid gzip/tar stream followed by stale bytes, so crates.io's raw
archive checksum did not match even though the package contents were unchanged.

## Change

- Validate and remove only the exact resolved crate archive before every clean
  package operation.
- Continue to reject symlinks and non-regular archive paths.
- Make the helper test double fail if a stale archive reaches Cargo, covering
  the regression directly.

## Verification

- Full Python unit suite: 2,905 passed.
- Cargo helper suite: 26 passed.
- Shell syntax, Ruff, Ruff format, and diff checks passed.
- Real Cargo 1.94.1 test against the immutable v2.0.1 source: an archive with an
  injected stale tail was cleaned, rebuilt, and matched the live crates.io API
  and sparse-index checksum 4e4ee7450a4ddffbf53146eaed33fdf8cc315601531cf8c5d1193fe7e6541fe2.

Refs #210
