### PR TITLE
build(ci): restart complete checks without changing source (#110)

### DIFF
--- a/.github/release/c-2.2.0.json
+++ b/.github/release/c-2.2.0.json
@@ -758,7 +758,7 @@
       "Wait for TypeDB server to be ready": "success"
     }
   },
-  "ci_workflow_sha256": "a0f983da23edbf983c61793aa30b941d26064e3e8336ac5efd0e5aaab4a6ab26",
+  "ci_workflow_sha256": "10ebf78d7d31420150b71c54d507dff99471008a538459ba9e4d27d2e478696e",
   "cosign_version": "3.0.6",
   "evidence": "type-bridge-c-evidence-2.2.0.tar.gz",
   "format": "typebridge.c-release-policy/v1",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [master, develop]
   pull_request:
     branches: [master, develop]
+  workflow_dispatch:
 
 env:
   CARGO_HOME: ${{ github.workspace }}/../.cargo-home

--- a/docs/development/c-release.md
+++ b/docs/development/c-release.md
@@ -25,7 +25,13 @@ regenerate its policy with `uv run python scripts/ci/c_release_policy.py`
 and review the resulting diff before committing.
 
 First require the complete CI run on the exact master commit to pass. The
-five C distribution jobs build deterministic artifact archives, validate
+run may start from a master push or a manual `ci.yml` dispatch on master.
+If GitHub infrastructure interrupts a run, dispatch the complete workflow
+again on the same commit. Each accepted run must succeed on its first
+attempt with every required job and step; partial reruns remain rejected.
+No source change is needed to restart verification.
+
+The five C distribution jobs build deterministic artifact archives, validate
 their dependency closure, notices, SBOMs and provenance, and exercise clean
 compiler-free installation plus compiled provider-free and live consumers.
 The live journey includes direct and caller-transport queries, custom-root

--- a/scripts/ci/promote_c_release.py
+++ b/scripts/ci/promote_c_release.py
@@ -148,13 +148,22 @@ def validate_run(
     for key in ("repository", "head_repository"):
         require(run.get(key, {}).get("full_name") == REPOSITORY, "Fork or wrong repository")
         require(run[key].get("id") == 1085407082, "Wrong repository ID")
-    if event == "push":
+    if workflow == ".github/workflows/ci.yml":
         require(run.get("head_branch") == "master", "CI must accept the exact master commit")
     else:
         require(
             run.get("head_branch") in {"master", "release/c-sdk-readiness", f"v{policy.VERSION}"},
             "Unselected verification branch",
         )
+
+
+def validate_ci_run(run: dict[str, Any], *, run_id: int, source: str) -> None:
+    event = run.get("event")
+    if not isinstance(event, str) or event not in {"push", "workflow_dispatch"}:
+        raise PromotionError("Unselected CI event")
+    validate_run(
+        run, run_id=run_id, source=source, workflow=".github/workflows/ci.yml", event=event
+    )
 
 
 def validate_jobs(
@@ -281,9 +290,7 @@ def capture(ci_run: int, output: Path) -> None:
     output.mkdir(parents=True, exist_ok=False)
     run = api(f"actions/runs/{ci_run}", output / "ci-run.json")
     jobs = api(f"actions/runs/{ci_run}/attempts/1/jobs?per_page=100", output / "ci-jobs.json")
-    validate_run(
-        run, run_id=ci_run, source=source, workflow=".github/workflows/ci.yml", event="push"
-    )
+    validate_ci_run(run, run_id=ci_run, source=source)
     validate_jobs(jobs, run_id=ci_run, source=source, expected=selected["ci_jobs"])
     artifacts = capture_artifacts(ci_run, source, policy.ARTIFACTS, output)
     write(
@@ -464,13 +471,7 @@ def stage(verify_run: int, output: Path) -> None:
     ci_jobs = api(
         f"actions/runs/{receipt['ci_run']}/attempts/1/jobs?per_page=100", output / "ci-jobs.json"
     )
-    validate_run(
-        ci_run,
-        run_id=receipt["ci_run"],
-        source=source,
-        workflow=".github/workflows/ci.yml",
-        event="push",
-    )
+    validate_ci_run(ci_run, run_id=receipt["ci_run"], source=source)
     validate_jobs(ci_jobs, run_id=receipt["ci_run"], source=source, expected=selected["ci_jobs"])
     reference = api(f"git/ref/tags/v{policy.VERSION}", output / "tag-ref.json")
     require(reference.get("object", {}).get("type") == "tag", "Annotated tag required")

--- a/tests/unit/compat/test_c_release_promotion.py
+++ b/tests/unit/compat/test_c_release_promotion.py
@@ -80,6 +80,7 @@ def test_selected_policy_matches_every_current_ci_step_and_workflow() -> None:
     )
 
 
+@pytest.mark.parametrize("event", ["push", "workflow_dispatch"])
 @pytest.mark.parametrize(
     ("key", "value"),
     [
@@ -87,8 +88,13 @@ def test_selected_policy_matches_every_current_ci_step_and_workflow() -> None:
         ("id", True),
         ("head_sha", "c" * 40),
         ("head_branch", "develop"),
+        ("head_branch", "release/c-sdk-readiness"),
+        ("head_branch", "v2.2.0"),
         ("path", ".github/workflows/release.yml"),
         ("event", "pull_request"),
+        ("event", "schedule"),
+        ("event", None),
+        ("event", True),
         ("run_attempt", 2),
         ("status", "in_progress"),
         ("conclusion", "failure"),
@@ -96,16 +102,15 @@ def test_selected_policy_matches_every_current_ci_step_and_workflow() -> None:
         ("head_repository", {"full_name": "attacker/type-bridge", "id": 1085407082}),
     ],
 )
-def test_source_run_rejects_identity_and_acceptance_changes(key: str, value: Any) -> None:
+def test_source_run_rejects_identity_and_acceptance_changes(
+    event: str, key: str, value: Any
+) -> None:
     run = run_snapshot()
-    promotion.validate_run(
-        run, run_id=123, source=SOURCE, workflow=".github/workflows/ci.yml", event="push"
-    )
+    run["event"] = event
+    promotion.validate_ci_run(run, run_id=123, source=SOURCE)
     run[key] = value
     with pytest.raises(promotion.PromotionError):
-        promotion.validate_run(
-            run, run_id=123, source=SOURCE, workflow=".github/workflows/ci.yml", event="push"
-        )
+        promotion.validate_ci_run(run, run_id=123, source=SOURCE)
 
 
 def jobs_snapshot() -> dict[str, Any]:


### PR DESCRIPTION
GitHub artifact-service HTTP 403 errors interrupted wheel downloads and
artifact upload finalization after builds and consumer checks passed. Add
a manual `ci.yml` trigger so a fresh complete run can verify the same
master commit without changing source files.

C release capture and promotion share the same event check. Both automatic
and manual CI must use the exact master source and succeed on their first
attempt. All 52 jobs, 623 step outcomes, and artifact checks remain required;
other events, branches, partial reruns, and incomplete results are rejected.
The committed policy changes only its CI workflow digest.

Validation: all nine Python checks pass, followed by a final 2,888-test
unit run after extending the rejection cases. All 61 release-control
cases, focused type checks, workflow lint, and the strict documentation
build pass. The change is five files, 33 added lines and 20 removed lines.

Hosted validation: [CI](https://github.com/ds1sqe/type-bridge/actions/runs/34255942514)
passes all 52 jobs on `7e1756ee`. Independent verification accepts all
623 step outcomes, and documentation checks pass.

Parts of #110
