### PR TITLE
build(ci): constrain mypy's wheel dependency (#110)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,10 @@ precision = 2
 [tool.coverage.html]
 directory = "htmlcov"
 
+[tool.uv]
+# Keep mypy's wheel-only helper on a complete, verified release.
+constraint-dependencies = ["ast-serialize==0.10.0"]
+
 [tool.uv.workspace]
 members = [
     "type-bridge-core",


### PR DESCRIPTION
Fresh Python 3.12–3.14 CI installs selected `ast-serialize 0.11.0` during its
PyPI upload, before compatible Linux wheels were available. Constrain uv
workspace resolution to the complete `0.10.0` release used by the accepted
checks and mypy 2.3.1. The change is four lines in `pyproject.toml`.

Validation: a filtered index reconstructed from the upload timestamps
reproduces all three original installation failures. All three Python
versions install successfully and run mypy with the constraint. A fresh
project install and all nine Python checks pass, including 2,867 unit tests.

Hosted validation: [CI](https://github.com/ds1sqe/type-bridge/actions/runs/34244207382)
passes all 52 jobs. Independent verification accepts all 623 required step
outcomes on commit `55ebc9ed`, including Linux, macOS, and Windows.

Parts of #110
