### PR TITLE
fix(release): align Python 3.14 driver probe with pinned package

### DIFF
--- a/tests/compat/typedb_driver_native/probe.py
+++ b/tests/compat/typedb_driver_native/probe.py
@@ -54,9 +54,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     installed_driver = driver_version()
     line = driver_line(installed_driver)
     if sys.version_info >= (3, 14):
-        if installed_driver != "3.12.1":
+        if installed_driver != "3.12.3":
             raise ProbeError(
-                f"Python 3.14 must resolve typedb-driver 3.12.1, got {installed_driver}"
+                f"Python 3.14 must resolve typedb-driver 3.12.3, got {installed_driver}"
             )
     elif not (line[0] == 3 and 8 <= line[1] < 13):
         raise ProbeError(


### PR DESCRIPTION
The Python 3.14 release artifact probe still required typedb-driver 3.12.1 even though both package dependency groups pin 3.12.3. Candidate run 34572704684 passed wheel and source-distribution acceptance and native construction, then failed this stale assertion. Align the exact version check with the declared pin.

Validation: 76 release artifact gate tests passed; Ruff lint and formatting passed. The complete release candidate will verify the installed Python 3.14 artifacts.
