### PR TITLE
fix(ci): isolate packaged Cargo metadata workspace (#214)

### DIFF
--- a/scripts/ci/cargo_release_candidate.py
+++ b/scripts/ci/cargo_release_candidate.py
@@ -839,30 +839,41 @@ def _validate_packaged_lock(
 
 
 def _cargo_metadata_package(
-    root: Path,
+    archive: bytes,
     *,
+    package: CargoInventoryPackage,
     cargo: tuple[str, ...],
     config: Path,
     environment: Mapping[str, str],
     runner: CommandRunner,
 ) -> Mapping[str, Any]:
-    result = _run(
-        (
-            *cargo,
-            "metadata",
-            "--format-version",
-            "1",
-            "--no-deps",
-            "--manifest-path",
-            str(root / "Cargo.toml"),
-            "--config",
-            str(config),
-        ),
-        cwd=root,
-        environment=environment,
-        runner=runner,
-        capture_output=True,
-    )
+    """Read archive metadata inside a synthetic one-package workspace."""
+    with tempfile.TemporaryDirectory(prefix="type-bridge-cargo-metadata-") as temporary:
+        workspace = Path(temporary)
+        root, _ = stage_archive(workspace, package=package, archive=archive)
+        # Cargo walks manifest ancestors for a workspace. Bound that discovery
+        # without changing the normalized package manifest or accepted archive.
+        (workspace / "Cargo.toml").write_text(
+            f'[workspace]\nmembers = [{json.dumps(root.name)}]\nresolver = "3"\n',
+            encoding="utf-8",
+        )
+        result = _run(
+            (
+                *cargo,
+                "metadata",
+                "--format-version",
+                "1",
+                "--no-deps",
+                "--manifest-path",
+                str(root / "Cargo.toml"),
+                "--config",
+                str(config),
+            ),
+            cwd=root,
+            environment=environment,
+            runner=runner,
+            capture_output=True,
+        )
     try:
         payload = json.loads(result.stdout)
     except (TypeError, json.JSONDecodeError) as error:
@@ -1012,7 +1023,8 @@ def build_candidate_bundle(
                     label=f"{package.name} Cargo.toml",
                 )
                 cargo_package = _cargo_metadata_package(
-                    staged_root,
+                    archive,
+                    package=package,
                     cargo=cargo,
                     config=config,
                     environment=environment,

--- a/tests/unit/compat/test_cargo_release_candidate.py
+++ b/tests/unit/compat/test_cargo_release_candidate.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import hashlib
 import io
 import json
+import os
 import struct
+import subprocess
 import tarfile
 from pathlib import Path, PurePosixPath
 
@@ -302,3 +304,67 @@ def test_candidate_builder_is_patch_free_and_keeps_cargo_verification() -> None:
     assert "patch.crates-io" not in source
     assert "--no-verify" not in source
     assert "registry_checksum" in source
+
+
+def test_cargo_metadata_isolates_archive_from_ancestor_workspace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "Cargo.toml").write_text(
+        "[workspace]\n"
+        "members = []\n"
+        'resolver = "3"\n\n'
+        "[workspace.package]\n"
+        'authors = ["ancestor workspace"]\n'
+        'description = "must not affect packaged metadata"\n\n'
+        "[workspace.lints.rust]\n"
+        'unsafe_code = "forbid"\n'
+    )
+    temporary_root = workspace / "target"
+    directory_source = temporary_root / "directory-source"
+    directory_source.mkdir(parents=True)
+    monkeypatch.setattr(candidate.tempfile, "tempdir", str(temporary_root))
+
+    item = package("first-party", classification="public-first-party", order=1)
+    archive = crate_bytes(item.name)
+    staged_root, files = candidate.stage_archive(
+        directory_source,
+        package=item,
+        archive=archive,
+    )
+    original = {
+        path.relative_to(staged_root): path.read_bytes()
+        for path in staged_root.rglob("*")
+        if path.is_file()
+    }
+    config = temporary_root / "cargo-config.toml"
+    config.write_text("")
+
+    metadata = candidate._cargo_metadata_package(  # noqa: SLF001
+        archive,
+        package=item,
+        cargo=("cargo", "+1.94.1"),
+        config=config,
+        environment=os.environ,
+        runner=subprocess.run,
+    )
+
+    manifest = candidate._parse_toml(  # noqa: SLF001
+        files[PurePosixPath("Cargo.toml")],
+        label=f"{item.name} Cargo.toml",
+    )
+    assert candidate.publish_metadata_from_cargo(
+        metadata,
+        manifest=manifest,
+        files=files,
+    ) == candidate.publish_metadata_from_manifest(manifest, files)
+    assert original == {
+        path.relative_to(staged_root): path.read_bytes()
+        for path in staged_root.rglob("*")
+        if path.is_file()
+    }
+    assert not any(
+        path.name.startswith("type-bridge-cargo-metadata-") for path in temporary_root.iterdir()
+    )


### PR DESCRIPTION
## Summary

- isolate Cargo metadata inspection in a temporary one-package resolver-3 workspace
- re-stage the exact accepted archive so ancestor workspaces cannot capture normalized packages
- preserve archive bytes, publish-metadata parity, and same-filesystem atomic bundle publication
- cover the failed workflow path with Cargo 1.94.1 and a hostile ancestor workspace

## Verification

- 2,278 unit tests passed; 16 skipped
- focused candidate tests: 8 passed
- Ruff lint and format, bytecode compilation, and diff hygiene passed
- exact 19-archive candidate build passed with manifest SHA-256 ce4cd94969142b529a8c8303add2ae432e3c4bb726f4b4da9529f865cbb5eff1
- archive graph, external consumers, CLI/server installs, crates.io preflight, release identity, and frozen TypeDB provenance passed
- independent final review found no blockers

Run 31347628113 failed before artifact upload and performed no release mutation. A fresh candidate run will be dispatched only after this correction merges.

Parts of #214