### PR TITLE
fix(release): prepare complete Python acceptance fixtures

### DIFF
--- a/.github/workflows/c-release.yml
+++ b/.github/workflows/c-release.yml
@@ -86,6 +86,7 @@ jobs:
       - name: Install verification dependencies
         run: |
           uv sync --extra dev
+          uv pip install maturin==1.14.1
           npm ci --prefix type-bridge-core/crates/node
           gcc --version
           clang --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -567,6 +567,11 @@ jobs:
           scripts/ci/prepare_generated_live_fixture.sh python
           tmp/release-generated-python
 
+      - name: Prepare generated Python artifact fixture
+        run: >-
+          scripts/ci/prepare_generated_live_fixture.sh python-artifact
+          tmp/release-generated-python-artifact
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
@@ -581,6 +586,13 @@ jobs:
         with:
           name: generated-python-live-fixture
           path: tmp/release-generated-python
+          if-no-files-found: error
+
+      - name: Upload generated Python artifact fixture
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: generated-python-artifact-fixture
+          path: tmp/release-generated-python-artifact
           if-no-files-found: error
 
   # Validate every immutable Python artifact produced by this workflow before
@@ -641,7 +653,7 @@ jobs:
       - name: Download generated Python fixture
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          name: generated-python-live-fixture
+          name: generated-python-artifact-fixture
           path: tmp/release-python-artifacts/generated
 
       - name: Validate exact Python release inventory
@@ -1625,7 +1637,8 @@ jobs:
           raise SystemExit(
               pytest.main(
                   [
-                      str(test),
+                      f"{test}::test_generated_package_preserves_application_operation_outcomes_live",
+                      f"{test}::test_generated_projection_round_trips_live_models",
                       "--rootdir",
                       str(workspace),
                       "--import-mode=importlib",

--- a/tests/unit/compat/test_c_release_promotion.py
+++ b/tests/unit/compat/test_c_release_promotion.py
@@ -311,6 +311,11 @@ def test_tag_requires_an_annotated_direct_same_source_target() -> None:
 
 def test_workflow_keeps_publish_protected_and_without_builders() -> None:
     workflow = yaml.load((ROOT / policy.WORKFLOW).read_text(), Loader=yaml.BaseLoader)
+    verification_steps = workflow["jobs"]["verify"]["steps"]
+    dependencies = next(
+        step for step in verification_steps if step["name"] == "Install verification dependencies"
+    )["run"]
+    assert "uv pip install maturin==1.14.1" in dependencies
     assert set(workflow["on"]) == {"workflow_dispatch"}
     assert workflow["permissions"] == {"contents": "read", "actions": "read"}
     publish = workflow["jobs"]["publish"]

--- a/tests/unit/infra/test_release_artifact_gates.py
+++ b/tests/unit/infra/test_release_artifact_gates.py
@@ -432,7 +432,8 @@ def test_python_publication_depends_on_exact_artifact_acceptance() -> None:
     assert "merge-multiple: true" in acceptance
     assert "name: core-sdist" in acceptance
     assert "name: python-dist" in acceptance
-    assert "name: generated-python-live-fixture" in acceptance
+    assert "name: generated-python-artifact-fixture" in acceptance
+    assert "name: generated-python-live-fixture" not in acceptance
     assert "scripts/ci/validate_python_release_artifacts.py" in acceptance
     assert "--core-wheels-dir tmp/release-python-artifacts/core-wheels" in acceptance
     assert "--core-sdist-dir tmp/release-python-artifacts/core-sdist" in acceptance
@@ -1434,6 +1435,11 @@ def test_live_release_parity_consumes_exact_artifacts_before_every_publish() -> 
     assert "test_generated_projection_live.py" in acceptance
     assert "test_generated_package_preserves_application_operation_outcomes_live" in acceptance
     assert "test_generated_projection_round_trips_live_models" in acceptance
+    assert (
+        'f"{test}::test_generated_package_preserves_application_operation_outcomes_live"'
+        in acceptance
+    )
+    assert 'f"{test}::test_generated_projection_round_trips_live_models"' in acceptance
     assert "generated-package-live.test.js" in acceptance
     assert "--import-mode=importlib" in acceptance
     assert "release-generated-parity.xml" in acceptance
@@ -1460,7 +1466,10 @@ def test_live_release_parity_consumes_exact_artifacts_before_every_publish() -> 
 
     fixture_script = "scripts/ci/prepare_generated_live_fixture.sh"
     assert f"{fixture_script} python" in build_python
+    assert f"{fixture_script} python-artifact" in build_python
     assert "name: generated-python-live-fixture" in build_python
+    assert "name: generated-python-artifact-fixture" in build_python
+    assert "path: tmp/release-generated-python-artifact" in build_python
     assert 'prepare_generated_live_fixture.sh" node' in pack_node
     assert "name: generated-node-live-fixture" in pack_node
     fixture_source = (REPO_ROOT / fixture_script).read_text(encoding="utf-8")


### PR DESCRIPTION
The 2.2.0 candidate failed Python artifact acceptance because it supplied the live fixture instead of the artifact fixture, which includes the identical-package and ordered-package cases. Its live parity job also collected additional SDK tests while enforcing a contract of exactly two specific journeys. C verification separately failed because its Python producer could not find Maturin.

Build and upload a separate Python artifact fixture, route it to wheel/sdist acceptance, and explicitly select the two declared live journeys while retaining exact names and zero skips. Install Maturin 1.14.1 in C verification, matching the existing CI setup for the same producer.

Validation: the actual candidate facade/core wheels pass the isolated generated Python artifact runner with the corrected fixture, including runtime checks and positive/negative Pyright checks. All 146 focused release-control tests, Ruff lint, and formatting pass. Final-master CI, the complete nonpublishing candidate, and same-source C verification remain required before tagging 2.2.0.
