### PR TITLE
fix(ci): select host addon in Node package smoke

### DIFF
--- a/tests/unit/infra/test_release_artifact_gates.py
+++ b/tests/unit/infra/test_release_artifact_gates.py
@@ -1468,8 +1468,14 @@ def test_npm_publication_uses_the_accepted_tarball() -> None:
     package = json.loads(
         (REPO_ROOT / "type-bridge-core/crates/node/package.json").read_text(encoding="utf-8")
     )
+    package_smoke = (REPO_ROOT / "type-bridge-core/crates/node/tests/package-smoke.cjs").read_text(
+        encoding="utf-8"
+    )
     assert package["scripts"]["clean:types"] == "node scripts/clean-types.js"
     assert package["scripts"]["build:types"] == ("npm run clean:types && tsc -p tsconfig.json")
+    assert 'require("../dist/native.js").loadNative()' in package_smoke
+    assert "readdirSync" not in package_smoke
+    assert ".sort()[0]" not in package_smoke
 
     native_legs = re.findall(
         r"^          - target: (.+)\n"

--- a/type-bridge-core/crates/node/tests/package-smoke.cjs
+++ b/type-bridge-core/crates/node/tests/package-smoke.cjs
@@ -2,8 +2,6 @@
 
 const assert = require("node:assert/strict");
 const { execSync } = require("node:child_process");
-const fs = require("node:fs");
-const path = require("node:path");
 const packageJson = require("../package.json");
 const typeBridge = require("../");
 
@@ -79,14 +77,7 @@ for (const name of removedAuthoringNames) {
   );
 }
 
-const nativeArtifact = process.env.TYPE_BRIDGE_NODE_NATIVE_PATH ?? fs
-  .readdirSync(path.resolve(__dirname, ".."))
-  .filter((name) => name.endsWith(".node"))
-  .sort()[0];
-assert.ok(nativeArtifact, "package smoke requires a built native artifact");
-const native = require(path.isAbsolute(nativeArtifact)
-  ? nativeArtifact
-  : path.resolve(__dirname, "..", nativeArtifact));
+const native = require("../dist/native.js").loadNative();
 for (const name of [
   "NodeDescriptorRegistry",
   "NodeDynamicEntityManager",


### PR DESCRIPTION
## Summary

- make source-package smoke load the native addon through the production platform resolver
- remove lexicographic selection across the six-module release fan-in
- freeze that resolver delegation in the release-infrastructure contract

## Failure evidence

Candidate Release run [31354107834](https://github.com/ds1sqe/type-bridge/actions/runs/31354107834) passed every producer and failed only in [Pack Node release candidate](https://github.com/ds1sqe/type-bridge/actions/runs/31354107834/job/93357596854). On Ubuntu x64, the smoke sorted all six native filenames and loaded `type_bridge_node.darwin-arm64.node`, which Node rejected with `invalid ELF header`.

The run failed safely: every publisher/release job skipped and the post-run registry audit found no public mutation.

## Verification

- exact six-native artifact reproduction: old smoke fails; corrected smoke passes
- `./scripts/check.sh node` (11 stages passed)
- `uv run pytest tests/unit/infra/test_release_artifact_gates.py -q` (69 passed)
- Ruff lint and format checks
- package smoke with automatic host selection and explicit `TYPE_BRIDGE_NODE_NATIVE_PATH`
- two independent reviews: no blockers

Closes no issue; continues #214 candidate acceptance.
