### PR TITLE
test(migration): require connected recovery gates (#214)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -903,6 +903,30 @@ jobs:
           --manifest-path type-bridge-core/Cargo.toml
           -p type-bridge-cli --test e2e_workspace_live
 
+      - name: Run connected migration rollback and reapply lifecycle
+        if: matrix.typedb-server == 'typedb/typedb:3.12.1'
+        env:
+          TYPEDB_ADDRESS: localhost:1729
+          TYPEDB_HTTP_PORT: "8000"
+          TYPE_BRIDGE_SCHEMA_MIGRATION_TYPEDB_DATABASE: type_bridge_ci_rollback
+        run: >-
+          bash scripts/ci/run_exact_ignored_rust_test.sh
+          runner_rolls_back_the_applied_head_and_reapplies_on_3_12_1
+          --manifest-path type-bridge-core/Cargo.toml --locked
+          -p type-bridge-schema-migration-typedb --test live_runner
+
+      - name: Run interrupted-plan fenced recovery lifecycle
+        if: matrix.typedb-server == 'typedb/typedb:3.12.1'
+        env:
+          TYPEDB_ADDRESS: localhost:1729
+          TYPEDB_HTTP_PORT: "8000"
+          TYPE_BRIDGE_SCHEMA_MIGRATION_TYPEDB_DATABASE: type_bridge_ci_recovery
+        run: >-
+          bash scripts/ci/run_exact_ignored_rust_test.sh
+          control_schema_and_fenced_lease_round_trip_on_3_12_1
+          --manifest-path type-bridge-core/Cargo.toml --locked
+          -p type-bridge-schema-migration-typedb --test live_store
+
   # Required, bounded TLS proof over one server per supported protocol band.
   # This intentionally runs only typedb-runtime's focused live target: the
   # broader plaintext, binding, CLI, and remote-envelope suites have separate

--- a/test.sh
+++ b/test.sh
@@ -365,6 +365,24 @@ if [[ "$integration" == 1 ]]; then
                 -p type-bridge-cli --test e2e_workspace_live
     done
 
+    printf "${BOLD}━━━ Connected migration recovery (integration) ━━━${RESET}\n\n"
+    run_step "connected rollback and reapply lifecycle" \
+        timeout --foreground 10m \
+        env TYPEDB_ADDRESS="$TYPEDB_ADDRESS" TYPEDB_HTTP_PORT="$TYPEDB_HTTP_PORT" \
+            TYPE_BRIDGE_SCHEMA_MIGRATION_TYPEDB_DATABASE="type_bridge_local_rollback_${$}" \
+        bash scripts/ci/run_exact_ignored_rust_test.sh \
+            runner_rolls_back_the_applied_head_and_reapplies_on_3_12_1 \
+            --manifest-path type-bridge-core/Cargo.toml --locked \
+            -p type-bridge-schema-migration-typedb --test live_runner
+    run_step "interrupted-plan fenced recovery lifecycle" \
+        timeout --foreground 10m \
+        env TYPEDB_ADDRESS="$TYPEDB_ADDRESS" TYPEDB_HTTP_PORT="$TYPEDB_HTTP_PORT" \
+            TYPE_BRIDGE_SCHEMA_MIGRATION_TYPEDB_DATABASE="type_bridge_local_recovery_${$}" \
+        bash scripts/ci/run_exact_ignored_rust_test.sh \
+            control_schema_and_fenced_lease_round_trip_on_3_12_1 \
+            --manifest-path type-bridge-core/Cargo.toml --locked \
+            -p type-bridge-schema-migration-typedb --test live_store
+
     printf "${BOLD}━━━ Python (integration) ━━━${RESET}\n\n"
     run_step "pytest -m integration" \
         timeout --foreground 20m \

--- a/tests/unit/infra/test_exact_ignored_rust_test_gate.py
+++ b/tests/unit/infra/test_exact_ignored_rust_test_gate.py
@@ -98,12 +98,21 @@ def test_ci_and_local_harness_route_cli_live_tests_through_the_gate() -> None:
         "shipped_python_converter_to_native_adoption_live",
     }
 
-    assert workflow.count(gate_call) == len(positive_tests) + 3
-    assert local.count(gate_call) == 5
+    migration_recovery_tests = {
+        "runner_rolls_back_the_applied_head_and_reapplies_on_3_12_1",
+        "control_schema_and_fenced_lease_round_trip_on_3_12_1",
+    }
+
+    assert workflow.count(gate_call) == len(positive_tests) + 5
+    assert local.count(gate_call) == 7
     assert "-- --ignored --exact --nocapture" not in local
-    for test_name in positive_tests | {"unsupported_server_apply_creates_neither_database_live"}:
+    for test_name in (
+        positive_tests
+        | migration_recovery_tests
+        | {"unsupported_server_apply_creates_neither_database_live"}
+    ):
         assert workflow.count(test_name) == 1
