### PR TITLE
docs(release): record 2.1.0 publication (#189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to TypeBridge will be documented in this file.
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-09-08
+
 ### Security and release reliability
 
 - Forward-ported the patched PyO3 0.29.2 and dependency graph from the 2.0.2
@@ -31,8 +33,9 @@ All notable changes to TypeBridge will be documented in this file.
   Read-only TOML conversion and archived migration loading, checksum
   verification, ledger import, snapshots, adoption, and recovery remain.
 - **2.1.0 artifact identity** - Python, npm, Cargo, generated Rust templates,
-  documentation, and release validation now share the 2.1.0 identity. Release
-  timing remains readiness-driven; no release date is declared here.
+  documentation, and release validation share the 2.1.0 identity. See the
+  [2.1.0 release notes](https://github.com/ds1sqe/type-bridge/releases/tag/v2.1.0)
+  for the complete cutover inventory and upgrade guidance.
 
 ## [2.0.2] - 2026-09-07
 

--- a/docs/guide/upgrade-v2.md
+++ b/docs/guide/upgrade-v2.md
@@ -1,5 +1,8 @@
 # Upgrading to 2.1
 
+[TypeBridge 2.1.0](https://github.com/ds1sqe/type-bridge/releases/tag/v2.1.0)
+was released on September 8, 2026.
+
 TypeBridge 2.1 makes Split YAML and generated bindings the only active schema
 and model authoring path. It preserves application operations through generated
 Python, TypeScript/Node, and Rust packages, removes the handwritten declaration


### PR DESCRIPTION
TypeBridge 2.1.0 is published, but the changelog still places its cutover
under Unreleased and says no release date is declared. Record September 8,
2026 as the release date and link the public release notes from the changelog
and upgrade guide.

Validation: strict MkDocs build and diff checks pass.

Parts of #189.
