### PR TITLE
fix(codegen): avoid single-variant family pattern warnings (#189)

### DIFF
--- a/tests/unit/compat/test_native_distribution_notices.py
+++ b/tests/unit/compat/test_native_distribution_notices.py
@@ -106,6 +106,7 @@ def test_generated_notice_covers_locked_compound_and_platform_licenses() -> None
         "`webpki-roots` | `1.0.7`",
         "`CDLA-Permissive-2.0`",
         "`rustls-webpki` | `0.103.13`",
+        "`pyo3` | `0.29.2`",
         "`untrusted` | `0.9.0`",
         "`subtle` | `2.6.1`",
         "`icu_collections` | `2.2.0`",

--- a/type-bridge-core/crates/schema-codegen/src/rust/render.rs
+++ b/type-bridge-core/crates/schema-codegen/src/rust/render.rs
@@ -1224,9 +1224,16 @@ fn render_families(projection: &RuntimeProjection) -> Result<String, Diagnostic>
         for descendant in &descendants {
             let variant_name = descendant.target_name().as_str();
             let fn_name = format!("as_{}", to_snake_case(variant_name));
+            let body = if descendants.len() == 1 {
+                format!("let Self::{variant_name}(__tb_inner) = self; Some(__tb_inner)")
+            } else {
+                format!(
+                    "if let Self::{variant_name}(__tb_inner) = self {{ Some(__tb_inner) }} else {{ None }}"
+                )
+            };
             let _ = writeln!(
                 output,
-                "\n  #[must_use]\n  pub fn {fn_name}(&self) -> Option<&{variant_name}> {{\n    if let Self::{variant_name}(__tb_inner) = self {{ Some(__tb_inner) }} else {{ None }}\n  }}"
+                "\n  #[must_use]\n  pub fn {fn_name}(&self) -> Option<&{variant_name}> {{\n    {body}\n  }}"
             );
         }
 

--- a/type-bridge-core/crates/schema-codegen/tests/rust_acceptance.rs
+++ b/type-bridge-core/crates/schema-codegen/tests/rust_acceptance.rs
@@ -310,6 +310,53 @@ fn generated_subtype_association_compiles_as_ordinary_dependency() {
 }
 
 #[test]
+fn single_variant_families_compile_without_irrefutable_patterns() {
+    let stage = Stage::new();
+    let generated = stage.path().join("generated");
+    let consumer = stage.path().join("consumer");
+    let source = include_str!("acceptance/schema.yaml")
+        .replacen(
+            "attributes:\n",
+            "attributes:\n  single-identifier:\n    abstract: true\n    value: string\n  single-id: { sub: single-identifier }\n",
+            1,
+        )
+        .replacen(
+            "entities:\n",
+            "entities:\n  single-actor:\n    abstract: true\n  single-person: { sub: single-actor }\n",
+            1,
+        );
+    let package = emit_from_source(&source);
+    write_package(&package, &generated);
+    let library = generated.join("src/lib.rs");
+    let source = fs::read_to_string(&library).unwrap();
+    fs::write(
+        &library,
+        format!("#![deny(irrefutable_let_patterns)]\n{source}"),
+    )
+    .unwrap();
+    write_consumer_with_features(
+        &consumer,
+        "single-variant-family-consumer",
+        "fn main() { let _ = generated::SingleActorFamily::as_single_person; let _ = generated::SingleIdentifierFamily::as_single_id; }\n",
+        &[],
+    );
+    let output = cargo(
+        &[
+            "check",
+            "--offline",
+            "--manifest-path",
+            consumer.join("Cargo.toml").to_str().unwrap(),
+        ],
+        &stage.path().join("consumer-target"),
+    );
+    assert!(
+        output.status.success(),
+        "single-variant pattern-lint consumer failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn abstract_attribute_family_compiles_and_runs_as_a_value_enum() {
     let stage = Stage::new();
     let generated = stage.path().join("generated");

--- a/type-bridge-core/crates/schema-codegen/tests/rust_emitter.rs
+++ b/type-bridge-core/crates/schema-codegen/tests/rust_emitter.rs
@@ -194,6 +194,8 @@ attributes:
     assert!(read.contains("EmployeeId(EmployeeId)"));
     assert!(read.contains("pub fn value(&self) -> &String"));
     assert!(read.contains("Self::EmployeeId(__tb_inner) => __tb_inner.value()"));
+    assert!(read.contains("let Self::EmployeeId(__tb_inner) = self; Some(__tb_inner)"));
+    assert!(!read.contains("if let Self::EmployeeId("));
     assert!(!read.contains("impl MaterializeModel for IdentifierFamily"));
     assert!(!read.contains("pub fn iid(&self)"));
     assert!(!declaration.contains("impl ModelFamily for IdentifierFamily"));


### PR DESCRIPTION
Generated Rust family accessors with only one descendant emitted an `if let` whose pattern always matched, causing builds that deny `irrefutable_let_patterns` to fail. Use unconditional destructuring for that case while preserving the existing `Option` API and multi-variant behavior.

This finishes the remaining 2.1 readiness change after the 2.0.2 integration in #221. It also explicitly checks the patched PyO3 version in native dependency notices.

Validation: all six Rust emitter tests, a compiled generated model/attribute-family consumer denying the affected lint, and 262 release/notice regressions pass. Rust formatting, Ruff and actionlint pass. The base master commit passed all 43 CI jobs and both documentation jobs.

Parts of #189
