### PR TITLE
fix(ci): launch packed npm smoke portably on Windows

### DIFF
--- a/tests/unit/infra/test_release_artifact_gates.py
+++ b/tests/unit/infra/test_release_artifact_gates.py
@@ -1471,11 +1471,22 @@ def test_npm_publication_uses_the_accepted_tarball() -> None:
     package_smoke = (REPO_ROOT / "type-bridge-core/crates/node/tests/package-smoke.cjs").read_text(
         encoding="utf-8"
     )
+    packed_package_smoke = (
+        REPO_ROOT / "type-bridge-core/crates/node/tests/packed-package-smoke.cjs"
+    ).read_text(encoding="utf-8")
     assert package["scripts"]["clean:types"] == "node scripts/clean-types.js"
     assert package["scripts"]["build:types"] == ("npm run clean:types && tsc -p tsconfig.json")
+    assert package["scripts"]["smoke:packed-package"] == ("node tests/packed-package-smoke.cjs")
     assert 'require("../dist/native.js").loadNative()' in package_smoke
     assert "readdirSync" not in package_smoke
     assert ".sort()[0]" not in package_smoke
+    assert "const npmExecPath = process.env.npm_execpath;" in packed_package_smoke
+    assert "npm_execpath is required; invoke this smoke through npm run" in (packed_package_smoke)
+    assert "spawnSync(\n    process.execPath," in packed_package_smoke
+    assert 'npmExecPath,\n      "install",' in packed_package_smoke
+    assert 'spawnSync("npm"' not in packed_package_smoke
+    assert "shell: false" in packed_package_smoke
+    assert "assert.ifError(install.error);" in packed_package_smoke
 
     native_legs = re.findall(
         r"^          - target: (.+)\n"

--- a/type-bridge-core/crates/node/tests/packed-package-smoke.cjs
+++ b/type-bridge-core/crates/node/tests/packed-package-smoke.cjs
@@ -22,12 +22,15 @@ const artifacts = fs
   .sort();
 assert.deepEqual(artifacts.length, 1, "exactly one packed artifact is required");
 const artifact = path.resolve(artifactDirectory, artifacts[0]);
+const npmExecPath = process.env.npm_execpath;
+assert.ok(npmExecPath, "npm_execpath is required; invoke this smoke through npm run");
 
 const stage = fs.mkdtempSync(path.join(os.tmpdir(), "type-bridge-node-packed-"));
 try {
   const install = spawnSync(
-    "npm",
+    process.execPath,
     [
+      npmExecPath,
       "install",
       "--ignore-scripts",
       "--no-audit",
@@ -38,8 +41,9 @@ try {
       stage,
       artifact,
     ],
-    { encoding: "utf8" },
+    { encoding: "utf8", shell: false },
   );
+  assert.ifError(install.error);
   assert.equal(install.status, 0, install.stderr || install.stdout);
 
   const requirePackage = createRequire(path.join(stage, "consumer.cjs"));


### PR DESCRIPTION
Refs #214

## Summary
- execute the npm JavaScript CLI through the current absolute Node executable
- keep packed-artifact installation shell-free on every platform
- surface child launch errors before checking the exit status
- lock the package-script and launcher contract in release infrastructure tests

## Failure evidence
Candidate run 31362808158 passed all five non-Windows packed Node consumers but failed both Windows x64 and arm64 legs before installation. `spawnSync("npm", ...)` returned a null status because npm is exposed through a Windows command shim. The accepted tarball and all six native addons passed independent inventory and byte audits.

## Verification
- exact failed-run tarball smoke passed normally
- exact failed-run tarball smoke passed with PATH empty using only `process.execPath` plus `npm_execpath`
- `./scripts/check.sh node` passed all 11 stages
- release infrastructure tests: 69 passed
- complete Python unit suite: 2,278 passed, 16 skipped
- Ruff, formatting, syntax, and diff hygiene passed
- two independent reviews found no blockers

No tag, package publication, OCI alias movement, GitHub Release, or deployment is part of this PR.