### PR TITLE
test(rust): fetch the locked generated consumer graph

### DIFF
--- a/type-bridge-core/crates/schema-codegen/tests/rust_projection_live.rs
+++ b/type-bridge-core/crates/schema-codegen/tests/rust_projection_live.rs
@@ -637,6 +637,18 @@ fn generated_rust_projection_round_trips_exact_live_models() {
             "forbidden consumer surface: {forbidden}"
         );
     }
+    // The frozen consumer graph can contain versions absent from the workspace cache.
+    // Fetch that exact graph before requiring the consumer compilation to be offline.
+    let consumer_fetch = Command::new(&cargo)
+        .args(["fetch", "--locked", "--manifest-path"])
+        .arg(&consumer_manifest_path)
+        .output()
+        .expect("locked consumer dependency fetch starts");
+    assert!(
+        consumer_fetch.status.success(),
+        "locked consumer dependency fetch failed\n{}",
+        String::from_utf8_lossy(&consumer_fetch.stderr)
+    );
     let consumer_check = Command::new(&cargo)
         .args([
             "check",


### PR DESCRIPTION
The 2.2.0 candidate failed its AMD64 container acceptance because the generated Rust consumer compiled offline before its separately locked dependencies had been downloaded. The clean runner lacked `anstream 0.6.21`, although the workspace and exact container checks passed.

Fetch the staged consumer graph with `cargo fetch --locked` before its existing `cargo check --locked --offline`. Keep the frozen graph, public API checks, and live application acceptance intact.

Validation: the generated-consumer preflight passes with an initially empty Cargo cache, including offline compilation. Three focused Rust harness tests, three source-inventory tests, and changed-file formatting pass. Complete final-master CI and nonpublishing candidate acceptance are required before tagging 2.2.0.
