### PR TITLE
fix(test): use locked TypeScript compiler for V4 Node acceptance

### DIFF
--- a/type-bridge-core/crates/cli/tests/sdk_v4_node_live.rs
+++ b/type-bridge-core/crates/cli/tests/sdk_v4_node_live.rs
@@ -87,12 +87,10 @@ fn generated_node_emits_complete_v4_report_on_3_12_3() {
         "generated package local dependency install",
     );
     run(
-        Command::new("npx").current_dir(&generated).args([
-            "--no-install",
-            "tsc",
-            "-p",
-            "tsconfig.json",
-        ]),
+        Command::new("node")
+            .arg(node_package.join("node_modules/typescript/bin/tsc"))
+            .current_dir(&generated)
+            .args(["-p", "tsconfig.json"]),
         "generated package build",
     );
 


### PR DESCRIPTION
The V4 Node producer failed on a fresh C release verification runner because `npx --no-install tsc` ran from a temporary generated package without a local TypeScript dependency. Invoke the compiler installed from the repository lockfile directly through Node, preserving complete package compilation and the live comparator.

Validation: Rust formatting and 12 V4 contract tests passed. The focused Node live producer passed in 187.86 seconds with global `tsc` and `npx` blocked to verify compiler discovery independently of host tooling.

Failure evidence: C verification run 34578199665, V4 Node generated package build.