-    for test_name in positive_tests:
+    for test_name in positive_tests | migration_recovery_tests:
         assert local.count(test_name) == 1
 
 
@@ -149,10 +158,56 @@ def test_migration_live_lanes_are_bound_to_the_exact_server_leg() -> None:
         "Apply and verify the unchanged documented initial constraints": (
             "documented_examples_initial_constraints_apply_and_verify_live"
         ),
+        "Run connected migration rollback and reapply lifecycle": (
+            "runner_rolls_back_the_applied_head_and_reapplies_on_3_12_1"
+        ),
+        "Run interrupted-plan fenced recovery lifecycle": (
+            "control_schema_and_fenced_lease_round_trip_on_3_12_1"
+        ),
     }.items():
         step = steps[name]
         assert step["if"] == "matrix.typedb-server == 'typedb/typedb:3.12.1'"
         assert test_name in step["run"]
+
+    rollback = steps["Run connected migration rollback and reapply lifecycle"]
+    assert "--locked" in rollback["run"]
+    assert "--test live_runner" in rollback["run"]
+    assert rollback["env"]["TYPE_BRIDGE_SCHEMA_MIGRATION_TYPEDB_DATABASE"] == (
+        "type_bridge_ci_rollback"
+    )
+
+    recovery = steps["Run interrupted-plan fenced recovery lifecycle"]
+    assert "--locked" in recovery["run"]
+    assert "--test live_store" in recovery["run"]
+    assert recovery["env"]["TYPE_BRIDGE_SCHEMA_MIGRATION_TYPEDB_DATABASE"] == (
+        "type_bridge_ci_recovery"
+    )
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "test_name"),
+    (
+        (
+            "type-bridge-core/crates/schema-migration-typedb/tests/live_runner.rs",
+            "runner_rolls_back_the_applied_head_and_reapplies_on_3_12_1",
+        ),
+        (
+            "type-bridge-core/crates/schema-migration-typedb/tests/live_store.rs",
+            "control_schema_and_fenced_lease_round_trip_on_3_12_1",
+        ),
+    ),
+)
+def test_reusable_migration_live_tests_delete_their_isolated_databases(
+    relative_path: str,
+    test_name: str,
+) -> None:
+    source = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+    body = source.split(f"async fn {test_name}()", maxsplit=1)[1].split(
+        "\n#[tokio::test",
+        maxsplit=1,
+    )[0]
+
+    assert body.count(".delete_database()") == 2
 
 
 def test_fresh_replay_and_documented_constraint_probes_cannot_regress_to_offline_only() -> None:

--- a/tests/unit/infra/test_release_artifact_gates.py
+++ b/tests/unit/infra/test_release_artifact_gates.py
@@ -1266,8 +1266,10 @@ def test_live_cli_workspace_state_machine_is_required_locally_and_in_ci() -> Non
     rust_integration = job_block(ci, "rust-integration")
     for test in tests:
         assert f"          {test}\n          --manifest-path" in rust_integration
-    assert rust_integration.count("scripts/ci/run_exact_ignored_rust_test.sh") == len(tests) + 2
+    assert rust_integration.count("scripts/ci/run_exact_ignored_rust_test.sh") == len(tests) + 4
     assert "unsupported_server_apply_creates_neither_database_live" in rust_integration
+    assert "runner_rolls_back_the_applied_head_and_reapplies_on_3_12_1" in rust_integration
+    assert "control_schema_and_fenced_lease_round_trip_on_3_12_1" in rust_integration
 
     loop = re.search(
         r"for cli_live_test in \\\n(?P<tests>.*?); do\n(?P<body>.*?)\n    done",

--- a/type-bridge-core/crates/schema-migration-typedb/tests/live_store.rs
+++ b/type-bridge-core/crates/schema-migration-typedb/tests/live_store.rs
@@ -766,4 +766,13 @@ async fn control_schema_and_fenced_lease_round_trip_on_3_12_1() {
         .release(&lease_three)
         .await
         .expect("release restarted store lease");
+
+    managed_database
+        .delete_database()
+        .await
+        .expect("delete isolated managed database");
+    journal_database
+        .delete_database()
+        .await
+        .expect("delete isolated journal database");
 }


### PR DESCRIPTION
## Summary

- require the exact TypeDB 3.12.1 rollback/reapply lifecycle in CI and the reusable local live harness
- require the exact interrupted-plan fenced-recovery lifecycle through the same fail-closed selector
- isolate and bound both probes, and delete their managed/journal databases for retained-server runs
- lock the workflow, selector, environment, and cleanup contracts with regression tests

## Verification

- exact rollback/reapply live probe passed against isolated TypeDB 3.12.1
- exact interrupted-plan recovery live probe passed against isolated TypeDB 3.12.1
- post-recovery TypeDB database inventory was empty
- `./scripts/check.sh all` passed all 30 stages
- focused workflow/infra suite passed 95 tests
- independent diff re-review found no remaining findings

No tag, publication, signing, alias, release, or deployment mutation is included.

Refs #214
Related to #189