### PR TITLE
fix(node): release Windows native lock before cleanup (#214)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,6 +331,55 @@ jobs:
       - name: Contract foundation adapter
         run: npm run test:contract-adapter
 
+  # Windows keeps a loaded native module locked until its Node process exits.
+  # Build and consume an actual tarball here so PR CI proves both native loading
+  # and strict cleanup before the release acceptance matrix runs.
+  node-packed-windows:
+    name: Node packed package (Windows)
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: type-bridge-core/crates/node
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: ${{ env.RUST_STABLE_TOOLCHAIN }}
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ${{ env.CARGO_HOME }}/registry
+            ${{ env.CARGO_HOME }}/git
+            type-bridge-core/target
+          key: ${{ runner.os }}-cargo-node-packed-v1-${{ hashFiles('type-bridge-core/Cargo.lock') }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: type-bridge-core/crates/node/package-lock.json
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Build native module and TypeScript surface
+        run: npm run build
+
+      - name: Pack the Windows package
+        run: |
+          New-Item -ItemType Directory -Force -Path tmp/packed-node | Out-Null
+          npm pack --ignore-scripts --pack-destination tmp/packed-node
+
+      - name: Consume and remove the Windows package
+        run: |
+          npm run smoke:packed-package -- --artifact-directory tmp/packed-node
+
   # Compile and execute a clean generated package against the exact wheel pair
   # on every supported Python line. The consumer extracts candidates outside
   # the checkout and rejects source leakage or handwritten root exports.

--- a/tests/unit/infra/test_release_artifact_gates.py
+++ b/tests/unit/infra/test_release_artifact_gates.py
@@ -1461,6 +1461,7 @@ def test_low_level_query_smokes_use_compiled_server_authority() -> None:
 
 def test_npm_publication_uses_the_accepted_tarball() -> None:
     workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    ci_windows = job_block(CI_WORKFLOW.read_text(encoding="utf-8"), "node-packed-windows")
     build = job_block(workflow, "build-node-native")
     pack = job_block(workflow, "pack-node-package")
     acceptance = job_block(workflow, "accept-node-package")
@@ -1482,11 +1483,24 @@ def test_npm_publication_uses_the_accepted_tarball() -> None:
     assert ".sort()[0]" not in package_smoke
     assert "const npmExecPath = process.env.npm_execpath;" in packed_package_smoke
     assert "npm_execpath is required; invoke this smoke through npm run" in (packed_package_smoke)
-    assert "spawnSync(\n    process.execPath," in packed_package_smoke
-    assert 'npmExecPath,\n      "install",' in packed_package_smoke
+    assert packed_package_smoke.count("spawnSync(") == 2
+    assert 'npmExecPath,\n        "install",' in packed_package_smoke
+    assert '[__filename, "--installed-root", installedRoot]' in packed_package_smoke
     assert 'spawnSync("npm"' not in packed_package_smoke
     assert "shell: false" in packed_package_smoke
     assert "assert.ifError(install.error);" in packed_package_smoke
+    assert "assert.ifError(verify.error);" in packed_package_smoke
+    assert "maxRetries: 5" in packed_package_smoke
+    assert "retryDelay: 100" in packed_package_smoke
+    assert "runs-on: windows-latest" in ci_windows
+    assert "npm run build" in ci_windows
+    assert "npm pack --ignore-scripts --pack-destination tmp/packed-node" in ci_windows
+    assert "npm run smoke:packed-package -- --artifact-directory tmp/packed-node" in ci_windows
+    assert (
+        ci_windows.index("npm run build")
+        < ci_windows.index("npm pack --ignore-scripts")
+        < ci_windows.index("npm run smoke:packed-package")
+    )
 
     native_legs = re.findall(
         r"^          - target: (.+)\n"

--- a/type-bridge-core/crates/node/tests/packed-package-smoke.cjs
+++ b/type-bridge-core/crates/node/tests/packed-package-smoke.cjs
@@ -14,40 +14,9 @@ function argument(name) {
   return index === -1 ? undefined : process.argv[index + 1];
 }
 
-const artifactDirectory = argument("--artifact-directory");
-assert.ok(artifactDirectory, "--artifact-directory is required");
-const artifacts = fs
-  .readdirSync(artifactDirectory)
-  .filter((name) => name.endsWith(".tgz"))
-  .sort();
-assert.deepEqual(artifacts.length, 1, "exactly one packed artifact is required");
-const artifact = path.resolve(artifactDirectory, artifacts[0]);
-const npmExecPath = process.env.npm_execpath;
-assert.ok(npmExecPath, "npm_execpath is required; invoke this smoke through npm run");
-
-const stage = fs.mkdtempSync(path.join(os.tmpdir(), "type-bridge-node-packed-"));
-try {
-  const install = spawnSync(
-    process.execPath,
-    [
-      npmExecPath,
-      "install",
-      "--ignore-scripts",
-      "--no-audit",
-      "--no-fund",
-      "--no-package-lock",
-      "--no-save",
-      "--prefix",
-      stage,
-      artifact,
-    ],
-    { encoding: "utf8", shell: false },
-  );
-  assert.ifError(install.error);
-  assert.equal(install.status, 0, install.stderr || install.stdout);
-
+function verifyInstalledPackage(installedRoot) {
+  const stage = path.dirname(path.dirname(path.dirname(installedRoot)));
   const requirePackage = createRequire(path.join(stage, "consumer.cjs"));
-  const installedRoot = path.join(stage, "node_modules", "@type-bridge", "node");
   const resolvedRoot = fs.realpathSync(requirePackage.resolve("@type-bridge/node"));
   assert.ok(
     resolvedRoot.startsWith(`${fs.realpathSync(installedRoot)}${path.sep}`),
@@ -110,6 +79,65 @@ try {
   ]) {
     assert.equal(Object.hasOwn(native, name), false, `${name} must be absent natively`);
   }
-} finally {
-  fs.rmSync(stage, { recursive: true, force: true });
+}
+
+function verifyPackedArtifact(artifactDirectory) {
+  const artifacts = fs
+    .readdirSync(artifactDirectory)
+    .filter((name) => name.endsWith(".tgz"))
+    .sort();
+  assert.deepEqual(artifacts.length, 1, "exactly one packed artifact is required");
+  const artifact = path.resolve(artifactDirectory, artifacts[0]);
+  const npmExecPath = process.env.npm_execpath;
+  assert.ok(npmExecPath, "npm_execpath is required; invoke this smoke through npm run");
+
+  const stage = fs.mkdtempSync(path.join(os.tmpdir(), "type-bridge-node-packed-"));
+  try {
+    const install = spawnSync(
+      process.execPath,
+      [
+        npmExecPath,
+        "install",
+        "--ignore-scripts",
+        "--no-audit",
+        "--no-fund",
+        "--no-package-lock",
+        "--no-save",
+        "--prefix",
+        stage,
+        artifact,
+      ],
+      { encoding: "utf8", shell: false },
+    );
+    assert.ifError(install.error);
+    assert.equal(install.status, 0, install.stderr || install.stdout);
+
+    // Native modules remain locked for the lifetime of their Node process on
+    // Windows. Load and inspect the installed package in a child so the DLL is
+    // unloaded before this parent removes the isolated installation.
+    const installedRoot = path.join(stage, "node_modules", "@type-bridge", "node");
+    const verify = spawnSync(
+      process.execPath,
+      [__filename, "--installed-root", installedRoot],
+      { encoding: "utf8", shell: false },
+    );
+    assert.ifError(verify.error);
+    assert.equal(verify.status, 0, verify.stderr || verify.stdout);
+  } finally {
+    fs.rmSync(stage, {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 100,
+    });
+  }
+}
+
+const installedRoot = argument("--installed-root");
+if (installedRoot === undefined) {
+  const artifactDirectory = argument("--artifact-directory");
+  assert.ok(artifactDirectory, "--artifact-directory is required");
+  verifyPackedArtifact(artifactDirectory);
+} else {
+  verifyInstalledPackage(path.resolve(installedRoot));
 }


### PR DESCRIPTION
## Summary

Fixes the deterministic Windows packed-consumer failures from candidate run 31375584806. The package and correct native addon loaded successfully, but the smoke process then tried to delete its still-mapped DLL and failed with EPERM.

## Key changes

- run installed-package and native assertions in a synchronous child Node process
- clean the temporary install only after that child exits and unloads the addon
- keep cleanup strict with bounded retries for transient Windows handles
- add a required Windows CI job that builds, packs, consumes, and removes a real npm tarball
- lock the child boundary and Windows gate into the release-infrastructure invariant

## Verification

- exact node-package artifact from failed run 31375584806 passes the corrected packed smoke
- complete Node check: 11/11 stages, including 50 unit tests
- release artifact gates: 69/69
- full Python unit suite: 2,278 passed, 16 skipped
- Ruff lint and format, JavaScript syntax, YAML parse, and diff hygiene pass
- two independent reviews found no blockers

Parts of #214