### PR TITLE
fix(typescript): resolve generated cardinality and member collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to TypeBridge will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix generated TypeScript construction for unbounded roles and list fields by
+  recognizing canonical `"unbounded"` cardinality metadata.
+- Project model fields and roles that collide with runtime members to names with
+  a trailing underscore, including the physical string key `name` as `name_`.
+  Preserve schema identity and existing non-colliding names. Regenerate complete
+  TypeScript packages after updating the generator and compatible runtime.
+
 ### C distribution preparation
 
 - Prepare the 2.2.0 standalone CLI and ABI 1.6 C shared runtime for Linux

--- a/docs/guide/typescript.md
+++ b/docs/guide/typescript.md
@@ -61,6 +61,20 @@ Generated values are immutable. Integer attributes use JavaScript `bigint` so
 the TypeDB integer domain is not silently truncated. Decimal and duration values
 use their lossless generated boundary representations.
 
+Schema fields and roles that collide with generated runtime members receive a
+trailing underscore in the canonical projection: a key physically named `name`
+is accessed as `name_`, and a role named `reference` becomes `reference_`.
+Use these same names in construction, references, field/role tokens, and hydrated
+values. Physical schema labels and key identity stay unchanged; existing
+non-colliding projected names stay unchanged.
+
+Unbounded role and list cardinalities accept any count at or above their
+declared minimum. Finite maxima and optional zero cardinality remain enforced.
+
+After upgrading the generator and compatible runtime, regenerate the complete
+package. Projection and package fingerprints are recomputed from the corrected
+names and runtime resources; semantic schema fingerprints remain unchanged.
+
 ## Managers
 
 ```ts

--- a/tests/contracts/c-broad-case-ledger-v1.json
+++ b/tests/contracts/c-broad-case-ledger-v1.json
@@ -5,16 +5,16 @@
   "transition_capabilities": ["G05", "G06", "G08", "G13"],
   "source_slices": {
     "query-remote": {
-      "source_commit": "8097bab115258a66d94fa4897f00c9abafd5f5f7",
+      "source_commit": "5ec1ec836efbcca75a789b7777aeef8ea4753b40",
       "authorities": [
-        {"path": "tests/contracts/sdk_conformance/sdk-v2/catalog-v2.json", "sha256": "c966d035583ad624cd05e325a0e0d554137a2849ff2395d78b1b2761917eb468"},
+        {"path": "tests/contracts/sdk_conformance/sdk-v2/catalog-v2.json", "sha256": "da28d4df64711f963aca46279ecdb57a2d2f53ff0cf559378ba4f604385c01e7"},
         {"path": "tests/contracts/sdk_conformance/sdk-v2/journey-v2.json", "sha256": "cb63ccb1b76e7f00f68fe6fd9d14fad978560f98cbc5a741949656b20e95ce96"}
       ]
     },
     "data-model": {
-      "source_commit": "4d74f2759612fe07fd7c6134d0e1976f951011c1",
+      "source_commit": "5ec1ec836efbcca75a789b7777aeef8ea4753b40",
       "authorities": [
-        {"path": "tests/contracts/sdk_conformance/sdk-v3/catalog-v3.json", "sha256": "639b8b4f78ee0e71801ce5424bc2f8f55f264136a4d10fc507fe901139507025"},
+        {"path": "tests/contracts/sdk_conformance/sdk-v3/catalog-v3.json", "sha256": "daddf890831fc148f382055faf4fee5d46c91076e1b409d714ad10088855e3ad"},
         {"path": "tests/contracts/sdk_conformance/sdk-v3/journey-v3.json", "sha256": "c5679b428c22e2bff7989f6d674cde3780b752a40f6bbce6ccb3aa451797b1c0"}
       ]
     },

--- a/tests/contracts/sdk_conformance/sdk-v1/catalog-v1.json
+++ b/tests/contracts/sdk_conformance/sdk-v1/catalog-v1.json
@@ -34,7 +34,7 @@
       "node": {
         "algorithm": "sha256",
         "canonicalization": "typebridge.binding-projection/v1",
-        "digest": "5f4bad879a2cc287003121b98fe540234141046c49b93b330917279a17658239",
+        "digest": "5a25c0d8f93f16b617a1d043aa9f50dd6f4250967cd59c05e361a88653b1750d",
         "domain": "typebridge.binding.projection",
         "semantic_profile": "typedb-3.12.1/v1"
       },

--- a/tests/contracts/sdk_conformance/sdk-v2/catalog-v2.json
+++ b/tests/contracts/sdk_conformance/sdk-v2/catalog-v2.json
@@ -40,7 +40,7 @@
       "node": {
         "algorithm": "sha256",
         "canonicalization": "typebridge.binding-projection/v1",
-        "digest": "5f4bad879a2cc287003121b98fe540234141046c49b93b330917279a17658239",
+        "digest": "5a25c0d8f93f16b617a1d043aa9f50dd6f4250967cd59c05e361a88653b1750d",
         "domain": "typebridge.binding.projection",
         "semantic_profile": "typedb-3.12.1/v1"
       },

--- a/tests/contracts/sdk_conformance/sdk-v3/catalog-v3.json
+++ b/tests/contracts/sdk_conformance/sdk-v3/catalog-v3.json
@@ -61,7 +61,7 @@
         "algorithm": "sha256",
         "canonicalization": "typebridge.binding-projection/v1",
         "semantic_profile": "typedb-3.12.1/v1",
-        "digest": "924b685239100ddbebd3456d2b85c3543af9e950a29501af3a48b9b375fd3c47"
+        "digest": "2d4c8ace97d751ce6ee68069359adc31adfc347d5ebf67947820aef95cc39730"
       },
       "rust": {
         "domain": "typebridge.binding.projection",

--- a/tests/unit/compat/test_sdk_conformance_v3_contract.py
+++ b/tests/unit/compat/test_sdk_conformance_v3_contract.py
@@ -304,7 +304,7 @@ def test_sdk_v3_catalog_freezes_final_fingerprint_authority() -> None:
             }
             for binding, digest in {
                 "python": "61713e741c3db3179d1bcb0a6d4880d1a7cd4cc37a19cdeb19bccd81c009bcc2",
-                "node": "924b685239100ddbebd3456d2b85c3543af9e950a29501af3a48b9b375fd3c47",
+                "node": "2d4c8ace97d751ce6ee68069359adc31adfc347d5ebf67947820aef95cc39730",
                 "rust": "4196b70e742635adf51b61aea9b5fa4e9c2966d48d3d0410faf4db4066be2011",
                 "c": "f406ca5fb5194bc516fb816aaf58fd4430a6ec39f8767cd7221618c60887fcd4",
             }.items()

--- a/type-bridge-core/crates/contract/src/projection.rs
+++ b/type-bridge-core/crates/contract/src/projection.rs
@@ -32,6 +32,32 @@ const BINDING_PROJECTION_CONTENT_DOMAIN: &str = "typebridge.binding.projection-c
 const MAX_TARGET_IDENTIFIER_BYTES: usize = 255;
 const MAX_C_SYMBOL_PREFIX_BYTES: usize = 63;
 
+/// Properties installed on generated TypeScript model tokens or hydrated facets.
+///
+/// Canonical model-member projection appends `_` when a camel-case field or
+/// role name is in this set. The emitter uses the same set to reject invalid
+/// descriptors without changing physical schema identities.
+pub const TYPESCRIPT_MODEL_RESERVED_NAMES: &[&str] = &[
+    "__proto__",
+    "completeRead",
+    "constructor",
+    "create",
+    "declaration",
+    "fields",
+    "id",
+    "iid",
+    "metadata",
+    "manager",
+    "name",
+    "plays",
+    "prototype",
+    "reference",
+    "roles",
+    "typeKey",
+    "typeToken",
+    "valueType",
+];
+
 /// ABI major required by C packages emitted under the C-v1 projection contract.
 pub const TYPE_BRIDGE_C_ABI_MAJOR: u32 = 1;
 /// Current aggregate ABI minor supported by the native C runtime.

--- a/type-bridge-core/crates/schema-codegen/src/typescript/mod.rs
+++ b/type-bridge-core/crates/schema-codegen/src/typescript/mod.rs
@@ -1308,15 +1308,15 @@ mod tests {
     #[test]
     fn legacy_runtime_source_remains_byte_exact() {
         assert_eq!(runtime_source(false).unwrap(), RUNTIME_SOURCE);
-        assert_eq!(RUNTIME_SOURCE.len(), 132_647);
+        assert_eq!(RUNTIME_SOURCE.len(), 132_719);
         assert_eq!(
             format!("{:x}", Sha256::digest(RUNTIME_SOURCE)),
-            "0900245d2dfb8f6a4a60d6ce086e535a2b15561f9fbe2b0f3547a61b620562a9"
+            "71f6aba6c743d3dd7d19b88b8f7549b90f069ce96341ace75e92417ad01ad849"
         );
         let resource = CodeResourceDigest::from_bytes(RUNTIME_SOURCE_ID, RUNTIME_SOURCE).unwrap();
         assert_eq!(
             resource.content_fingerprint().digest().to_hex(),
-            "1c976e41892f2e0a31ec19d97ebd6a0c73004ca2ff37dc4d616be77649a8e371"
+            "955879feedff263aa72d578c5c05823adf1f4811dc1429f2dd3d2a3816abd25a"
         );
     }
 

--- a/type-bridge-core/crates/schema-codegen/src/typescript/render.rs
+++ b/type-bridge-core/crates/schema-codegen/src/typescript/render.rs
@@ -7,14 +7,13 @@ use type_bridge_contract::id::{TypeId, TypeKind};
 use type_bridge_contract::projection::{
     FunctionReturnElementProjection, FunctionReturnProjection, ModelProjection, ProjectedContainer,
     ProjectedModelForm, ProjectedModelUse, ProjectedMultiplicity, ProjectedTypeRef,
-    RuntimeProjection,
+    RuntimeProjection, TYPESCRIPT_MODEL_RESERVED_NAMES as MODEL_RESERVED_NAMES,
 };
 use type_bridge_contract::schema::OwnsFactId;
 use type_bridge_contract::value::ValueTypeTag;
 
 use super::reserved::{
-    MODEL_RESERVED_NAMES, ORDERED_PUBLIC_RUNTIME_NAMES, PUBLIC_RUNTIME_NAMES, PUBLIC_SCHEMA_NAMES,
-    is_typescript_keyword,
+    ORDERED_PUBLIC_RUNTIME_NAMES, PUBLIC_RUNTIME_NAMES, PUBLIC_SCHEMA_NAMES, is_typescript_keyword,
 };
 use crate::{
     EmbeddedAuthority, GeneratedPackage, MIGRATION_HISTORY_BUNDLE_RESOURCE,

--- a/type-bridge-core/crates/schema-codegen/src/typescript/reserved.rs
+++ b/type-bridge-core/crates/schema-codegen/src/typescript/reserved.rs
@@ -78,28 +78,6 @@ pub(super) const PUBLIC_SCHEMA_NAMES: &[&str] = &[
     "SEMANTIC_SCHEMA_FINGERPRINT_JSON",
 ];
 
-/// Properties installed on generated model tokens or hydrated facets.
-pub(super) const MODEL_RESERVED_NAMES: &[&str] = &[
-    "__proto__",
-    "completeRead",
-    "constructor",
-    "create",
-    "declaration",
-    "fields",
-    "id",
-    "iid",
-    "metadata",
-    "manager",
-    "name",
-    "plays",
-    "prototype",
-    "reference",
-    "roles",
-    "typeKey",
-    "typeToken",
-    "valueType",
-];
-
 /// Complete TypeScript-v1 strict-mode and contextual keyword set.
 pub(super) const TYPESCRIPT_STRICT_KEYWORDS: &[&str] = &[
     "abstract",

--- a/type-bridge-core/crates/schema-codegen/src/typescript/runtime.ts
+++ b/type-bridge-core/crates/schema-codegen/src/typescript/runtime.ts
@@ -48,7 +48,8 @@ const FUNCTION_CALL_BRAND: unique symbol = Symbol("typebridge.function-call");
 export interface Cardinality {
   readonly kind: "cardinality";
   readonly min: string;
-  readonly max: string | null;
+  // Canonical cardinality encodes an unlimited maximum as "unbounded".
+  readonly max: string;
 }
 
 export type ProjectedModelForm = "complete" | "reference";
@@ -563,7 +564,7 @@ function validateMultiplicity(
   const actual = BigInt(count);
   const minimum = BigInt(multiplicity.cardinality.min);
   const maximum =
-    multiplicity.cardinality.max === null
+    multiplicity.cardinality.max === "unbounded"
       ? null
       : BigInt(multiplicity.cardinality.max);
   if (actual < minimum || (maximum !== null && actual > maximum)) {

--- a/type-bridge-core/crates/schema-codegen/tests/typescript_acceptance/blockers_check.mjs
+++ b/type-bridge-core/crates/schema-codegen/tests/typescript_acceptance/blockers_check.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { Aliases, Archive, Marker, Name, NameValue } from "./generated_blockers/dist/index.js";
+
+const name = Name.create("marker");
+const values = { name_: name, nameValue: NameValue.create("label"), aliases: [], revision: null };
+const marker = Marker.create(values);
+assert.equal(marker.name_, name);
+assert.equal(Marker.name, "Marker");
+assert.equal(Marker.name_.multiplicity.cardinality.max, "1");
+assert.equal(Marker.aliases.multiplicity.cardinality.max, "unbounded");
+assert.equal(Marker.create({ ...values, aliases: Array(5).fill(Aliases.create("alias")) }).aliases.length, 5);
+const reference = Marker.reference("marker-iid", { name_: name });
+assert.equal(reference.name_, name);
+assert.equal(reference.iid, "marker-iid");
+assert.equal(Marker.reference(null, { name_: name }).name_, name);
+const optional = Marker.create({ name_: name, nameValue: values.nameValue });
+assert.deepEqual(optional.aliases, []);
+assert.equal(optional.revision, null);
+const roles = { name_: [marker, marker, marker], nameValue: [], reference_: [] };
+assert.equal(Archive.create(roles).name_.length, 3);
+assert.throws(() => Archive.create({ ...roles, name_: [] }), RangeError);
+assert.throws(() => Archive.create({ ...roles, reference_: [marker, marker, marker] }), RangeError);
+assert.equal(Archive.create({ ...roles, reference_: [marker, marker] }).reference_.length, 2);
+assert.throws(() => Marker.create({ ...values, name_: null }), RangeError);
+const hydrateComplete = Object.getOwnPropertySymbols(Marker).find(
+  (symbol) => symbol.description === "typebridge.hydrate-complete",
+);
+assert(hydrateComplete);
+const hydrated = Marker[hydrateComplete]("marker-iid", values);
+assert.equal(hydrated.name_, name);
+assert.equal(hydrated.iid, "marker-iid");
+const hydratedArchive = Archive[hydrateComplete]("archive-iid", {
+  name_: [hydrated, hydrated, hydrated], nameValue: [], reference_: [],
+});
+assert.equal(hydratedArchive.name_.length, 3);
+assert.equal(hydratedArchive.name_[0].name_, name);
+assert(Object.isFrozen(hydratedArchive));
+console.log("TypeScript generation blocker regressions passed");

--- a/type-bridge-core/crates/schema-codegen/tests/typescript_acceptance/blockers_positive.ts
+++ b/type-bridge-core/crates/schema-codegen/tests/typescript_acceptance/blockers_positive.ts
@@ -1,0 +1,21 @@
+import { Archive, Marker, Name, NameValue, type MarkerRef } from "./generated_blockers/src/index.js";
+
+const name = Name.create("marker");
+const marker: Marker = Marker.create({
+  name_: name,
+  nameValue: NameValue.create("label"),
+  aliases: [],
+  revision: null,
+});
+const reference: MarkerRef = Marker.reference("marker-iid", { name_: name });
+const archive: Archive = Archive.create({
+  name_: [marker, marker, marker],
+  nameValue: [],
+  reference_: [],
+});
+const key: Name = marker.name_;
+void reference;
+void archive;
+void key;
+// @ts-expect-error Physical labels do not replace canonical projected member names.
+Marker.create({ name, nameValue: NameValue.create("label"), aliases: [], revision: null });

--- a/type-bridge-core/crates/schema-codegen/tests/typescript_acceptance/check.mjs
+++ b/type-bridge-core/crates/schema-codegen/tests/typescript_acceptance/check.mjs
@@ -8,6 +8,7 @@ const CORE = resolve(HERE, "../../../..");
 const ROOT = resolve(CORE, "..");
 const STAGE = resolve(CORE, "target/schema-codegen-typescript-acceptance");
 const GENERATED = resolve(STAGE, "generated_v2");
+const BLOCKERS = resolve(STAGE, "generated_blockers");
 const ORDERED = resolve(STAGE, "generated_ordered");
 const FOREIGN = resolve(STAGE, "generated_foreign");
 const PROJECTED = resolve(STAGE, "generated_projected");
@@ -33,10 +34,12 @@ function command(program, args, cwd = ROOT, environment = process.env) {
 }
 
 for (const fixture of [
+  "blockers_positive.ts",
   "positive.ts",
   "negative.ts",
   "ordered_batch_positive.ts",
   "ordered_batch_negative.ts",
+  "blockers_check.mjs",
   "runtime_check.mjs",
   "projected_parity_check.mjs",
 ]) {
@@ -53,8 +56,10 @@ for (const forbidden of ["as unknown as", "@ts-ignore"]) {
   }
 }
 for (const fixture of [
+  "blockers_positive.ts",
   "positive.ts",
   "ordered_batch_positive.ts",
+  "blockers_check.mjs",
   "runtime_check.mjs",
 ]) {
   const source = readFileSync(resolve(HERE, fixture), "utf8");
@@ -170,8 +175,14 @@ command("cargo", [
   projectedForeignSchema,
   PROJECTED_FOREIGN,
 ]);
+command("cargo", [
+  "run", "--quiet", "--manifest-path", resolve(CORE, "Cargo.toml"),
+  "--package", "type-bridge-schema-codegen", "--example", "emit_typescript_acceptance",
+  "--", resolve(HERE, "schema-blockers.yaml"), BLOCKERS,
+]);
 mkdirSync(resolve(STAGE, "node_modules/@type-bridge"), { recursive: true });
 symlinkSync(NODE_PACKAGE, resolve(STAGE, "node_modules/@type-bridge/node"), "dir");
+command("tsc", ["--project", resolve(BLOCKERS, "tsconfig.json")]);
 command("tsc", ["--project", resolve(GENERATED, "tsconfig.json")]);
 command("tsc", ["--project", resolve(ORDERED, "tsconfig.json")]);
 command("tsc", ["--project", resolve(FOREIGN, "tsconfig.json")]);
@@ -207,10 +218,12 @@ if (!orderedModelsDts.includes("OrderedModelToken as ModelToken")) {
 }
 
 for (const fixture of [
+  "blockers_positive.ts",
   "positive.ts",
   "negative.ts",
   "ordered_batch_positive.ts",
   "ordered_batch_negative.ts",
+  "blockers_check.mjs",
   "runtime_check.mjs",
   "authority_rejection_check.mjs",
   "projected_parity_check.mjs",
@@ -234,6 +247,7 @@ writeFileSync(
       skipLibCheck: false,
     },
     include: [
+      "blockers_positive.ts",
       "positive.ts",
       "negative.ts",
       "ordered_batch_positive.ts",
@@ -247,6 +261,7 @@ writeFileSync(
 );
 command("tsc", ["--project", resolve(STAGE, "tsconfig.json")]);
 command("node", [resolve(STAGE, "authority_rejection_check.mjs")]);
+command("node", [resolve(STAGE, "blockers_check.mjs")]);
 command("node", [resolve(STAGE, "runtime_check.mjs")]);
 const externalProjectedReport = process.env.TYPE_BRIDGE_PROJECTED_PARITY_REPORT;
 const projectedReport = externalProjectedReport ?? resolve(STAGE, "projected-node-report.json");

--- a/type-bridge-core/crates/schema-codegen/tests/typescript_acceptance/projected_live_check.mjs
+++ b/type-bridge-core/crates/schema-codegen/tests/typescript_acceptance/projected_live_check.mjs
@@ -41,7 +41,7 @@ export const SEMANTIC_SCHEMA_FINGERPRINT = Object.freeze({
 export const PROJECTION_FINGERPRINT = Object.freeze({
   algorithm: "sha256",
   canonicalization: "typebridge.binding-projection/v1",
-  digest: "924b685239100ddbebd3456d2b85c3543af9e950a29501af3a48b9b375fd3c47",
+  digest: "2d4c8ace97d751ce6ee68069359adc31adfc347d5ebf67947820aef95cc39730",
   domain: "typebridge.binding.projection",
   semantic_profile: SEMANTIC_PROFILE,
 });

--- a/type-bridge-core/crates/schema-codegen/tests/typescript_acceptance/schema-blockers.yaml
+++ b/type-bridge-core/crates/schema-codegen/tests/typescript_acceptance/schema-blockers.yaml
@@ -1,0 +1,25 @@
+format: typebridge.schema/v2
+attributes:
+  name: { value: string }
+  name-value: { value: string }
+  aliases: { value: string }
+  revision: { value: integer }
+entities:
+  marker:
+    owns:
+      name: { key: true }
+      name-value: { card: 1 }
+      aliases: { card: { min: 0 } }
+      revision: { card: { min: 0, max: 1 } }
+relations:
+  archive:
+    relates:
+      name: { card: { min: 1 } }
+      name-value: { card: { min: 0 } }
+      reference: { card: { min: 0, max: 2 } }
+plays:
+  marker:
+    archive:
+      name: {}
+      name-value: {}
+      reference: {}

--- a/type-bridge-core/crates/schema-codegen/tests/typescript_emitter.rs
+++ b/type-bridge-core/crates/schema-codegen/tests/typescript_emitter.rs
@@ -193,3 +193,33 @@ fn rejects_schema_name_colliding_with_runtime_export() {
     );
     assert!(error.to_string().contains("Cardinality"));
 }
+
+#[test]
+fn emits_collision_safe_members_with_canonical_key_identity() {
+    use type_bridge_contract::id::{AttributeId, TypeId, TypeKind};
+    use type_bridge_contract::schema::OwnsFactId;
+
+    let emitter = TypeScriptEmitter::new();
+    let resources = emitter.code_resources().unwrap();
+    let source = include_str!("typescript_acceptance/schema-blockers.yaml");
+    let (projection, authority) = projected(source, &resources);
+    let marker = TypeId::new(TypeKind::Entity, "marker").unwrap();
+    let key = OwnsFactId::new(marker.clone(), AttributeId::new("name").unwrap()).unwrap();
+    let model = &projection.models()[&marker];
+    assert_eq!(model.reference_read().key_fields(), std::slice::from_ref(&key));
+    let token = &model.query_tokens().fields()[&key];
+    assert!(token.is_key());
+    assert_eq!(token.target_name().as_str(), "name_");
+    assert!(
+        model
+            .create()
+            .fields()
+            .iter()
+            .any(|field| field.token() == &key)
+    );
+    let package = emitter.emit(&projection, &authority).unwrap();
+    let models = std::str::from_utf8(package.get("src/models.ts").unwrap()).unwrap();
+    assert!(models.contains("readonly name_:"));
+    assert!(models.contains("readonly nameValue:"));
+    assert_eq!(package, emitter.emit(&projection, &authority).unwrap());
+}

--- a/type-bridge-core/crates/schema/src/project.rs
+++ b/type-bridge-core/crates/schema/src/project.rs
@@ -12,7 +12,8 @@ use type_bridge_contract::projection::{
     ProjectedModelForm, ProjectedModelUse, ProjectedMultiplicity, ProjectedTypeRef,
     ProjectionConfig, ProjectionHandler, QueryTokenProjection, ReadFieldProjection,
     ReadRoleProjection, ReferenceReadProjection, RoleTokenProjection, RuntimeProjection,
-    RustCreatePolicy, StructFieldProjection, StructProjection, TargetIdentifier,
+    RustCreatePolicy, StructFieldProjection, StructProjection, TYPESCRIPT_MODEL_RESERVED_NAMES,
+    TargetIdentifier,
 };
 use type_bridge_contract::schema::{
     AnnotationFactId, AnnotationKindId, AnnotationSubjectId, FunctionReturnMode, OwnsFactId,
@@ -224,6 +225,20 @@ impl<'a> ProjectionNamer<'a> {
                 "unsupported_binding_projection_target",
                 "schema projection does not support this binding target",
             ))
+        }
+    }
+
+    fn model_member_identifier(&self, label: &str) -> Result<TargetIdentifier, SchemaDiagnostics> {
+        if self.target == BindingTarget::TypeScript {
+            let mut name = typescript_member_name(label);
+            if TYPESCRIPT_MODEL_RESERVED_NAMES.contains(&name.as_str()) {
+                // Camel-case projection removes underscores, so this suffix cannot
+                // collide with an otherwise valid, unchanged projected member.
+                name.push('_');
+            }
+            TargetIdentifier::typescript(name).map_err(no_source)
+        } else {
+            self.member_identifier(label)
         }
     }
 
@@ -666,7 +681,7 @@ pub fn project(
                         "ordered ownership is absent from the effective ownership map",
                     )
                 })?;
-            let name = namer.member_identifier(owns.id().attribute().label().as_str())?;
+            let name = namer.model_member_identifier(owns.id().attribute().label().as_str())?;
             names.insert(
                 format!("model:{id:?}"),
                 &name,
@@ -733,7 +748,7 @@ pub fn project(
             if replaced.contains(role_id) {
                 continue;
             }
-            let name = namer.member_identifier(role_id.label().as_str())?;
+            let name = namer.model_member_identifier(role_id.label().as_str())?;
             names.insert(format!("model:{id:?}"), &name, format!("role:{role_id:?}"))?;
             let resolved_role = resolved.roles().get(role_id).ok_or_else(|| {
                 projection_error(

--- a/type-bridge-core/crates/schema/tests/projection.rs
+++ b/type-bridge-core/crates/schema/tests/projection.rs
@@ -1100,34 +1100,37 @@ entities:
 }
 
 #[test]
-fn typescript_runtime_reserved_names_fail_before_emission() {
-    let documents = SchemaDocumentSet::parse([(
-        DocumentId::new("schema.yaml").unwrap(),
-        r#"format: typebridge.schema/v2
-relations:
-  bad:
-    relates: [prototype]
-"#,
-    )])
-    .unwrap();
-    let declared = normalize_documents(&documents).unwrap();
-    let resolved = resolve(
-        &declared,
-        &SemanticProfileId::new("typedb-3.12.1/v1").unwrap(),
-    )
-    .unwrap();
-    let error = project(
-        &resolved,
-        BindingTarget::TypeScript,
-        &ProjectionConfig::typescript(),
-        &[ProjectionHandler::typescript_v1()],
-        &[],
-    )
-    .unwrap_err();
-    assert_eq!(
-        error.iter().next().unwrap().diagnostic().code().as_str(),
-        "reserved_typescript_projection_identifier"
-    );
+fn typescript_runtime_reserved_model_members_are_escaped() {
+    use type_bridge_contract::projection::TYPESCRIPT_MODEL_RESERVED_NAMES;
+
+    for reserved in TYPESCRIPT_MODEL_RESERVED_NAMES {
+        // Labels are projected through camel case before checking runtime names.
+        let label = match *reserved {
+            "iid" => "Iid",
+            "plays" => "Plays",
+            other => other,
+        };
+        let source = format!(
+            "format: typebridge.schema/v2\nrelations:\n  holder:\n    relates: [{label}]\n"
+        );
+        let projected = projection_for(
+            &source,
+            BindingTarget::TypeScript,
+            ProjectionConfig::typescript(),
+            ProjectionHandler::typescript_v1(),
+        );
+        let holder = TypeId::new(TypeKind::Relation, "holder").unwrap();
+        let role = RoleId::new("holder", label).unwrap();
+        let name = projected.models()[&holder].query_tokens().roles()[&role]
+            .target_name()
+            .as_str();
+        let expected = if *reserved == "__proto__" {
+            "proto".to_owned()
+        } else {
+            format!("{reserved}_")
+        };
+        assert_eq!(name, expected);
+    }
 }
 
 #[test]


### PR DESCRIPTION
Generated TypeScript packages reject valid unbounded roles because runtime validation tries to parse the canonical `"unbounded"` maximum as a bigint. A physical key named `name` also prevents emission because its projected member collides with the runtime token.

Recognize canonical unbounded maxima and let the canonical projector escape reserved model fields and roles with a trailing underscore (`name_`, `reference_`). The emitter shares the reservation set. Regenerated SDK catalog and exact-live expectations retain strict fingerprint checks; only TypeScript projection hashes change. Physical labels and key identity remain intact, and existing non-colliding names stay unchanged. Document complete package regeneration for 2.2.0.

Validation: focused schema projection tests, six TypeScript emitter tests, five runtime-source tests, canonical fingerprint inventory, strict documentation build, all 12 Node scope checks, and 2,932 local Python unit tests pass. Clippy passes on the release-pinned Rust 1.94.1 toolchain. Generated Rust acceptance and public documentation checks pass on MSRV 1.88.

The existing acceptance harness compiles pristine complete packages and a typed consumer, then exercises native construction, references, hydration, unbounded lists/roles, minima, finite maxima, and optional zero cardinality. All 52 CI jobs pass, including the Linux, macOS, and Windows Rust checks and exact TypeDB live parity. The candidate test gate passes; the separate installed CLI version-report acceptance fix is tracked in #229.
