### PR TITLE
build(release): install Clippy for producer tests (#110)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,7 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: 1.94.1
+          components: clippy
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5


### PR DESCRIPTION
The release test gate fails because its minimal Rust 1.94.1 installation
lacks Clippy. Request the component in the existing setup step so both
strict generated-producer tests can run. This adds one line.

Validation: both affected Rust producer tests pass with the Clippy component
installed. All 245 release-validation tests and workflow lint pass.

Parts of #110
